### PR TITLE
Fix ais repo unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,29 @@
 #ignore files
 *.pyc
+*.html
 
 #pytorch weights
 *.pt
 
 #ignore folders
 **.vscode
-**/data
-**/.ipynb_checkpoints
-**/validation
-**/training
-**/weights
-**/wandb
-**/trained-inference-models
-**/pretrained-models
-**/records
-**/venv
-**/testfiles
-**/logs
-**/temp
+data
+.ipynb_checkpoints
+validation
+training
+weights
+wandb
+trained-inference-models
+pretrained-models
+records
+venv
+testfiles
+logs
+temp
 config
-**/untracked-data
+untracked-data
 debug
-**/*.egg-info
-**/*.html
+*.egg-info
 datasets
 runs
+outputs

--- a/conftest.py
+++ b/conftest.py
@@ -7,13 +7,6 @@ import sys
 
 logging.basicConfig()
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--test-package",
-        action="store",
-        default=False,
-        help="Run packaging tests",
-    )
 
 def pytest_configure(config):
     # Set up logging specifically for pytest_configure
@@ -28,13 +21,3 @@ def pytest_configure(config):
     # Prevent logging from propagating to the root logger
     logger.propagate = False
     
-    try:
-        logger.info('Starting git LFS pull...')
-        result = subprocess.run(["git", "lfs", "pull"], check=True, capture_output=True, text=True)
-        logger.info(f"Git LFS pull output: {result.stdout}")
-    except subprocess.CalledProcessError as e:
-        logger.exception(f"Error running git lfs pull some tests may fail: {e.output}")
-        if "Not in a Git repository" in e.output:
-            logger.error("You are not in a git repository. Please run this command in a git repository.")
-        else:
-            pytest.exit(f"Error running git lfs pull some tests may fail: {e.output}")

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
@@ -1,23 +1,13 @@
 import pytest
 import logging
-import sys
 import os
 import tempfile
 import subprocess
+from pathlib import Path
 
