### PR TITLE
Fix resize issue

### DIFF
--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -107,7 +107,7 @@ def revert_mask_to_origin(mask, operations:list):
     """
     This func reverts the mask image according to the operations list IN ORDER.
     The operations list contains items as dictionary. The items are listed as follows: 
-        1. <pad: [pad_left_pixels, pad_right_pixels, pad_top_pixels, pad_top_pixels]> 
+        1. <pad: [pad_left_pixels, pad_right_pixels, pad_top_pixels, pad_bottom_pixels]> 
         2. <resize: [current_w, current_h, target_w, target_h]>
     """
     h,w = mask.shape[:2]

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -110,12 +110,11 @@ def revert_mask_to_origin(mask, operations:list):
         1. <pad: [pad_left_pixels, pad_right_pixels, pad_top_pixels, pad_bottom_pixels]> 
         2. <resize: [current_w, current_h, target_w, target_h]>
     """
-    h,w = mask.shape[:2]
     mask2 = mask.copy()
     for operator in reversed(operations):
         h,w = mask2.shape[:2]
         if 'resize' in operator:
-            w,h,nw,nh = operator['resize']
+            _,_,nw,nh = operator['resize']
             mask2 = cv2.resize(mask2,(nw,nh))
         if 'pad' in operator:
             pad = operator['pad']

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -259,14 +259,3 @@ def load_pipeline_def(filepath):
         for dt in l:
             kwargs[dt['name']] = dt['default_value']
     return kwargs
-
-
-if __name__ == '__main__':
-    file = './data/WT10-MK1005-03746-1678197770571059.gadget2d.png'
-    im = cv2.imread(file)
-    h,w = im.shape[:2]
-    h2,w2 = 500,600
-    operators = [{'resize': [w,h,w2,h2]}]
-    im2 = revert_mask_to_origin(im,operators)
-    print(im2.shape)
-    


### PR DESCRIPTION
current revert_mask_to_origin function uses **floor** operation to get the original image's height and width. This will cause the inconsistency with the actual original image size.