### PR TITLE
FAIE-1227 - Modify AD model annotation for Top board

### DIFF
--- a/anomaly_detectors/anomalib_lmi/ad_utils.py
+++ b/anomaly_detectors/anomalib_lmi/ad_utils.py
@@ -259,7 +259,7 @@ def postprocess(self, orig_image, anomaly_map, err_thresh, err_size, mask=None, 
         anomaly_map = cv2.bitwise_and(anomaly_map_fp32, anomaly_map_fp32, mask=mask)
     ind = anomaly_map<err_thresh
     err_count = np.count_nonzero(ind==False)
-    anomaly_map[ind] = err_thresh
+    anomaly_map[ind] = 0
     max_error = {'emax':round(anomaly_map.max().tolist(), 1), 'ecnt':err_count}
 
     if useContours:


### PR DESCRIPTION
Set the value to 0 for pixels under threshold, not to threshold.