### PR TITLE
improvements for utils resize & pad & gadget_surface_utils Z parameters parsing

### DIFF
--- a/lmi_utils/gadget_utils/gadget_surface_utils.py
+++ b/lmi_utils/gadget_utils/gadget_surface_utils.py
@@ -211,8 +211,6 @@ if __name__=="__main__":
     src=args['src']
     dest=args['dest']
     intensity = args['intensity']
-    ZResolution = args['zresolution']
-    ZOffset = args['zoffset']
 
     translate=GadgetSurfaceUtils()
 
@@ -233,6 +231,8 @@ if __name__=="__main__":
     elif option=='png_2_pkl':
         translate.png_2_pkl(src,dest)
     elif option=='pcd_2_pkl':
+        ZResolution = float(args['zresolution'])
+        ZOffset = float(args['zoffset'])
         translate.pcd_2_pkl(src,dest,ZResolution,ZOffset)
     else:
         raise Exception('Input option must be pkl_2_npy, pkl_2_png, npy_2_pkl, or png_2_pkl')

--- a/lmi_utils/image_utils/img_pad_to_size.py
+++ b/lmi_utils/image_utils/img_pad_to_size.py
@@ -16,9 +16,7 @@ def pad_image(input_path,output_path,W,H):
         print(f'Input file: {input_file}')
         im=cv2.imread(input_file)
         im_out=pad_array(im,W,H)
-        fname=os.path.split(input_file)[1]
-        fname=os.path.splitext(fname)[0]
-        fname=fname+'_'+str(W)+'x'+str(H)+'.png'
+        fname=os.path.basename(input_file)
         output_file=os.path.join(output_path,fname)
         print(f'Output file: {output_file}') 
         cv2.imwrite(output_file,im_out)
@@ -63,10 +61,7 @@ if __name__=="__main__":
     W=args['W']
     H=args['H']
 
-    output_dir=os.path.split(output_path)[0]
-    if os.path.exists(output_dir):
-        pass
-    else:
-        os.makedirs(output_dir)
+    if not os.path.isdir(output_path):
+        os.makedirs(output_path)
     
     pad_image(input_path,output_path,W,H)

--- a/lmi_utils/image_utils/resize_image.py
+++ b/lmi_utils/image_utils/resize_image.py
@@ -25,7 +25,7 @@ def resize_images(path_imgs, output_imsize, path_out):
     W,H = output_imsize
     ratio_out = W/H
     for file in file_list:
-        im = cv2.imread(file)
+        im = cv2.imread(file, cv2.IMREAD_UNCHANGED)
         im_name = os.path.basename(file)
         h,w = im.shape[:2]
         logger.info(f'input file: {im_name} with size of [{w},{h}]')
@@ -34,7 +34,7 @@ def resize_images(path_imgs, output_imsize, path_out):
         if ratio_in != ratio_out:
             logger.warning(f'file: {im_name}, asepect ratio changed from {ratio_in} to {ratio_out}')
         
-        out_name = os.path.splitext(im_name)[0] + f'_resized_{W}x{H}' + '.png'
+        out_name = im_name
         
         im2 = cv2.resize(im, dsize=tuple(output_imsize))
 


### PR DESCRIPTION
imread with unchanged format so that after action like vstack the format can still be the same
keep the same filename after resizing and padding, since the track can happens at target folder level
make more robust at parsing parameter ZResolution and ZOffSet