-# add path to the repo
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        sys.path.append(os.path.join(ROOT, 'anomaly_detectors'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
+# path to the repo
+PATH = Path(__file__).resolve()
+ROOT = PATH.parents[3]
 
 from anomalib_lmi.anomaly_model import AnomalyModel
 from ad_core.anomaly_detector import AnomalyDetector
@@ -34,15 +24,15 @@ OUTPUT_PATH = 'tests/assets/validation/ad_v0'
 
 
 
-def test_model(add_root_path):
+def test_model():
     ad = AnomalyModel(MODEL_PATH)
     ad.test(DATA_PATH, OUTPUT_PATH, generate_stats=True,annotate_inputs=True)
 
-def test_model_api(add_root_path):
+def test_model_api():
     ad = AnomalyDetector(dict(framework='anomalib', model_name='patchcore', task='seg', version='v0'), MODEL_PATH)
     ad.test(DATA_PATH, OUTPUT_PATH, generate_stats=True,annotate_inputs=True)
         
-def test_cmds(add_root_path):
+def test_cmds():
     with tempfile.TemporaryDirectory() as t:
         my_env = os.environ.copy()
         my_env['PYTHONPATH'] = f'$PYTHONPATH:{ROOT}/lmi_utils:{ROOT}/anomaly_detectors'

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
@@ -1,13 +1,7 @@
-import pytest
 import logging
 import os
 import tempfile
 import subprocess
-from pathlib import Path
-
-# path to the repo
-PATH = Path(__file__).resolve()
-ROOT = PATH.parents[3]
 
 from anomalib_lmi.anomaly_model import AnomalyModel
 from ad_core.anomaly_detector import AnomalyDetector
@@ -35,7 +29,6 @@ def test_model_api():
 def test_cmds():
     with tempfile.TemporaryDirectory() as t:
         my_env = os.environ.copy()
-        my_env['PYTHONPATH'] = f'$PYTHONPATH:{ROOT}/lmi_utils:{ROOT}/anomaly_detectors'
         cmd = f'python -m anomalib_lmi.anomaly_model -i {MODEL_PATH} -d {DATA_PATH} -o {str(t)} -g -p'
         logger.info(f'running cmd: {cmd}')
         result = subprocess.run(cmd,shell=True,env=my_env,capture_output=True,text=True)

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
@@ -9,13 +9,8 @@ import numpy as np
 import torch
 import subprocess
 import time
-from pathlib import Path
 from anomalib.deploy.inferencers.torch_inferencer import TorchInferencer
 from anomalib.data.utils import read_image
-
-# path to the repo
-PATH = Path(__file__).resolve()
-ROOT = PATH.parents[3]
 
 
 from anomalib_lmi.anomaly_model2 import AnomalyModel2
@@ -200,7 +195,6 @@ def test_cmds():
     """
     with tempfile.TemporaryDirectory() as t:
         my_env = os.environ.copy()
-        my_env['PYTHONPATH'] = f'$PYTHONPATH:{ROOT}/lmi_utils:{ROOT}/anomaly_detectors'
         cmd = f'python -m anomalib_lmi.anomaly_model2 test -i {MODEL_PATH} -d {DATA_PATH} -o {str(t)} -g -p --tile 224 224 --stride 224 224 --resize'
         logger.info(f'running cmd: {cmd}')
         result = subprocess.run(cmd,shell=True,env=my_env,capture_output=True,text=True)

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 from collections.abc import Sequence
-import sys
 import os
 import tempfile
 import glob
@@ -10,20 +9,13 @@ import numpy as np
 import torch
 import subprocess
 import time
+from pathlib import Path
 from anomalib.deploy.inferencers.torch_inferencer import TorchInferencer
 from anomalib.data.utils import read_image
 
-# add path to the repo
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        sys.path.append(os.path.join(ROOT, 'anomaly_detectors'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
+# path to the repo
+PATH = Path(__file__).resolve()
+ROOT = PATH.parents[3]
 
 
 from anomalib_lmi.anomaly_model2 import AnomalyModel2
@@ -54,7 +46,7 @@ def test_data():
     return out,names
 
 
-def test_compare_results_with_anomalib(add_root_path):
+def test_compare_results_with_anomalib():
     """
     compare prediction results between current implementation and anomalib
     """
@@ -82,7 +74,7 @@ def test_compare_results_with_anomalib(add_root_path):
         
         assert np.array_equal(pred, pred2)
 
-def test_compare_results_with_anomalib_api(add_root_path):
+def test_compare_results_with_anomalib_api():
     """
     compare prediction results between current implementation and anomalib
     """
@@ -111,7 +103,7 @@ def test_compare_results_with_anomalib_api(add_root_path):
         assert np.array_equal(pred, pred2)
 
         
-def test_warmup(add_root_path):
+def test_warmup():
     ad = AnomalyModel2(MODEL_PATH,224,112)
     ad.warmup()
     ad.warmup([672,640])
@@ -120,7 +112,7 @@ def test_warmup(add_root_path):
     ad.warmup()
     ad.warmup([256,224])
 
-def test_warmup_api(add_root_path):
+def test_warmup_api():
     ad = AnomalyDetector(dict(framework='anomalib1', model_name='padim', task='seg', version='v1', model_path=MODEL_PATH),224,112)
     ad.warmup()
     ad.warmup([672,640])
@@ -130,7 +122,7 @@ def test_warmup_api(add_root_path):
     ad.warmup([256,224])
     
 
-def test_model(add_root_path):
+def test_model():
     ad = AnomalyModel2(MODEL_PATH,224,224,'resize')
     ad.test(DATA_PATH, os.path.join(OUTPUT_PATH,'tile-resize'))
     
@@ -140,14 +132,14 @@ def test_model(add_root_path):
     ad = AnomalyModel2(MODEL_PATH)
     ad.test(DATA_PATH, OUTPUT_PATH)
 
-def test_model_api(add_root_path):
+def test_model_api():
     ad = AnomalyDetector(dict(framework='anomalib1', model_name='padim', version='v1', model_path=MODEL_PATH),224,224,'resize')
     ad.test(DATA_PATH, OUTPUT_PATH)
     
     ad = AnomalyDetector(dict(framework='anomalib1', model_name='padim', version='v1', model_path=MODEL_PATH))
     ad.test(DATA_PATH, OUTPUT_PATH)
     
-def test_annotate(test_data, add_root_path):
+def test_annotate(test_data, ):
     def old_func(img, ad_scores, ad_threshold, ad_max):
         # Resize AD score to match input image
         h_img,w_img=img.shape[:2]
@@ -203,7 +195,7 @@ def test_annotate(test_data, add_root_path):
             assert np.array_equal(out2,out3)
     
     
-def test_cmds(add_root_path):
+def test_cmds():
     """test model inference and model to tensorrt conversion
     """
     with tempfile.TemporaryDirectory() as t:

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     runtime: nvidia # ensure that Nvidia Container Toolkit is installed
     ipc: host
     command: >
-      bash -c "cd /app/repo/ && bash tests/run_tests.sh v1-all install-packages"
+      bash -c "cd /app/repo/ && bash tests/run_tests.sh v1-all"
   
   test_ais_v0_all:
     depends_on:
@@ -22,5 +22,5 @@ services:
     runtime: nvidia # ensure that Nvidia Container Toolkit is installed
     ipc: host
     command: >
-      bash -c "cd /app/repo/ && bash tests/run_tests.sh v0-all install-packages"
+      bash -c "cd /app/repo/ && bash tests/run_tests.sh v0-all"
   

--- a/tests/dockerfile
+++ b/tests/dockerfile
@@ -10,6 +10,7 @@ RUN pip install opencv-python -U --user
 RUN pip install tabulate
 RUN pip install pytest
 RUN pip install ultralytics
+RUN pip install albumentations
 
 # Installing from anomalib src
 RUN git clone -b v1.1.1 https://github.com/openvinotoolkit/anomalib.git && cd anomalib && pip install -e .

--- a/tests/dockerfile.v0
+++ b/tests/dockerfile.v0
@@ -28,5 +28,7 @@ RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'
 RUN git clone https://github.com/facebookresearch/detectron2 detectron2
 RUN pip install --user -e detectron2 
 RUN pip install opencv-python==4.8.0.74
+RUN pip install numpy==1.23.5
+
 # report generation
 RUN pip install pytest-html 

--- a/tests/lmi_utils/dataset_utils/test_representations.py
+++ b/tests/lmi_utils/dataset_utils/test_representations.py
@@ -6,23 +6,10 @@ import pytest
 import sys
 import logging
 
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-# add a pytest fixture to add the root path to sys.path based on the argument passed
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
-
 
 from dataset_utils.representations import (
     Point2d,
@@ -39,13 +26,14 @@ from dataset_utils.representations import (
     AnnotationType
 )
 from dataset_utils.mask_encoder import mask2rle
+from lmi_utils.label_utils.bbox_utils import rotate
 
 
 # ============================
 #  Geometry and Conversion Tests
 # ============================
 
-def test_point2d_from_dict_and_to_yolo(add_root_path):
+def test_point2d_from_dict_and_to_yolo():
     p = Point2d.from_dict({"x": 10, "y": 20})
     assert p.x == 10
     assert p.y == 20
@@ -53,7 +41,7 @@ def test_point2d_from_dict_and_to_yolo(add_root_path):
     expected = [[10/200, 20/100]]
     assert yolo == expected
 
-def test_point2d_resize_and_pad(add_root_path):
+def test_point2d_resize_and_pad():
     p = Point2d(10, 20)
     p.resize(100, 100, 200, 200)
     # Coordinates should double.
@@ -63,14 +51,14 @@ def test_point2d_resize_and_pad(add_root_path):
     assert np.isclose(p.x, 25)
     assert np.isclose(p.y, 45)
 
-def test_box_from_dict_and_to_yolo_no_angle(add_root_path):
+def test_box_from_dict_and_to_yolo_no_angle():
     b = Box.from_dict({"x_min": 10, "y_min": 20, "x_max": 50, "y_max": 80, "angle": 0})
     yolo = b.to_yolo(100, 100)
     expected = [[0.3, 0.5, 0.4, 0.6]]
     logger.warning(f'{yolo}')
     assert yolo == expected
 
-def test_box_resize_and_pad(add_root_path):
+def test_box_resize_and_pad():
     b = Box(10, 20, 50, 80, 0)
     b.resize(orig_h=100, orig_w=100, new_h=200, new_w=200)
     # Coordinates should double.
@@ -84,15 +72,26 @@ def test_box_resize_and_pad(add_root_path):
     assert np.isclose(b.x_max, 105)
     assert np.isclose(b.y_max, 165)
 
-def test_box_to_mask(add_root_path):
+def test_box_to_mask():
     b = Box(10, 20, 50, 80, 0)
     m = b.to_mask(h=100, w=100, mask_type=AnnotationType.MASK)
     assert isinstance(m, Mask)
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:80, 10:50] = 1
     assert np.allclose(m.to_numpy(h=100, w=100), mask)
+    
+    # test rotated box
+    b = Box(10, 20, 50, 80, 30)  # 30 degrees rotation
+    m = b.to_mask(h=100, w=100, mask_type=AnnotationType.MASK)
+    assert isinstance(m, Mask)
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    pts = rotate(10, 20, 50-10, 80-20, 30)
+    cv2.fillPoly(mask, [pts], 1)
+    assert np.allclose(m.to_numpy(h=100, w=100), mask)
+    poly = b.to_mask(mask_type=AnnotationType.POLYGON)
+    assert np.allclose(poly.to_numpy(), pts)
 
-def test_box_invalid_coordinates(add_root_path):
+def test_box_invalid_coordinates():
     with pytest.raises(ValueError):
         # x_min > x_max should raise an exception.
         Box(50, 20, 10, 80, 0)
@@ -100,18 +99,18 @@ def test_box_invalid_coordinates(add_root_path):
         # y_min > y_max should raise an exception.
         Box(10, 80, 50, 20, 0)
 
-def test_box_point_in_box(add_root_path):
+def test_box_point_in_box():
     b = Box(10, 20, 50, 80, 0)
     assert b.point_in_box(30, 50)
     assert not b.point_in_box(5, 50)
 
-def test_polygon_from_dict_and_to_yolo(add_root_path):
+def test_polygon_from_dict_and_to_yolo():
     poly = Polygon.from_dict({"points": [[10, 20], [30, 20], [30, 40], [10, 40]]})
     yolo = poly.to_yolo(100, 100)
     expected = [[10/100, 20/100], [30/100, 20/100], [30/100, 40/100], [10/100, 40/100]]
     assert yolo == expected
 
-def test_polygon_resize_and_pad(add_root_path):
+def test_polygon_resize_and_pad():
     poly = Polygon([[10, 20], [30, 20], [30, 40], [10, 40]])
     poly.resize(100, 100, 200, 200)
     # Points should be doubled.
@@ -121,7 +120,7 @@ def test_polygon_resize_and_pad(add_root_path):
     pts = np.array(poly.points)
     np.testing.assert_allclose(pts, np.array([[25, 45], [65, 45], [65, 85], [25, 85]]))
 
-def test_polygon_to_mask(add_root_path):
+def test_polygon_to_mask():
     poly = Polygon([[10, 20], [30, 20], [30, 40], [10, 40]])
     m = poly.to_mask(h=100, w=100)
     assert isinstance(m, Mask)
@@ -129,7 +128,7 @@ def test_polygon_to_mask(add_root_path):
     cv2.fillPoly(mask, [np.array(poly.points).astype(np.int32)], 1)
     assert np.allclose(m.to_numpy(h=100, w=100), mask)
 
-def test_mask_from_dict_and_to_yolo(add_root_path):
+def test_mask_from_dict_and_to_yolo():
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:80, 10:50] = 1
     rle = mask2rle(mask)
@@ -138,7 +137,7 @@ def test_mask_from_dict_and_to_yolo(add_root_path):
     assert isinstance(yolo, list)
     assert len(yolo) > 0
 
-def test_mask_resize_and_pad(add_root_path):
+def test_mask_resize_and_pad():
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:80, 10:50] = 1
     rle = mask2rle(mask)
@@ -149,7 +148,7 @@ def test_mask_resize_and_pad(add_root_path):
     assert m.to_numpy(h=210, w=210).shape == (210, 210)
     
 
-def test_mask_to_box(add_root_path):
+def test_mask_to_box():
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:80, 10:50] = 1
     rle = mask2rle(mask)
@@ -161,14 +160,14 @@ def test_mask_to_box(add_root_path):
 # #     Annotation Tests
 # # ============================
 
-def test_box_annotation_to_yolo(add_root_path):
+def test_box_annotation_to_yolo():
     b = Box(10, 20, 50, 80, 0)
     ba = BoxAnnotation("a1", "label1", b)
     yolo = ba.to_yolo(100, 100)
     expected = b.to_yolo(100, 100)
     assert yolo == expected
 
-def test_mask_annotation_to_yolo(add_root_path):
+def test_mask_annotation_to_yolo():
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:80, 10:50] = 1
     rle = mask2rle(mask)
@@ -178,14 +177,14 @@ def test_mask_annotation_to_yolo(add_root_path):
     expected = m.to_yolo(h=100, w=100)
     assert yolo == expected
 
-def test_keypoint_annotation_to_yolo(add_root_path):
+def test_keypoint_annotation_to_yolo():
     p = Point2d(10, 20)
     ka = KeypointAnnotation("a3", "label3", p)
     yolo = ka.to_yolo(100, 100)
     expected = p.to_yolo(100, 100)
     assert yolo == expected
 
-def test_polygon_annotation_to_yolo(add_root_path):
+def test_polygon_annotation_to_yolo():
     poly = Polygon([[10, 20], [30, 20], [30, 40], [10, 40]])
     pa = PolygonAnnotation("a4", "label4", poly)
     yolo = pa.to_yolo(100, 100)
@@ -208,12 +207,12 @@ def dummy_file_annotations():
     ba = BoxAnnotation(id="a1", label_id="label1", value=b)
     return FileAnnotations(id=file_id,path=file_path, height=height,width=width, annotations=[ba])
 
-def test_file_annotations_relative_path(dummy_file_annotations, add_root_path):
+def test_file_annotations_relative_path(dummy_file_annotations):
     rel_path = dummy_file_annotations.relative_path("/dummy")
     expected = os.path.relpath(dummy_file_annotations.path, "/dummy")
     assert rel_path == expected
 
-def test_file_annotations_update_file(dummy_file_annotations, add_root_path):
+def test_file_annotations_update_file(dummy_file_annotations):
     # Create a new File and update the file annotation.
     file_id = "file1"
     file_path = "/dummy/path/image1.jpg"
@@ -224,7 +223,7 @@ def test_file_annotations_update_file(dummy_file_annotations, add_root_path):
     assert dummy_file_annotations.height == 100
     assert dummy_file_annotations.width == 100
 
-def test_file_annotations_delete_annotation(dummy_file_annotations, add_root_path):
+def test_file_annotations_delete_annotation(dummy_file_annotations):
     # Try deleting an annotation that exists.
     result = dummy_file_annotations.delete_annotation("a1", list_type="annotations")
     assert result is True
@@ -232,14 +231,14 @@ def test_file_annotations_delete_annotation(dummy_file_annotations, add_root_pat
     result = dummy_file_annotations.delete_annotation("a1", list_type="annotations")
     assert result is False
 
-def test_file_annotations_update_annotations(dummy_file_annotations, add_root_path):
+def test_file_annotations_update_annotations(dummy_file_annotations):
     # Update annotations list.
     new_ann = BoxAnnotation("a_new", "label1", Box(5, 5, 15, 15, 0))
     dummy_file_annotations.update_annotations([new_ann], list_type="annotations")
     assert len(dummy_file_annotations.annotations) == 1
     assert dummy_file_annotations.annotations[0].id == "a_new"
 
-def test_file_annotations_assign_keypoints_error(add_root_path):
+def test_file_annotations_assign_keypoints_error():
     # Create a FileAnnotations with a keypoint that does not fall inside any box.
     file_id = "file1"
     file_path = "/dummy/path/image1.jpg"
@@ -252,7 +251,7 @@ def test_file_annotations_assign_keypoints_error(add_root_path):
     with pytest.raises(Exception, match="not assigned"):
         fa.assign_keypoints()
 
-def test_file_annotations_to_yolo(dummy_file_annotations, add_root_path):
+def test_file_annotations_to_yolo(dummy_file_annotations):
     logger.warning(f"dummy_file_annotations: {dummy_file_annotations}")
     # logger.warning(f"yolo: {yolo}")
     yolo, label_ids = dummy_file_annotations.to_yolo(
@@ -286,7 +285,7 @@ def dummy_dataset():
     file_ann = FileAnnotations(id=file_id, path=file_path,height=height,width=width, annotations=[ba, ka])
     return Dataset(labels, [file_ann])
 
-def test_dataset_from_dict(dummy_dataset, add_root_path):
+def test_dataset_from_dict(dummy_dataset):
     data = {
         "labels": [
             {"id": "label1", "name": "Label One"},
@@ -310,20 +309,20 @@ def test_dataset_from_dict(dummy_dataset, add_root_path):
     assert len(ds.labels) == 2
     assert len(ds.files) == 1
 
-def test_dataset_label_to_index(dummy_dataset, add_root_path):
+def test_dataset_label_to_index(dummy_dataset):
     idx = dummy_dataset.label_to_index("label1")
     assert isinstance(idx, int)
     with pytest.raises(ValueError):
         dummy_dataset.label_to_index("nonexistent")
 
-def test_dataset_base_path(dummy_dataset, add_root_path):
+def test_dataset_base_path(dummy_dataset):
     # Compute common prefix and ensure base_path is the directory.
     bp = dummy_dataset.base_path
     # In this dummy case, the base path should be the directory part of "/dummy/path/image1.jpg"
     expected = os.path.dirname("/dummy/path/image1.jpg")
     assert bp == expected
 
-def test_dataset_to_yolo(dummy_dataset, add_root_path):
+def test_dataset_to_yolo(dummy_dataset):
     yolo_data = dummy_dataset.to_yolo(to_segmentation=False, to_object_detection=False)
     assert "image_labels" in yolo_data
     assert "class_map" in yolo_data
@@ -331,7 +330,7 @@ def test_dataset_to_yolo(dummy_dataset, add_root_path):
     for key, annotations in yolo_data["image_labels"].items():
         assert len(annotations) > 0
 
-def test_dataset_save_and_load(tmp_path, dummy_dataset, add_root_path):
+def test_dataset_save_and_load(tmp_path, dummy_dataset):
     # Test the Base.save and Base.load functionality using a temporary file.
     file_path = tmp_path / "dataset.json"
     # Save dataset as JSON.
@@ -344,7 +343,7 @@ def test_dataset_save_and_load(tmp_path, dummy_dataset, add_root_path):
     # Check one field from a label.
     assert loaded.labels[0].id == dummy_dataset.labels[0].id
 
-def test_base_to_dict_and_to_json(dummy_dataset, add_root_path):
+def test_base_to_dict_and_to_json(dummy_dataset):
     # Test that Base.to_dict and to_json work.
     d = dummy_dataset.to_dict()
     j = dummy_dataset.to_json()

--- a/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
+++ b/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
@@ -6,23 +6,9 @@ import sys
 import os
 import cv2
 
-# add path to the repo
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-
-
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-# add a pytest fixture to add the root path to sys.path based on the argument passed
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
     
 
 import gadget_utils.pipeline_utils as pipeline_utils
@@ -39,7 +25,7 @@ class Test_resize_image:
             (torch.rand(150, 100, 1).numpy(), {"W": 50}, (75, 50, 1)),  # Test gray image (3D)
         ]
     )
-    def test_cases(self,im, resize_args, expected_shape, add_root_path):
+    def test_cases(self,im, resize_args, expected_shape):
         im2 = pipeline_utils.resize_image(im, **resize_args)
         assert im2.shape == expected_shape
         assert im2.dtype == im.dtype
@@ -101,7 +87,7 @@ class Test_fit_im_to_size:
             (torch.rand(100, 100, 1).numpy(), [89, None]),
         ]
     )
-    def test_cases(self, im, wh, add_root_path):
+    def test_cases(self, im, wh):
         W,H = wh
         im1, l1, r1, t1, b1 = self.np_func(im, W, H)
         
@@ -177,7 +163,7 @@ class Test_revert_to_origin:
             ),
         ]
     )
-    def test_cases(self, pts, operations, add_root_path):
+    def test_cases(self, pts, operations):
         pts1 = self.np_func(pts, operations)
         
         pts2 = pipeline_utils.revert_to_origin(pts, operations)
@@ -217,7 +203,7 @@ class Test_profile_to_3d:
             (torch.randint(-32768, 32767, (90,100), dtype=torch.int16).numpy(), [1, 1, 1], [0, 0, 0]),
         ]
     )
-    def test_cases(self, profile, resolution, offset, add_root_path):
+    def test_cases(self, profile, resolution, offset):
         x1,y1,z1,m1 = self.np_func(profile, resolution, offset)
         x2,y2,z2,m2 = pipeline_utils.profile_to_3d(profile, resolution, offset)
         assert np.array_equal(x1, x2)
@@ -260,7 +246,7 @@ class Test_uint16_to_int16:
             (torch.randint(0, 65535, (520,530), dtype=torch.uint16).numpy()),
         ]
     )
-    def test_cases(self, profile, add_root_path):
+    def test_cases(self, profile):
         p1 = self.np_func(profile)
         p2 = pipeline_utils.uint16_to_int16(profile)
         assert np.array_equal(p1, p2)
@@ -301,7 +287,7 @@ class Test_pts_to_3d:
             (np.array([[15, 25], [35, 45], [55, 65], [75, 85]]), torch.randint(-32768, 32767, (90,100), dtype=torch.int16).numpy(), [1, 1, 1], [0, 0, 0]),
         ]
     )
-    def test_cases(self, pts, profile, resolution, offset, add_root_path):
+    def test_cases(self, pts, profile, resolution, offset):
         xyz1 = self.np_func(pts, profile, resolution, offset)
         
         xyz2 = pipeline_utils.pts_to_3d(pts, profile, resolution, offset)
@@ -318,7 +304,7 @@ class Test_pts_to_3d:
             assert xyz3.is_cuda
             assert np.array_equal(xyz1,xyz3.cpu().numpy())
             
-    def test_error_handle(self, add_root_path):
+    def test_error_handle(self):
         pts = np.array([[15, 25], [35, 45], [55, 65], [75, 85]])
         profile = torch.randint(-32768, 32767, (90,100), dtype=torch.int16)
         resolution = [1, 1, 1]

--- a/tests/lmi_utils/image_utils/test_img_tile.py
+++ b/tests/lmi_utils/image_utils/test_img_tile.py
@@ -1,26 +1,20 @@
 import pytest
 import os
-import pathlib
-import sys
 import tempfile
 import logging
 import torch
 import torchvision
 import subprocess
 
-# path to the repo
-PATH = pathlib.Path(__file__)
-ROOT = PATH.parents[3]
+from image_utils.img_tile import to_tiles,to_images,ScaleMode
+from system_utils import path_utils
 
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-from image_utils.img_tile import to_tiles,to_images,ScaleMode
-from system_utils import path_utils
-
-PATH_IMG = ROOT/'tests/assets/images/dota'
+PATH_IMG = 'tests/assets/images/dota'
 
 
 def load_imgs(im_dir, recursive=True):
@@ -80,7 +74,6 @@ def test_interpolation(tile,stride):
 def test_cmds():
     imgs = load_imgs(PATH_IMG)
     my_env = os.environ.copy()
-    my_env['PYTHONPATH'] = f'$PYTHONPATH:{str(ROOT)}/lmi_utils'
     with tempfile.TemporaryDirectory() as tmpdir:
         cmd = f'python -m image_utils.img_tile --option tile -i {str(PATH_IMG)} -o {str(tmpdir)} --tile 224 224 --stride 112 112'
         out = subprocess.run(cmd,check=True,shell=True,env=my_env,capture_output=True,text=True)

--- a/tests/lmi_utils/image_utils/test_img_tile.py
+++ b/tests/lmi_utils/image_utils/test_img_tile.py
@@ -8,7 +8,7 @@ import torch
 import torchvision
 import subprocess
 
-# add path to the repo
+# path to the repo
 PATH = pathlib.Path(__file__)
 ROOT = PATH.parents[3]
 
@@ -16,14 +16,6 @@ ROOT = PATH.parents[3]
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
 
 from image_utils.img_tile import to_tiles,to_images,ScaleMode
 from system_utils import path_utils
@@ -49,7 +41,7 @@ def load_imgs(im_dir, recursive=True):
         ([224,256],[56,64],[224,256])
     ]
 )
-def test_cases(tile_hw, stride_hw, expected_tile_hw, add_root_path):
+def test_cases(tile_hw, stride_hw, expected_tile_hw):
     imgs = load_imgs(PATH_IMG)
     with tempfile.TemporaryDirectory() as tmpdir:
         to_tiles(PATH_IMG,tmpdir,tile_hw,stride_hw,recursive=True)
@@ -72,7 +64,7 @@ def test_cases(tile_hw, stride_hw, expected_tile_hw, add_root_path):
         ([224,256],[56,64])
     ]
 )                
-def test_interpolation(tile,stride, add_root_path):
+def test_interpolation(tile,stride):
     with tempfile.TemporaryDirectory() as tmp1:
         with tempfile.TemporaryDirectory() as tmp2:
             to_tiles(PATH_IMG,tmp1,tile,stride,mode=ScaleMode.INTERPOLATION)
@@ -85,7 +77,7 @@ def test_interpolation(tile,stride, add_root_path):
                 assert list(im.shape[-2:])==tile
 
 
-def test_cmds(add_root_path):
+def test_cmds():
     imgs = load_imgs(PATH_IMG)
     my_env = os.environ.copy()
     my_env['PYTHONPATH'] = f'$PYTHONPATH:{str(ROOT)}/lmi_utils'

--- a/tests/lmi_utils/image_utils/test_tiler.py
+++ b/tests/lmi_utils/image_utils/test_tiler.py
@@ -6,19 +6,9 @@ import logging
 import torch
 import torchvision
 
-# add path to the repo
+# path to the repo
 PATH = pathlib.Path(__file__)
 ROOT = PATH.parents[3]
-# sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
 
 from image_utils.tiler import Tiler, ScaleMode
 from system_utils import path_utils
@@ -49,7 +39,7 @@ def load_imgs(im_dir, recursive=True):
         (torch.rand(1,1,110,110),[224,112],[112,112],[1,1,224,112],[224,112]),
     ]
 )
-def test_cases(im,tile,stride,expected_tile_hw,expected_resized_hw, add_root_path):
+def test_cases(im,tile,stride,expected_tile_hw,expected_resized_hw):
     t = Tiler(tile,stride)
     tiles1 = t.tile(im)
     assert list(tiles1.shape) == expected_tile_hw
@@ -77,7 +67,7 @@ def test_cases(im,tile,stride,expected_tile_hw,expected_resized_hw, add_root_pat
         (torch.rand(8,3,512,512), 256, 256),
     ]
 )        
-def test_batch(im, tile, stride, add_root_path):
+def test_batch(im, tile, stride):
     mode = ScaleMode.INTERPOLATION
     t = Tiler(tile, stride)
     tiles = t.tile(im, mode)

--- a/tests/lmi_utils/image_utils/test_tiler.py
+++ b/tests/lmi_utils/image_utils/test_tiler.py
@@ -1,14 +1,8 @@
 import pytest
 import os
-import pathlib
-import sys
 import logging
 import torch
 import torchvision
-
-# path to the repo
-PATH = pathlib.Path(__file__)
-ROOT = PATH.parents[3]
 
 from image_utils.tiler import Tiler, ScaleMode
 from system_utils import path_utils
@@ -17,7 +11,7 @@ logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-PATH_IMG = ROOT/'tests/assets/images/dota'
+PATH_IMG = 'tests/assets/images/dota'
 
 
 def load_imgs(im_dir, recursive=True):

--- a/tests/object_detectors/detectron2_lmi/test_detectron2_model.py
+++ b/tests/object_detectors/detectron2_lmi/test_detectron2_model.py
@@ -1,11 +1,7 @@
 import os
 import pytest
-import sys
 import json 
 import cv2
-import glob
-import subprocess
-
 import torch
 from torch import Tensor, nn
 from detectron2 import model_zoo
@@ -14,21 +10,6 @@ from detectron2.utils.testing import (
 )
 import logging
 import numpy as np
-
-
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-# sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-# sys.path.append(os.path.join(ROOT, 'object_detectors'))
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        sys.path.append(os.path.join(ROOT, 'object_detectors'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
 
 from detectron2_lmi.model import Detectron2Model
 from od_core.object_detector import ObjectDetector
@@ -54,7 +35,7 @@ logger.setLevel(logging.DEBUG)
 
 class TestDetectron2ModelPT:
 
-    def test_model(self, add_root_path):
+    def test_model(self):
         og_model = model_zoo.get(MASKRCNN_MODEL_CONFIG, trained=True)
         og_model.eval()
         img = get_sample_coco_image()
@@ -77,7 +58,7 @@ class TestDetectron2ModelPT:
         assert np.allclose(orginal_preds.scores.cpu().numpy(), preds.get('scores'))
         assert np.allclose(orginal_preds.pred_masks.cpu().numpy(), preds.get('masks'))
         
-    def test_annotations(self, add_root_path):
+    def test_annotations(self):
         confs = {
            v:0.95 for k,v in class_map.items()
         }
@@ -97,7 +78,7 @@ class TestDetectron2ModelPT:
         )
         cv2.imwrite(os.path.join(OUT_DIR, os.path.basename(SAMPLE_IMAGE)), annotated_image)
         
-    def test_operators(self, add_root_path):
+    def test_operators(self):
         confs = {
            v:0.95 for k,v in class_map.items()
         }
@@ -120,7 +101,7 @@ class TestDetectron2ModelPT:
         )
         cv2.imwrite(os.path.join(OUT_DIR, os.path.basename(SAMPLE_IMAGE)), annotated_image)
     
-    def test_operators_no_masks(self, add_root_path):
+    def test_operators_no_masks(self):
         confs = {
            v:1.0 for k,v in class_map.items()
         }
@@ -139,7 +120,7 @@ class TestDetectron2ModelPT:
         
 class TestDetectron2ModelPT_API:
 
-    def test_model(self, add_root_path):
+    def test_model(self):
         og_model = model_zoo.get(MASKRCNN_MODEL_CONFIG, trained=True)
         og_model.eval()
         img = get_sample_coco_image()
@@ -162,7 +143,7 @@ class TestDetectron2ModelPT_API:
         assert np.allclose(orginal_preds.scores.cpu().numpy(), preds.get('scores'))
         assert np.allclose(orginal_preds.pred_masks.cpu().numpy(), preds.get('masks'))
         
-    def test_annotations(self, add_root_path):
+    def test_annotations(self):
         confs = {
            v:0.95 for k,v in class_map.items()
         }
@@ -182,7 +163,7 @@ class TestDetectron2ModelPT_API:
         )
         cv2.imwrite(os.path.join(OUT_DIR, os.path.basename(SAMPLE_IMAGE)), annotated_image)
         
-    def test_operators(self, add_root_path):
+    def test_operators(self):
         confs = {
            v:0.95 for k,v in class_map.items()
         }
@@ -205,7 +186,7 @@ class TestDetectron2ModelPT_API:
         )
         cv2.imwrite(os.path.join(OUT_DIR, os.path.basename(SAMPLE_IMAGE)), annotated_image)
     
-    def test_operators_no_masks(self, add_root_path):
+    def test_operators_no_masks(self):
         confs = {
            v:1.0 for k,v in class_map.items()
         }

--- a/tests/object_detectors/ultralytics_lmi/yolo/test_model_yolo.py
+++ b/tests/object_detectors/ultralytics_lmi/yolo/test_model_yolo.py
@@ -6,21 +6,6 @@ import sys
 import os
 import cv2
 
-# add path to the repo
-PATH = os.path.abspath(__file__)
-ROOT = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))))
-# sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-# sys.path.append(os.path.join(ROOT, 'object_detectors'))
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        sys.path.append(os.path.join(ROOT, 'object_detectors'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
-
 import gadget_utils.pipeline_utils as pipeline_utils
 from ultralytics_lmi.yolo.model import Yolo, YoloObb, YoloPose
 from od_core.object_detector import ObjectDetector
@@ -93,32 +78,32 @@ def model_pose():
 @pytest.fixture
 def model_det_api():
     return [
-        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='od', framework='ultralytics', model_path=model)) for model in OD_DET_MODELS
+        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='od', framework='ultralytics', model_path=model, image_size=[640, 640])) for model in OD_DET_MODELS
     ]
 
 @pytest.fixture
 def model_seg_api():
     return [
-        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='seg', framework='ultralytics'), model_path=model) for model in OD_SEG_MODELS
+        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='seg', framework='ultralytics', model_path=model, image_size=[640, 640])) for model in OD_SEG_MODELS
     ]
 
 @pytest.fixture
 def model_obb_dota8_api():
     return [
-        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='obb', framework='ultralytics'), model_path=model) for model in OD_OBB_DOTA_8
+        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='obb', framework='ultralytics', model_path=model, image_size=[640, 640])) for model in OD_OBB_DOTA_8
     ]
     
 @pytest.fixture
 def model_obb_dota_api():
     return [
-        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='obb', framework='ultralytics'), model_path=model) for model in OD_OBB_DOTA
+        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='obb', framework='ultralytics', model_path=model, image_size=[640, 640])) for model in OD_OBB_DOTA
     ]
 
 
 @pytest.fixture
 def model_pose_api():
     return [
-        ObjectDetector(dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='pose', framework='ultralytics'), model_path=model) for model in OD_POSE_MODELS
+        ObjectDetector(metadata=dict(version='v1', model_name='yolov8' if 'yolov8n' in model else 'yolov11', task='pose', framework='ultralytics', model_path=model, image_size=[640, 640])) for model in OD_POSE_MODELS
     ]
 
 def load_image(path):
@@ -182,11 +167,11 @@ def imgs_dota8():
 
 
 class Test_Yolo_Det:
-    def test_warmup(self, model_det,add_root_path):
+    def test_warmup(self, model_det):
         for model in model_det:
             model.warmup()
             
-    def test_predict(self, model_det, imgs_coco, add_root_path):
+    def test_predict(self, model_det, imgs_coco):
         i = 0
         for model in model_det:
             for img,resized,op in zip(*imgs_coco):
@@ -209,11 +194,11 @@ class Test_Yolo_Det:
                 i += 1
 
 class Test_Yolo_Det_API:
-    def test_warmup(self, model_det_api, add_root_path):
+    def test_warmup(self, model_det_api):
         for model in model_det_api:
             model.warmup()
             
-    def test_predict(self, model_det_api, imgs_coco, add_root_path):
+    def test_predict(self, model_det_api, imgs_coco):
         i = 0
         for model in model_det_api:
             for img,resized,op in zip(*imgs_coco):
@@ -236,11 +221,11 @@ class Test_Yolo_Det_API:
                 i += 1
                 
 class Test_Yolo_Seg:
-    def test_warmup(self, model_seg, add_root_path):
+    def test_warmup(self, model_seg):
         for model in model_seg:
             model.warmup()
             
-    def test_predict(self, model_seg, imgs_coco, add_root_path):
+    def test_predict(self, model_seg, imgs_coco):
         i = 0
         for model in model_seg:
             for img,resized,op in zip(*imgs_coco):
@@ -263,11 +248,11 @@ class Test_Yolo_Seg:
                 i += 1
 
 class Test_Yolo_Seg_API:
-    def test_warmup(self, model_seg_api, add_root_path):
+    def test_warmup(self, model_seg_api):
         for model in model_seg_api:
             model.warmup()
             
-    def test_predict(self, model_seg_api, imgs_coco, add_root_path):
+    def test_predict(self, model_seg_api, imgs_coco):
         i = 0
         for model in model_seg_api:
             for img,resized,op in zip(*imgs_coco):
@@ -290,15 +275,15 @@ class Test_Yolo_Seg_API:
                 i += 1
 
 class Test_Yolo_Obb:
-    def test_warmup_dota8(self, model_obb_dota8, add_root_path):
+    def test_warmup_dota8(self, model_obb_dota8):
         for model in model_obb_dota8:
             model.warmup()
             
-    def test_warmup_dota(self, model_obb_dota, add_root_path):
+    def test_warmup_dota(self, model_obb_dota):
         for model in model_obb_dota:
             model.warmup()
         
-    def test_predict_dota8(self, model_obb_dota8, imgs_dota8, add_root_path):
+    def test_predict_dota8(self, model_obb_dota8, imgs_dota8):
         i = 0
         for model in model_obb_dota8:
             for img,resized,op in zip(*imgs_dota8):
@@ -320,7 +305,7 @@ class Test_Yolo_Obb:
                     cv2.imwrite(os.path.join(OUT_DIR, f'obb-{i}.png'), im_out)
                 i += 1
     
-    def test_predict_dota(self, model_obb_dota, imgs_dota, add_root_path):
+    def test_predict_dota(self, model_obb_dota, imgs_dota):
         i = 0
         for model in model_obb_dota:
             for img,resized,op in zip(*imgs_dota):
@@ -343,15 +328,15 @@ class Test_Yolo_Obb:
                 i += 1
 
 class Test_Yolo_Obb_API:
-    def test_warmup_dota8(self, model_obb_dota8_api, add_root_path):
+    def test_warmup_dota8(self, model_obb_dota8_api):
         for model in model_obb_dota8_api:
             model.warmup()
             
-    def test_warmup_dota(self, model_obb_dota_api, add_root_path):
+    def test_warmup_dota(self, model_obb_dota_api):
         for model in model_obb_dota_api:
             model.warmup()
         
-    def test_predict_dota8(self, model_obb_dota8_api, imgs_dota8, add_root_path):
+    def test_predict_dota8(self, model_obb_dota8_api, imgs_dota8):
         i = 0
         for model in model_obb_dota8_api:
             for img,resized,op in zip(*imgs_dota8):
@@ -373,7 +358,7 @@ class Test_Yolo_Obb_API:
                     cv2.imwrite(os.path.join(OUT_DIR, f'obb-{i}.png'), im_out)
                 i += 1
     
-    def test_predict_dota(self, model_obb_dota_api, imgs_dota, add_root_path):
+    def test_predict_dota(self, model_obb_dota_api, imgs_dota):
         i = 0
         for model in model_obb_dota_api:
             for img,resized,op in zip(*imgs_dota):
@@ -396,11 +381,11 @@ class Test_Yolo_Obb_API:
                 i += 1  
 
 class Test_Yolo_Pose:
-    def test_warmup(self, model_pose, add_root_path):
+    def test_warmup(self, model_pose):
         for model in model_pose:
             model.warmup()
         
-    def test_predict(self, model_pose, imgs_coco, add_root_path):
+    def test_predict(self, model_pose, imgs_coco):
         i = 0
         for model in model_pose:
             for img,resized,op in zip(*imgs_coco):
@@ -424,11 +409,11 @@ class Test_Yolo_Pose:
                 
 
 class Test_Yolo_Pose_API:
-    def test_warmup(self, model_pose_api, add_root_path):
+    def test_warmup(self, model_pose_api):
         for model in model_pose_api:
             model.warmup()
         
-    def test_predict(self, model_pose_api, imgs_coco, add_root_path):
+    def test_predict(self, model_pose_api, imgs_coco):
         i = 0
         for model in model_pose_api:
             for img,resized,op in zip(*imgs_coco):

--- a/tests/object_detectors/yolov8_lmi/test_yolov8_model.py
+++ b/tests/object_detectors/yolov8_lmi/test_yolov8_model.py
@@ -6,22 +6,6 @@ import sys
 import os
 import cv2
 
-# add path to the repo
-PATH = os.path.abspath(__file__)
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(PATH))))
-# sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-# sys.path.append(os.path.join(ROOT, 'object_detectors'))
-
-@pytest.fixture()
-def add_root_path(request):
-    if request.config.getoption("--test-package") is False:
-        sys.path.append(os.path.join(ROOT, 'lmi_utils'))
-        sys.path.append(os.path.join(ROOT, 'object_detectors'))
-        logger.info(f"Added {ROOT} to sys.path")
-    else:
-        logger.info("Skipping adding root path to sys.path")
-
-
 import gadget_utils.pipeline_utils as pipeline_utils
 from yolov8_lmi.model import Yolov8, Yolov8Obb, Yolov8Pose
 from od_core.object_detector import ObjectDetector
@@ -59,19 +43,19 @@ def model_pose():
 
 @pytest.fixture
 def model_det_api():
-    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='od', framework='ultralytics'), weights=MODEL_DET)
+    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='od', framework='ultralytics', model_path=MODEL_DET, image_size=[640, 640]))
 
 @pytest.fixture
 def model_seg_api():
-    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='seg', framework='ultralytics'), weights=MODEL_SEG)
+    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='seg', framework='ultralytics', model_path=MODEL_SEG, image_size=[640, 640]))
 
 @pytest.fixture
 def model_obb_api():
-    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='obb', framework='ultralytics'), weights=MODEL_OBB)
+    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='obb', framework='ultralytics', model_path=MODEL_OBB, image_size=[640, 640]))
 
 @pytest.fixture
 def model_pose_api():
-    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='pose', framework='ultralytics'), weights=MODEL_POSE)
+    return ObjectDetector(metadata=dict(version='v0', model_name='yolov8', task='pose', framework='ultralytics', model_path=MODEL_POSE, image_size=[640, 640]))
 
 def load_image(path):
     im = cv2.imread(path)
@@ -116,10 +100,10 @@ def imgs_dota():
 
 
 class Test_Yolov8:
-    def test_warmup(self, model_det, add_root_path):
+    def test_warmup(self, model_det):
         model_det.warmup()
             
-    def test_predict(self, model_det, imgs_coco, add_root_path):
+    def test_predict(self, model_det, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_det.predict(resized,configs=0.5,operators=op)
@@ -142,10 +126,10 @@ class Test_Yolov8:
             
 
 class Test_Yolov8_API:
-    def test_warmup(self, model_det_api, add_root_path):
+    def test_warmup(self, model_det_api):
         model_det_api.warmup()
             
-    def test_predict(self, model_det_api, imgs_coco, add_root_path):
+    def test_predict(self, model_det_api, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_det_api.predict(resized,configs=0.5,operators=op)
@@ -168,10 +152,10 @@ class Test_Yolov8_API:
                 
                 
 class Test_Yolov8_seg:
-    def test_warmup(self, model_seg, add_root_path):
+    def test_warmup(self, model_seg):
         model_seg.warmup()
             
-    def test_predict(self, model_seg, imgs_coco, add_root_path):
+    def test_predict(self, model_seg, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_seg.predict(resized,configs=0.5,operators=op)
@@ -194,10 +178,10 @@ class Test_Yolov8_seg:
             
 
 class Test_Yolov8_seg_API:
-    def test_warmup(self, model_seg_api, add_root_path):
+    def test_warmup(self, model_seg_api):
         model_seg_api.warmup()
             
-    def test_predict(self, model_seg_api, imgs_coco, add_root_path):
+    def test_predict(self, model_seg_api, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_seg_api.predict(resized,configs=0.5,operators=op)
@@ -220,10 +204,10 @@ class Test_Yolov8_seg_API:
 
 
 class Test_Yolov8_obb:
-    def test_warmup(self, model_obb, add_root_path):
+    def test_warmup(self, model_obb):
         model_obb.warmup()
         
-    def test_predict(self, model_obb, imgs_dota, add_root_path):
+    def test_predict(self, model_obb, imgs_dota):
         i = 0
         for img,resized,op in zip(*imgs_dota):
             out,time_info = model_obb.predict(resized,configs=0.5,operators=op)
@@ -246,10 +230,10 @@ class Test_Yolov8_obb:
             
 
 class Test_Yolov8_obb_API:
-    def test_warmup(self, model_obb_api, add_root_path):
+    def test_warmup(self, model_obb_api):
         model_obb_api.warmup()
         
-    def test_predict(self, model_obb_api, imgs_dota, add_root_path):
+    def test_predict(self, model_obb_api, imgs_dota):
         i = 0
         for img,resized,op in zip(*imgs_dota):
             out,time_info = model_obb_api.predict(resized,configs=0.5,operators=op)
@@ -272,10 +256,10 @@ class Test_Yolov8_obb_API:
             
 
 class Test_Yolov8_pose:
-    def test_warmup(self, model_pose, add_root_path):
+    def test_warmup(self, model_pose):
         model_pose.warmup()
         
-    def test_predict(self, model_pose, imgs_coco, add_root_path):
+    def test_predict(self, model_pose, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_pose.predict(resized,configs=0.5,operators=op)
@@ -297,10 +281,10 @@ class Test_Yolov8_pose:
             i += 1
             
 class Test_Yolov8_pose_API:
-    def test_warmup(self, model_pose_api, add_root_path):
+    def test_warmup(self, model_pose_api):
         model_pose_api.warmup()
         
-    def test_predict(self, model_pose_api, imgs_coco, add_root_path):
+    def test_predict(self, model_pose_api, imgs_coco):
         i = 0
         for img,resized,op in zip(*imgs_coco):
             out,time_info = model_pose_api.predict(resized,configs=0.5,operators=op)

--- a/tests/object_detectors/yolov8_lmi/test_yolov8_model.py
+++ b/tests/object_detectors/yolov8_lmi/test_yolov8_model.py
@@ -1,8 +1,6 @@
 import pytest
 import torch
-import numpy as np
 import logging
-import sys
 import os
 import cv2
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,46 +1,48 @@
+#!/bin/bash
 if [ "$#" -eq 0 ]; then
     echo "Usage: $0 <argument>"
     exit 1
 fi
+
 INSTALL=$2
 if [ "$INSTALL" == "install-packages" ]; then
     echo "Installing packages"
     pip3 install -e lmi_utils/
     pip3 install -e object_detectors/
     pip3 install -e anomaly_detectors/
+else
+    echo "using repo env"
+    source /app/repo/lmi_ai.env
 fi
+
+# Git LFS pull all the artifacts
+echo "running git lfs pull"
+git lfs pull
+echo "git lfs pull complete"
+
+outpath=tests/outputs
 ARGUMENT=$1
 if [ "$ARGUMENT" == "v1-all" ]; then
-    pytest --test-package=True --html=/app/repo/tests/lmi_utils_v1_packaged.html tests/lmi_utils/
-    pytest --test-package=True --html=/app/repo/tests/object_detectors_v1_packaged.html tests/object_detectors/
-    pytest --test-package=True --html=/app/repo/tests/anomaly_detectors_v1_packaged.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2*
-    pytest --test-package=False --html=/app/repo/tests/lmi_utils_v1.html tests/lmi_utils/
-    pytest --test-package=False --html=/app/repo/tests/object_detectors_v1.html tests/object_detectors/
-    pytest --test-package=False --html=/app/repo/tests/anomaly_detectors_v1.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2*
+    pytest --html=$outpath/lmi_utils_v1.html tests/lmi_utils/
+    pytest --html=$outpath/object_detectors_v1.html tests/object_detectors/
+    pytest --html=$outpath/anomaly_detectors_v1.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
     exit 0
 elif [ "$ARGUMENT" == "v0-all" ]; then
-    pytest --test-package=True --html=/app/repo/tests/lmi_utils_v0_packaged.html tests/lmi_utils/
-    pytest --test-package=True --html=/app/repo/tests/object_detectors_v0_packaged.html tests/object_detectors/
-    pytest --test-package=True --html=/app/repo/tests/anomaly_detectors_v0_packaged.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
-    pytest --test-package=False --html=/app/repo/tests/lmi_utils_v0.html tests/lmi_utils/
-    pytest --test-package=False --html=/app/repo/tests/object_detectors_v0.html tests/object_detectors/
-    pytest --test-package=False --html=/app/repo/tests/anomaly_detectors_v0.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
+    pytest --html=$outpath/lmi_utils_v0.html tests/lmi_utils/
+    pytest --html=$outpath/object_detectors_v0.html tests/object_detectors/
+    pytest --html=$outpath/anomaly_detectors_v0.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
     exit 0
 elif [ "$ARGUMENT" == "object_detectors" ]; then
-    pytest --test-package=True --html=/app/repo/tests/object_detectors_packaged.html tests/object_detectors/
-    pytest --test-package=False --html=/app/repo/tests/object_detectors.html tests/object_detectors/
+    pytest --html=$outpath/object_detectors.html tests/object_detectors/
     exit 0
 elif [ "$ARGUMENT" == "lmi_utils" ]; then
-    pytest --test-package=True --html=/app/repo/tests/lmi_utils_packaged.html tests/lmi_utils/
-    pytest --test-package=False --html=/app/repo/tests/lmi_utils.html tests/lmi_utils/
+    pytest --html=$outpath/lmi_utils.html tests/lmi_utils/
     exit 0
 elif [ "$ARGUMENT" == "anomaly_detectors-v0" ]; then
-    pytest --test-package=True --html=/app/repo/tests/anomaly_detectors_v0_packaged.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
-    pytest --test-package=False --html=/app/repo/tests/anomaly_detectors_v0.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
+    pytest --html=$outpath/anomaly_detectors_v0.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model.py
     exit 0
 elif [ "$ARGUMENT" == "anomaly_detectors-v1" ]; then
-    pytest --test-package=True --html=/app/repo/tests/anomaly_detectors_v1_packaged.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
-    pytest --test-package=False --html=/app/repo/tests/anomaly_detectors_v1.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
+    pytest --html=$outpath/anomaly_detectors_v1.html tests/anomaly_detectors/anomalib_lmi/test_anomaly_model2.py
     exit 0
 fi
 echo "Invalid argument. Please use 'v1-all' 'v0-all' 'object_detectors' 'lmi_utils' 'anomaly_detectors-v0' 'anomaly_detectors-v1'. "


### PR DESCRIPTION
fixed errors:  
1. import ais functions when the AIS packages are not installed.
2. add required metadata for testing YOLO API, such as model_path and image_size.

Major changes:
1. remove add_root_path() fixture. Because it does not work when the packages are not installed.
2. add LMI AIS repo paths to the run_tests.sh instead of each testing scripts.
3. call git lfs pull once in the run_test.sh instead of calling it multiple times