### PR TITLE
remove logging.basicConfig from submodules/files

### DIFF
--- a/anomaly_detectors/padim/padim.py
+++ b/anomaly_detectors/padim/padim.py
@@ -14,8 +14,6 @@ from matplotlib import pyplot as plt
 # 3. Own modules
 from padim.data_loader import DataLoader
 
-logging.basicConfig(level=logging.INFO)
-
 def plot_histogram(xvec):
     '''
     DESCRIPTION: 

--- a/anomaly_detectors/padim/padim.py
+++ b/anomaly_detectors/padim/padim.py
@@ -14,6 +14,7 @@ from matplotlib import pyplot as plt
 # 3. Own modules
 from padim.data_loader import DataLoader
 
+
 def plot_histogram(xvec):
     '''
     DESCRIPTION: 

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -6,7 +6,6 @@ import json
 import torch
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
 

--- a/lmi_utils/image_utils/make_collage.py
+++ b/lmi_utils/image_utils/make_collage.py
@@ -7,7 +7,6 @@ from image_utils.img_resize import resize
 from image_utils.pad_image import fit_array_to_size
 import logging
 
-logging.basicConfig(level=logging.INFO)
 #%%
 def gen_collage(input_path,output_path,colmax,width,rowmax=None):
 

--- a/lmi_utils/image_utils/resize_image.py
+++ b/lmi_utils/image_utils/resize_image.py
@@ -6,7 +6,6 @@ import logging
 #3rd party packages
 import cv2
 
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/image_utils/sample_image.py
+++ b/lmi_utils/image_utils/sample_image.py
@@ -7,7 +7,6 @@ import logging
 import shutil
 import random
 
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/COCO_dataset.py
+++ b/lmi_utils/label_utils/COCO_dataset.py
@@ -6,7 +6,6 @@ import os
 import glob
 import logging
 
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/lst_json_to_coco.py
+++ b/lmi_utils/label_utils/lst_json_to_coco.py
@@ -5,7 +5,6 @@ import json
 import numpy as np
 from label_utils.COCO_dataset import COCO_Dataset, Annotation, rotate
 
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/plot_coco_json.py
+++ b/lmi_utils/label_utils/plot_coco_json.py
@@ -8,8 +8,6 @@ import numpy as np
 from label_utils.COCO_dataset import COCO_Dataset, rotate
 from label_utils.plot_utils import plot_one_polygon
 
-
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/plot_coco_json.py
+++ b/lmi_utils/label_utils/plot_coco_json.py
@@ -8,6 +8,7 @@ import numpy as np
 from label_utils.COCO_dataset import COCO_Dataset, rotate
 from label_utils.plot_utils import plot_one_polygon
 
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/resize_with_csv.py
+++ b/lmi_utils/label_utils/resize_with_csv.py
@@ -10,8 +10,6 @@ import cv2
 #LMI packages
 from label_utils import mask, rect, csv_utils
 
-
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/rot90_with_csv.py
+++ b/lmi_utils/label_utils/rot90_with_csv.py
@@ -12,7 +12,6 @@ import cv2
 from label_utils import mask, rect, csv_utils
 
 
-logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/lmi_utils/label_utils/scretch_to_edges.py
+++ b/lmi_utils/label_utils/scretch_to_edges.py
@@ -9,7 +9,7 @@ import json
 #3rd party packages
 import cv2
 
-logging.basicConfig()
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
Remove logging.basicConfig from local files, as its a global setting which takes effect at the first call, while subsequent calls are ignored.
for example, It introduces lots of unexpected DEBUG logs to my code when gadget_utils.pipeline_utils is imported to my code, as it has level=logging.DEBUG defined.
![image](https://github.com/lmitechnologies/LMI_AI_Solutions/assets/19623402/a3c49621-45dd-44f5-9a2a-adcfe218c93b)
