### PR TITLE
Remove gpu availability check

### DIFF
--- a/lmi_utils/image_utils/img_resize.py
+++ b/lmi_utils/image_utils/img_resize.py
@@ -38,9 +38,9 @@ def resize(image, width=None, height=None, device='cpu', inter=cv2.INTER_AREA):
     else:
         pass
 
-    if device=='gpu':
-        if not is_cuda_cv():
-            device='cpu'
+    # if device=='gpu':
+    #     if not is_cuda_cv():
+    #         device='cpu'
 
     if device=='gpu':
         src = cv2.cuda_GpuMat()


### PR DESCRIPTION
1. leave the gpu availability check to user
2. fail fast when gpu is not available but 'gpu' option is given, so that user's intention is fullfilled or reported. Just like it fails the docker container with gpu enabled when gpu is unavailable.
3. improve the performance as the gpu availability check takes around 3 milliseconds on GoMax NGX with Jetpack 5.0.2