### PR TITLE
chore: use PAT for updating pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   run-test:
+    if: github.head_ref != 'update-pre-commit-hooks'
     strategy:
       matrix:
         runner-config:

--- a/.github/workflows/update-pre-commit.yaml
+++ b/.github/workflows/update-pre-commit.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PRE_COMMIT_TOKEN }}
           commit-message: "chore: update pre-commit hooks"
           title: "Update Pre-commit Hooks"
           body: "This is an automated PR to update the pre-commit hooks to their latest versions."


### PR DESCRIPTION
1. use PAT instead of default token
2. skip CI when updating pre-commit