### PR TITLE
FAIE-840 - Remove dependency on tensorflow.addon from padim

### DIFF
--- a/anomaly_detectors/padim/padim.py
+++ b/anomaly_detectors/padim/padim.py
@@ -566,7 +566,7 @@ class PaDiM(object):
             dist_tensor_x=tf.expand_dims(dist_tensor_x,-1)
             dist_tensor_x=tf.image.resize(dist_tensor_x,self.img_shape)
             tg0=time.time()
-            if self.tfa_gaussian_filter2d and False:
+            if self.tfa_gaussian_filter2d:
                 dist_tensor_x=self.tfa_gaussian_filter2d(dist_tensor_x,filter_shape=(3,3))
             else:
                 dist_tensor_x=gaussian_filter(dist_tensor_x, sigma=1, radius=1) # the size of the kernel along each axis will be 2*radius + 1

--- a/anomaly_detectors/padim/padim.py
+++ b/anomaly_detectors/padim/padim.py
@@ -575,7 +575,7 @@ class PaDiM(object):
             # Aggregate tensors in batch
             dist_list.append(dist_tensor_x)
             tdel=(t1-t0)/B
-            logging.info(f'[ANOMDET] Proc Time: {tdel}, gaussian filter time: {(t1-tg0)/B}')
+            logging.info(f'[ANOMDET] Proc Time: {tdel}, B={B} gaussian filter time: {(t1-tg0)/B}')
             proctime.append(tdel)
         
         image_tensor=tf.concat(image_list,axis=0)

--- a/anomaly_detectors/padim/padim.py
+++ b/anomaly_detectors/padim/padim.py
@@ -566,7 +566,7 @@ class PaDiM(object):
             dist_tensor_x=tf.expand_dims(dist_tensor_x,-1)
             dist_tensor_x=tf.image.resize(dist_tensor_x,self.img_shape)
             tg0=time.time()
-            if self.tfa_gaussian_filter2d:
+            if self.tfa_gaussian_filter2d and False:
                 dist_tensor_x=self.tfa_gaussian_filter2d(dist_tensor_x,filter_shape=(3,3))
             else:
                 dist_tensor_x=gaussian_filter(dist_tensor_x, sigma=1, radius=1) # the size of the kernel along each axis will be 2*radius + 1


### PR DESCRIPTION
tfa.image.gaussian_filter2d prevails when it is available, otherwise, use scipy gaussian_filter instead. 
Presumably tfa.image.gaussian_filter2d would have a better performance as it directly operates on tf.Tensor, while gaussian_filter will need to convert between gpu and native but acceptable for now.
Tested the training and testing flow