### PR TITLE
fix an error in the yolo classifier after upgrading ultralytics to the latest version

### DIFF
--- a/classifiers/yolov8_cls/model.py
+++ b/classifiers/yolov8_cls/model.py
@@ -76,6 +76,7 @@ class Yolov8_cls(Yolov8):
         """
         
         results = defaultdict(list)
+        preds = preds[0] if isinstance(preds, (list, tuple)) else preds
         for pred in preds:
             pred = pred.cpu().numpy()
             idx = pred.argmax()


### PR DESCRIPTION
The classification model now return a list instead of a tensor. Check it out here: https://github.com/ultralytics/ultralytics/blob/40a8f5d0190dfefb6a42417c354f78d095a8ba30/ultralytics/nn/modules/head.py#L304