### PR TITLE
improve the od core

### DIFF
--- a/object_detectors/od_core/__init__.py
+++ b/object_detectors/od_core/__init__.py
@@ -1,4 +1,0 @@
-from ultralytics_lmi.yolo.model import *
-from detectron2_lmi.model import *
-from yolov8_lmi.model import *
-from yolov5_lmi.model import *

--- a/object_detectors/od_core/object_detector.py
+++ b/object_detectors/od_core/object_detector.py
@@ -3,6 +3,10 @@ from .od_base import ODBase
 from .object_detector_registry import ObjectDetectorRegistry
 import logging
 
+# register models automatically
+ObjectDetectorRegistry.auto_register_models()
+
+
 class ObjectDetector(ODBase):
 
     def __new__(cls, metadata: Dict[str, Any], *args, **kwargs):

--- a/object_detectors/od_core/object_detector_registry.py
+++ b/object_detectors/od_core/object_detector_registry.py
@@ -1,6 +1,18 @@
 import json
 from typing import Type, Dict, Tuple, Any, Optional, List
 import logging
+import importlib
+import pkgutil
+
+
+PACKAGES = ["ultralytics_lmi", "yolov8_lmi", "detectron2_lmi", "yolov5_lmi"]
+TARGET_MODULE_SUFFIXES = ['.model'] # Target suffixes to look for in the packages
+
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class ObjectDetectorRegistry:
     _registry: Dict[Tuple[str, str, str, str, str], Type] = {}
@@ -18,7 +30,6 @@ class ObjectDetectorRegistry:
 
     @classmethod
     def register(cls, metadata: Dict[str, Any]):
-        logger = logging.getLogger(__name__)
         logger.debug(f"Registering class with metadata: {metadata}")
         frameworks: Optional[List[str]] = metadata.get('frameworks')
         model_names: Optional[List[str]] = metadata.get('model_names')
@@ -46,7 +57,7 @@ class ObjectDetectorRegistry:
                                     f"Combination already registered: "
                                     f"framework='{framework}', model_name='{model_name}', "
                                     f"task='{task}', version='{version}', info='{json.dumps(info, sort_keys=True)}' "
-                                    f"points to {existing_cls.__name__}. Cannot re-register with {wrapper_cls.__name__}."
+                                    f"points to {existing_cls.__module__}. Cannot re-register with {wrapper_cls.__module__}."
                                 )
                             cls._registry[key] = wrapper_cls
             return wrapper_cls
@@ -78,3 +89,24 @@ class ObjectDetectorRegistry:
             )
 
         return wrapper_cls
+    
+    
+    @classmethod
+    def auto_register_models(cls):
+        """
+        Dynamically discovers and imports models to trigger registration.
+        """
+        
+        logger.info("Starting auto-discovery of object detector models...")
+        for package_name in PACKAGES:
+            package = importlib.import_module(package_name)
+            package_path = package.__path__
+
+            # search for target module in each package
+            for _, module_name, _ in pkgutil.walk_packages(package_path, package_name + '.'):
+                if any(module_name.endswith(target) for target in TARGET_MODULE_SUFFIXES):
+                    try:
+                        importlib.import_module(f"{module_name}")
+                        logger.info(f"Successfully imported {module_name}")
+                    except ImportError as e:
+                        logger.warning(f"Failed to import {module_name}: {e}")

--- a/tests/object_detectors/od_core/test_registry.py
+++ b/tests/object_detectors/od_core/test_registry.py
@@ -1,0 +1,28 @@
+import pytest
+import logging
+from od_core.object_detector_registry import ObjectDetectorRegistry
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_auto_registration():
+    """
+    Test that the auto-registration of object detector models works correctly.
+    This will check if the models are registered in the ObjectDetectorRegistry.
+    """
+    ObjectDetectorRegistry.auto_register_models()
+    assert len(ObjectDetectorRegistry._registry) > 0, "ObjectDetectorRegistry should have registered models."
+    
+    to_be_tested_keys = [
+        ('detectron2', 'mask_rcnn', 'objectdetection', 'v0'),
+        ('ultralytics', 'yolov5', 'objectdetection', 'v0'),
+        ('ultralytics', 'yolov8', 'instancesegmentation', 'v0'),
+        ('ultralytics', 'yolo', 'objectdetection', 'v1')
+    ]
+
+    for key in to_be_tested_keys:
+        key2 = ObjectDetectorRegistry._generate_key(*key, info={})
+        assert key2 in ObjectDetectorRegistry._registry, f"Model {key} should be registered."
+        


### PR DESCRIPTION
The od_core contains the base classes which all the OD models depend on. The od_core.__init__ should not import the OD models otherwise it might cause circular import issues. The best practice is that imports should be one directional.