### PR TITLE
faie-1145 - Optimize Docker Compose Workflow for Anomalib Models

### DIFF
--- a/anomaly_detectors/anomalib/.env
+++ b/anomaly_detectors/anomalib/.env
@@ -1,0 +1,32 @@
+##################################################################################
+# Mounted Resources, with default placeholder values to be overridden by env var
+# check main.sh -h for required resources for each action
+#############################################################
+data_path=./temp/data_train
+
+test_path=./temp/data_test
+
+outdir=./temp/outdir
+
+engine=./temp/engine
+
+onnx=./temp/onnx
+
+#############################################
+# variables
+######################################
+# options:
+#   - x86_64
+#   - aarch64
+platform=x86_64
+
+# options:
+#   - train
+#   - convert
+#   - test
+action=train
+
+# options:
+#   - padim
+#   - patchcore (not tested yet)
+model=padim

--- a/anomaly_detectors/anomalib/docker-compose.yml
+++ b/anomaly_detectors/anomalib/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  patchcore_train:
+    build:
+      context: .
+      dockerfile: docker/dockerfile.$platform
+    volumes:
+      - .:/app/ws
+      - $data_path:/app/data/train
+      - $test_path:/app/data/test
+      - $engine:/app/engine
+      - $onnx:/app/onnx
+      - $outdir:/app/out
+    shm_size: '2gb'
+    runtime: nvidia
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [gpu]
+    command: bash ws/internal_runner.sh $action $model
+

--- a/anomaly_detectors/anomalib/internal_runner.sh
+++ b/anomaly_detectors/anomalib/internal_runner.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
 action=$1
-MODEL=$2
-onnx_dir=/app/mounted/onnx
-engine_dir=/app/mounted/engine
+model=$2
+onnx_dir=/app/onnx
+engine_dir=/app/engine
 
-trained_models_dir=/app/out/results/$MODEL/trained-models
-engines_dir=/app/out/engines/$MODEL
+if [[ -z $model ]]; then
+    model=padim
+fi
 
-if [[ ! -d $onnx_dir ]]; then
+echo action $action, model $model
+
+trained_models_dir=/app/out/results/$model/trained-models
+engines_dir=/app/out/engines/$model
+
+if [[ ! -f $onnx_dir/model.onnx ]]; then
     onnx_dir=$trained_models_dir
 fi
-if [[ ! -d $engine_dir ]]; then
+if [[ ! -f $engine_dir/model.engine ]]; then
     engine_dir=$engines_dir
 fi
 
@@ -19,15 +25,15 @@ if [ "$action" = "train" ] || [ "$action" = "all" ]; then
 
     # -O for disabling assert in the python script to workaround following error:
     # https://github.com/openvinotoolkit/anomalib/issues/1238
-    python3 -O anomalib/tools/train.py --config /app/ws/configs/$MODEL.yaml
+    python3 -O anomalib/tools/train.py --config /app/ws/configs/$model.yaml
 
     build_name="$(date +'%Y-%m-%d-%H-%M')"
     mkdir -p $trained_models_dir && \
-    mv /app/out/results/$MODEL/model/train/run/weights/onnx $trained_models_dir/$build_name
+    mv /app/out/results/$model/model/train/run/weights/onnx $trained_models_dir/$build_name
 
     # tune hyp parameters
-    # python anomalib/tools/hpo/sweep.py --model $MODEL --model_config /app/configs/config.yaml \
+    # python anomalib/tools/hpo/sweep.py --model $model --model_config /app/configs/config.yaml \
     #     --sweep_config tools/hpo/configs/comet.yaml
 fi
 
-python3 ws/anomaly_model.py $action $MODEL $onnx_dir $engine_dir
+python3 ws/anomaly_model.py $action $model $onnx_dir $engine_dir

--- a/anomaly_detectors/anomalib/main.sh
+++ b/anomaly_detectors/anomalib/main.sh
@@ -8,11 +8,11 @@ usage_and_exit() {
     echo    test     test trained model
     echo    convert  convert trained model to trt engine
     echo -o output directory for action results
-    echo -d train data path, only required for train
-    echo -t test data path, only required for test
-    echo -e the folder that contains model.engine to test, defaults to latest folder in output/engines
-    echo -m the model type to train: padim as default or patchcore
-    echo -x the folder that contains model.onnx to be converted to trt engine, defaults to the latest in output/results/model/trained models
+    echo -d for train, train data path
+    echo -m for train, the model type, defaults to padim
+    echo -t for test, test data path
+    echo -e for test, the folder that contains model.engine to test, defaults to latest folder in output/engines
+    echo -x for convert, the folder that contains model.onnx to be converted to trt engine, defaults to the latest in output/results/model/trained models
     echo examples:
     echo -------- train -----
     echo bash main.sh -a train -d /path/to/train/data -o /path/to/outdir
@@ -87,13 +87,13 @@ if [[ $onnx_dir ]]; then
   if [[ $onnx_dir != /* ]]; then
     onnx_dir=$(pwd)/$onnx_dir
   fi
-  docker_run_cmd="${docker_run_cmd} -v $onnx_dir:/app/mounted/onnx"
+  docker_run_cmd="${docker_run_cmd} -v $onnx_dir:/app/onnx"
 fi
 if [[ $engine_dir ]]; then
   if [[ $engine_dir != /* ]]; then
     engine_dir=$(pwd)/$engine_dir
   fi
-  docker_run_cmd="${docker_run_cmd} -v $engine_dir:/app/mounted/engine"
+  docker_run_cmd="${docker_run_cmd} -v $engine_dir:/app/engine"
 fi
 
 docker_run_cmd="${docker_run_cmd} $image_name bash /app/ws/internal_runner.sh $action $model"


### PR DESCRIPTION
Tested:

- train
action=train data_path=/home/wendong/ws/trex-winchester-board-models/data/top/patchcore/top outdir=/home/wendong/ws/untracked-data docker compose up

- convert
# onnx defaults to latest trained model, useful when user would like to convert after train
action=convert outdir=/home/wendong/ws/untracked-data docker compose up

# convert given onnx
action=convert onnx=/home/wendong/ws/untracked-data/results/padim/trained-models/2023-08-07-21-46 outdir=/home/wendong/ws/untracked-data docker compose up

- test
# engine defaulst to latest engine in the outdir/engines
action=test test_path=/home/wendong/ws/trex-winchester-board-models/data/top/patchcore/top/test/defects outdir=/home/wendong/ws/untracked-data docker compose up

# or explicitly specify it
action=test engine=/home/wendong/ws/untracked-data/engines/padim/2023-08-11-11-28 test_path=/home/wendong/ws/trex-winchester-board-models/data/top/patchcore/top/test/defects outdir=/home/wendong/ws/untracked-data docker compose up

