### PR TITLE
feat: preprocessor supports both tiling and resize_and_pad

### DIFF
--- a/lmi_utils/image_utils/img_resize.py
+++ b/lmi_utils/image_utils/img_resize.py
@@ -4,7 +4,7 @@ import os
 
 import cv2
 import numpy as np
-from gadget_utils.pipeline_utils import fit_array_to_size, resize_image
+from gadget_utils.pipeline_utils import fit_im_to_size, resize_image
 from system_utils.path_utils import get_relative_paths
 
 logging.basicConfig()
@@ -25,49 +25,28 @@ def is_cuda_cv():  # 1 == using cuda, 0 = not using cuda
 
 def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwargs):
     h, w = image.shape[:2]
-    th, tw = height, width
-    operators = kwargs.get("operators", [])
-    if (tw is None and th is None) or (tw == w and th == h):
-        th, tw = h, w
+    # Default target dimensions to current if not provided
+    tw = width if width is not None else w
+    th = height if height is not None else h
+    operators = kwargs.get("operators", [])[:]
+    # Check if resize is needed
+    if tw == w and th == h:
         im_out = image
     else:
         if preserve_aspect:
             scale = min(th / h, tw / w)
-            tw = np.int32(scale * w)
-            th = np.int32(scale * h)
-            im_out = resize_image(image, W=tw, H=th, mode=kwargs.get("mode", "bilinear"))
-            operators.append(
-                {
-                    "resize": [
-                        im_out.shape[1],
-                        im_out.shape[0],
-                        image.shape[1],
-                        image.shape[0],
-                    ]
-                }
-            )
-            if width is not None and height is not None:
-                im_out, pad_l, pad_r, pad_t, pad_b = fit_array_to_size(im_out, width, height)
+            new_w = int(scale * w)
+            new_h = int(scale * h)
+            im_out = resize_image(image, W=new_w, H=new_h, mode=kwargs.get("mode", "bilinear"))
+            operators.append({"resize": [new_w, new_h, w, h]})
+
+            if new_w != tw or new_h != th:
+                im_out, pad_l, pad_r, pad_t, pad_b = fit_im_to_size(im_out, tw, th)
                 operators.append({"pad": [pad_l, pad_r, pad_t, pad_b]})
         else:
-            if tw is None:
-                tw = w
-                im_out = resize_image(image, H=th, mode=kwargs.get("mode", "bilinear"))
-            elif th is None:
-                th = h
-                im_out = resize_image(image, W=tw, mode=kwargs.get("mode", "bilinear"))
-            else:
-                im_out = resize_image(image, W=tw, H=th, mode=kwargs.get("mode", "bilinear"))
-            operators.append(
-                {
-                    "resize": [
-                        im_out.shape[1],
-                        im_out.shape[0],
-                        image.shape[1],
-                        image.shape[0],
-                    ]
-                }
-            )
+            # Direct Resize (Stretch)
+            im_out = resize_image(image, W=tw, H=th, mode=kwargs.get("mode", "bilinear"))
+            operators.append({"resize": [tw, th, w, h]})
     if kwargs.get("return_operators", False) is True:
         return im_out, operators
     return im_out

--- a/lmi_utils/image_utils/img_resize.py
+++ b/lmi_utils/image_utils/img_resize.py
@@ -24,29 +24,29 @@ def is_cuda_cv():  # 1 == using cuda, 0 = not using cuda
 
 
 def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwargs):
-    h, w = image.shape[:2]
+    h0, w0 = image.shape[:2]
     # Default target dimensions to current if not provided
-    tw = width if width is not None else w
-    th = height if height is not None else h
+    tw = width if width is not None else w0
+    th = height if height is not None else h0
     operators = kwargs.get("operators", [])[:]
     # Check if resize is needed
-    if tw == w and th == h:
+    if tw == w0 and th == h0:
         im_out = image
     else:
         if preserve_aspect:
-            scale = min(th / h, tw / w)
-            new_w = int(scale * w)
-            new_h = int(scale * h)
-            im_out = resize_image(image, W=new_w, H=new_h, mode=kwargs.get("mode", "bilinear"))
-            operators.append({"resize": [new_w, new_h, w, h]})
+            scale = min(th / h0, tw / w0)
+            w1 = int(scale * w0)
+            h1 = int(scale * h0)
+            im_out = resize_image(image, W=w1, H=h1, mode=kwargs.get("mode", "bilinear"))
+            operators.append({"resize": [w1, h1, w0, h0]})
 
-            if new_w != tw or new_h != th:
+            if w1 != tw or h1 != th:
                 im_out, pad_l, pad_r, pad_t, pad_b = fit_im_to_size(im_out, tw, th)
                 operators.append({"pad": [pad_l, pad_r, pad_t, pad_b]})
         else:
             # Direct Resize (Stretch)
             im_out = resize_image(image, W=tw, H=th, mode=kwargs.get("mode", "bilinear"))
-            operators.append({"resize": [tw, th, w, h]})
+            operators.append({"resize": [tw, th, w0, h0]})
     if kwargs.get("return_operators", False) is True:
         return im_out, operators
     return im_out

--- a/lmi_utils/image_utils/tiler.py
+++ b/lmi_utils/image_utils/tiler.py
@@ -1,9 +1,9 @@
 import json
 import logging
-import os
 from enum import Enum
 from itertools import product
 from math import ceil
+from pathlib import Path
 
 import torch
 from torch.nn import functional as F
@@ -181,6 +181,8 @@ def downscale_image(image: torch.Tensor, size: tuple, mode: ScaleMode = ScaleMod
 class Tiler:
     logger = logging.getLogger("Tiler")
 
+    EXPECTED_FIELDS = {"tile_size", "stride", "im_size", "scale_size", "batch_size", "num_channel", "n_tiles"}
+
     def __init__(self, tile_size, stride):
         """init tiler
 
@@ -193,21 +195,28 @@ class Tiler:
         if isinstance(stride, int):
             stride = [stride] * 2
 
-        if not isinstance(tile_size, list) or len(tile_size) != 2:
-            raise Exception(f"tile size must be a list of two elements. Got: {tile_size}")
-        if not isinstance(stride, list) or len(stride) != 2:
-            raise Exception(f"stride must be a list of two elements. Got: {stride}")
-        if stride[0] > tile_size[0] or stride[1] > tile_size[1]:
-            raise Exception("Stride size must be smaller or equal to tile size")
+        self.validate_tile_and_stride(tile_size, stride)
 
         self.tile_size = tile_size
         self.stride = stride
-        self.im_size: list
-        self.scale_size: list
-        self.batch_size: int
-        self.num_channel: int
-        self.n_tiles: list
+        self.im_size: list = None
+        self.scale_size: list = None
+        self.batch_size: int = None
+        self.num_channel: int = None
+        self.n_tiles: list = None
         self._blend_mask_cache = {}  # Cache for blend masks by overlap mode
+
+    @classmethod
+    def validate_tile_and_stride(cls, tile_size, stride):
+        """Validate that tile size and stride are set correctly."""
+        if not tile_size or not stride:
+            raise ValueError("Tile size and stride must be set.")
+        if not isinstance(tile_size, list) or len(tile_size) != 2:
+            raise ValueError(f"tile size must be a list of two elements. Got: {tile_size}")
+        if not isinstance(stride, list) or len(stride) != 2:
+            raise ValueError(f"stride must be a list of two elements. Got: {stride}")
+        if stride[0] > tile_size[0] or stride[1] > tile_size[1]:
+            raise ValueError("Stride size must be smaller or equal to tile size")
 
     @classmethod
     def from_json(cls, json_path):
@@ -216,12 +225,17 @@ class Tiler:
         Args:
             json_path (str): path to a metadata json
         """
-        obj = cls(0, 0)  # init an obj using dummy sizes
         with open(json_path, "r") as file:
             metadata = json.load(file)
+            tile_size = metadata.get("tile_size")
+            stride = metadata.get("stride")
+            if tile_size is None or stride is None:
+                raise ValueError("JSON metadata must contain 'tile_size' and 'stride'")
 
+        obj = cls(tile_size, stride)
         for k, v in metadata.items():
-            setattr(obj, k, v)
+            if k in cls.EXPECTED_FIELDS and getattr(obj, k, None) is None:
+                setattr(obj, k, v)
         return obj
 
     @classmethod
@@ -231,11 +245,59 @@ class Tiler:
         Args:
             metadata (dict): metadata dictionary
         """
-        obj = cls(0, 0)  # init an obj using dummy sizes
+        if not metadata:
+            raise ValueError("Metadata dictionary cannot be empty")
 
+        tile_size = metadata.get("tile_size")
+        stride = metadata.get("stride")
+        if tile_size is None or stride is None:
+            raise ValueError("Metadata dictionary must contain 'tile_size' and 'stride'")
+
+        obj = cls(tile_size, stride)
         for k, v in metadata.items():
-            setattr(obj, k, v)
+            if k in cls.EXPECTED_FIELDS and getattr(obj, k, None) is None:
+                setattr(obj, k, v)
         return obj
+
+    def to_dict(self):
+        """save tiler metadata to a dict
+
+        Returns:
+            dict: tiler metadata
+        """
+        metadata = {}
+        for field in self.EXPECTED_FIELDS:
+            value = getattr(self, field, None)
+            if value is None:
+                raise RuntimeError(f"Tiler metadata incomplete. Missing field: {field}")
+            metadata[field] = value
+        return metadata
+
+    def write_metadata(self, out_path):
+        """write tiler metadata to a json file
+
+        Args:
+            out_path (str | Path): a output folder or a output file path
+        """
+
+        def save_json(data, json_file):
+            with open(json_file, "w") as f:
+                json.dump(data, f)
+
+        out_path = Path(out_path)
+        ext = out_path.suffix.lower()
+        if ext == ".json":
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            save_json(self.to_dict(), out_path)
+        else:
+            out_path.mkdir(parents=True, exist_ok=True)
+            save_json(self.to_dict(), out_path / "metadata.json")
+
+    def _validate_state(self):
+        """Validate that all required state is set"""
+        missing = [f for f in self.EXPECTED_FIELDS if getattr(self, f, None) is None]
+        if missing:
+            raise RuntimeError(f"Tiler state incomplete. Missing: {missing}. Call tile() first or ensure metadata contains all fields.")
 
     @torch.inference_mode()
     def tile(self, im: torch.Tensor, mode="padding") -> torch.Tensor:
@@ -243,7 +305,7 @@ class Tiler:
 
         Args:
             im (Tensor): input image in the format: [b,c,h,w]
-            mode (str or ScaleMode, optional): scale mode. Defaults to "padding".
+            mode (str | ScaleMode, optional): scale mode. Defaults to "padding".
 
         Returns:
             Tensor: resized tiles
@@ -291,19 +353,20 @@ class Tiler:
     def untile(
         self,
         tiles,
-        scale_mode=ScaleMode.PADDING,
-        overlap_mode: OverlapMode = OverlapMode.AVERAGE,
+        scale_mode="padding",
+        overlap_mode="average",
     ):
         """convert tiles into original image. Apply blending for smooth transitions.
 
         Args:
             tiles (Torch): the tiles tensor in the format: [n_tiles*batch, c, tile_h, tile_w]
-            scale_mode (str or ScaleMode, optional): scale mode. Defaults to ScaleMode.PADDING.
-            overlap_mode (str or OverlapMode, optional): overlap handling mode. Defaults to OverlapMode.AVERAGE.
+            scale_mode (str | ScaleMode, optional): scale mode. Defaults to "padding".
+            overlap_mode (str | OverlapMode, optional): overlap handling mode. Defaults to "average".
 
         Returns:
             Tensor: the reconstructed image with smooth blending
         """
+        self._validate_state()
         if not isinstance(scale_mode, (str, ScaleMode)):
             raise ValueError(f"scale_mode must be str or ScaleMode enum. Got: {type(scale_mode)}")
         if not isinstance(overlap_mode, (str, OverlapMode)):
@@ -315,7 +378,14 @@ class Tiler:
         if not isinstance(overlap_mode, OverlapMode):
             overlap_mode = OverlapMode(overlap_mode)
 
-        _, num_channel, tile_h, tile_w = tiles.shape
+        # Validate input shape
+        n_tiles_total, num_channel, tile_h, tile_w = tiles.shape
+        expected_n_tiles = self.n_tiles[0] * self.n_tiles[1] * self.batch_size
+        if n_tiles_total != expected_n_tiles:
+            raise ValueError(f"Expected {expected_n_tiles} tiles, got {n_tiles_total}")
+        if [tile_h, tile_w] != self.tile_size:
+            raise ValueError(f"Expected tile size {self.tile_size}, got [{tile_h}, {tile_w}]")
+
         tiles = tiles.contiguous().view(-1, self.batch_size, num_channel, tile_h, tile_w)
         device = tiles.device
 
@@ -335,7 +405,7 @@ class Tiler:
                     tile,
                 )
         else:
-            cache_key = (overlap_mode.value, str(device))
+            cache_key = (overlap_mode.value, device.type, device.index if device.index is not None else -1)
             if cache_key not in self._blend_mask_cache:
                 self._blend_mask_cache[cache_key] = create_blend_mask(self.tile_size, self.stride, overlap_mode, device)
 
@@ -360,39 +430,3 @@ class Tiler:
             im = torch.div(im, weight_sum + eps)
 
         return downscale_image(im, self.im_size, scale_mode).to(tiles.dtype)
-
-    def save_metadata(self):
-        """save tiler metadata to a dict
-
-        Returns:
-            dict: tiler metadata
-        """
-        metadata = {
-            "tile_size": self.tile_size,
-            "stride": self.stride,
-            "im_size": self.im_size,
-            "scale_size": self.scale_size,
-            "batch_size": self.batch_size,
-            "num_channel": self.num_channel,
-            "n_tiles": self.n_tiles,
-        }
-        return metadata
-
-    def write_metadata(self, out_path):
-        """write tiler metadata to a json file
-
-        Args:
-            out_path (str): a output folder or a output file path
-        """
-
-        def save_json(data, json_file):
-            with open(json_file, "w") as f:
-                json.dump(data, f)
-
-        ext = os.path.splitext(out_path)[-1]
-        if ext == ".json":
-            os.makedirs(os.path.dirname(out_path), exist_ok=True)
-            save_json(self.__dict__, out_path)
-        else:
-            os.makedirs(out_path, exist_ok=True)
-            save_json(self.__dict__, os.path.join(out_path, "metadata.json"))

--- a/lmi_utils/image_utils/tiler.py
+++ b/lmi_utils/image_utils/tiler.py
@@ -224,19 +224,37 @@ class Tiler:
             setattr(obj, k, v)
         return obj
 
+    @classmethod
+    def from_dict(cls, metadata: dict):
+        """init tiler from a metadata dict
+
+        Args:
+            metadata (dict): metadata dictionary
+        """
+        obj = cls(0, 0)  # init an obj using dummy sizes
+
+        for k, v in metadata.items():
+            setattr(obj, k, v)
+        return obj
+
     @torch.inference_mode()
-    def tile(self, im: torch.Tensor, mode=ScaleMode.PADDING) -> torch.Tensor:
+    def tile(self, im: torch.Tensor, mode="padding") -> torch.Tensor:
         """generate tiles from the image. Will resize images if necessary.
 
         Args:
             im (Tensor): input image in the format: [b,c,h,w]
-            mode (ScaleMode, optional): scale mode. Defaults to ScaleMode.PADDING.
+            mode (str or ScaleMode, optional): scale mode. Defaults to "padding".
 
         Returns:
             Tensor: resized tiles
         """
+        if not isinstance(mode, (str, ScaleMode)):
+            raise ValueError(f"mode must be str or ScaleMode enum. Got: {type(mode)}")
+
+        # Convert string to enum if needed
         if not isinstance(mode, ScaleMode):
-            raise Exception("mode must be a ScaleMode object")
+            mode = ScaleMode(mode)
+
         self.batch_size, self.num_channel, im_h, im_w = im.shape
         self.im_size = [im_h, im_w]
         device = im.device
@@ -280,16 +298,22 @@ class Tiler:
 
         Args:
             tiles (Torch): the tiles tensor in the format: [n_tiles*batch, c, tile_h, tile_w]
-            mode (ScaleMode, optional): scale mode. Defaults to ScaleMode.PADDING.
-            overlap_mode (OverlapMode, optional): overlap handling mode. Defaults to OverlapMode.AVERAGE.
+            scale_mode (str or ScaleMode, optional): scale mode. Defaults to ScaleMode.PADDING.
+            overlap_mode (str or OverlapMode, optional): overlap handling mode. Defaults to OverlapMode.AVERAGE.
 
         Returns:
             Tensor: the reconstructed image with smooth blending
         """
+        if not isinstance(scale_mode, (str, ScaleMode)):
+            raise ValueError(f"scale_mode must be str or ScaleMode enum. Got: {type(scale_mode)}")
+        if not isinstance(overlap_mode, (str, OverlapMode)):
+            raise ValueError(f"overlap_mode must be str or OverlapMode enum. Got: {type(overlap_mode)}")
+
+        # Convert string to enum if needed
         if not isinstance(scale_mode, ScaleMode):
-            raise Exception("mode must be a ScaleMode object")
+            scale_mode = ScaleMode(scale_mode)
         if not isinstance(overlap_mode, OverlapMode):
-            raise Exception("overlap_mode must be an OverlapMode object")
+            overlap_mode = OverlapMode(overlap_mode)
 
         _, num_channel, tile_h, tile_w = tiles.shape
         tiles = tiles.contiguous().view(-1, self.batch_size, num_channel, tile_h, tile_w)
@@ -336,6 +360,23 @@ class Tiler:
             im = torch.div(im, weight_sum + eps)
 
         return downscale_image(im, self.im_size, scale_mode).to(tiles.dtype)
+
+    def save_metadata(self):
+        """save tiler metadata to a dict
+
+        Returns:
+            dict: tiler metadata
+        """
+        metadata = {
+            "tile_size": self.tile_size,
+            "stride": self.stride,
+            "im_size": self.im_size,
+            "scale_size": self.scale_size,
+            "batch_size": self.batch_size,
+            "num_channel": self.num_channel,
+            "n_tiles": self.n_tiles,
+        }
+        return metadata
 
     def write_metadata(self, out_path):
         """write tiler metadata to a json file

--- a/lmi_utils/pipeline_base/core/schemas/schema_2.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_2.py
@@ -106,7 +106,7 @@ class Model:
             format=data.get("format", ""),
         )
 
-    def get_metadata(self, include_tiling: bool) -> Dict[str, Any]:
+    def get_metadata(self, use_model_internal_tiling: bool) -> Dict[str, Any]:
         """Returns the metadata of the model as a dictionary."""
         # check for tiling preprocessing
         tiling_config = self.details.get_preprocessing_by_type("tile")
@@ -117,7 +117,7 @@ class Model:
             "algorithm": self.details.training_algorithm.lower(),
             "package": self.details.training_package.lower(),
         }
-        if include_tiling and tiling_config:
+        if use_model_internal_tiling and tiling_config:
             metadata["tile_size"] = [
                 tiling_config.get("configuration", {}).get("height", None),
                 tiling_config.get("configuration", {}).get("width", None),
@@ -142,10 +142,10 @@ class ModelCollection:
         models = {role: Model.from_dict(model_info) for role, model_info in data.items() if model_info is not None}
         return cls(models=models)
 
-    def get_metadata(self, include_tiling: bool) -> Dict[str, Any]:
+    def get_metadata(self, use_model_internal_tiling: bool) -> Dict[str, Any]:
         configs = {}
         for role, model in self.models.items():
-            configs[role] = model.get_metadata(include_tiling)
+            configs[role] = model.get_metadata(use_model_internal_tiling)
         return configs
 
     def get_global_preprocessing(self) -> Dict[str, Any]:
@@ -194,6 +194,6 @@ class ModelSchemaV_2:
         return ModelCollection.from_dict(data)
 
     @staticmethod
-    def get_metadata(model_collection: ModelCollection, include_tiling: bool = True) -> Dict[str, Any]:
+    def get_metadata(model_collection: ModelCollection, use_model_internal_tiling: bool = True) -> Dict[str, Any]:
         """Returns the metadata of the model collection."""
-        return model_collection.get_metadata(include_tiling)
+        return model_collection.get_metadata(use_model_internal_tiling)

--- a/lmi_utils/pipeline_base/core/schemas/schema_2.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_2.py
@@ -106,7 +106,7 @@ class Model:
             format=data.get("format", ""),
         )
 
-    def get_metadata(self) -> Dict[str, Any]:
+    def get_metadata(self, include_tiling: bool) -> Dict[str, Any]:
         """Returns the metadata of the model as a dictionary."""
         # check for tiling preprocessing
         tiling_config = self.details.get_preprocessing_by_type("tile")
@@ -117,7 +117,7 @@ class Model:
             "algorithm": self.details.training_algorithm.lower(),
             "package": self.details.training_package.lower(),
         }
-        if tiling_config:
+        if include_tiling and tiling_config:
             metadata["tile_size"] = [
                 tiling_config.get("configuration", {}).get("height", None),
                 tiling_config.get("configuration", {}).get("width", None),
@@ -142,11 +142,47 @@ class ModelCollection:
         models = {role: Model.from_dict(model_info) for role, model_info in data.items() if model_info is not None}
         return cls(models=models)
 
-    def get_metadata(self) -> Dict[str, Any]:
+    def get_metadata(self, include_tiling: bool) -> Dict[str, Any]:
         configs = {}
-        for model in self.models.values():
-            configs[model.model_role] = model.get_metadata()
+        for role, model in self.models.items():
+            configs[role] = model.get_metadata(include_tiling)
         return configs
+
+    def get_global_preprocessing(self) -> Dict[str, Any]:
+        """Returns the global preprocessing steps of the model collection."""
+
+        def parse(steps: List[Dict[str, Any]]):
+            """Parses preprocessing steps and formats tiling configurations."""
+            supported_types = {"resize", "tile"}
+            tiling_keys = {"height", "width", "xStride", "yStride"}
+
+            ops = []
+            for preprocess in steps:
+                if "type" not in preprocess or "configuration" not in preprocess:
+                    raise ValueError("Must contain 'type' and 'configuration' keys.")
+
+                p_type = preprocess["type"]
+                config = preprocess["configuration"]
+
+                if p_type not in supported_types:
+                    raise ValueError(f"Unsupported type '{p_type}'.")
+
+                if p_type == "tile":
+                    if not tiling_keys.issubset(config.keys()):
+                        raise ValueError(f"Tiling configuration must contain keys: {tiling_keys}.")
+
+                    # Format the tile config immediately
+                    tile_config = {"tile_size": [config["height"], config["width"]], "stride": [config["yStride"], config["xStride"]]}
+                    ops.append({"type": "tile", "configuration": tile_config})
+                elif p_type == "resize":
+                    ops.append(preprocess)
+            return ops
+
+        global_preprocessing = {}
+        for role, model in self.models.items():
+            steps = model.details.global_preprocessing
+            global_preprocessing[role] = parse(steps)
+        return global_preprocessing
 
 
 class ModelSchemaV_2:
@@ -158,6 +194,6 @@ class ModelSchemaV_2:
         return ModelCollection.from_dict(data)
 
     @staticmethod
-    def get_metadata(model_collection: ModelCollection) -> Dict[str, Any]:
+    def get_metadata(model_collection: ModelCollection, include_tiling: bool = True) -> Dict[str, Any]:
         """Returns the metadata of the model collection."""
-        return model_collection.get_metadata()
+        return model_collection.get_metadata(include_tiling)

--- a/lmi_utils/pipeline_base/core/schemas/schema_2.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_2.py
@@ -154,7 +154,7 @@ class ModelCollection:
         def parse(steps: List[Dict[str, Any]]):
             """Parses preprocessing steps and formats tiling configurations."""
             supported_types = {"resize", "tile"}
-            tiling_keys = {"height", "width", "xStride", "yStride"}
+            tiling_keys = {"height", "width", "x_stride", "y_stride"}
 
             ops = []
             for preprocess in steps:
@@ -172,7 +172,7 @@ class ModelCollection:
                         raise ValueError(f"Tiling configuration must contain keys: {tiling_keys}.")
 
                     # Format the tile config immediately
-                    tile_config = {"tile_size": [config["height"], config["width"]], "stride": [config["yStride"], config["xStride"]]}
+                    tile_config = {"tile_size": [config["height"], config["width"]], "stride": [config["y_stride"], config["x_stride"]]}
                     ops.append({"type": "tile", "configuration": tile_config})
                 elif p_type == "resize":
                     ops.append(preprocess)

--- a/lmi_utils/pipeline_base/core/schemas/schema_2.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_2.py
@@ -36,12 +36,6 @@ class Details:
             defect_class_list=data.get("defect_class_list"),
         )
 
-    def get_preprocessing_by_type(self, preprocessing_type: str) -> Optional[Dict[str, Any]]:
-        for step in self.global_preprocessing:
-            if step.get("type") == preprocessing_type:
-                return step
-        return None
-
 
 @dataclass
 class Configs:
@@ -106,10 +100,8 @@ class Model:
             format=data.get("format", ""),
         )
 
-    def get_metadata(self, use_model_internal_tiling: bool) -> Dict[str, Any]:
+    def get_metadata(self) -> Dict[str, Any]:
         """Returns the metadata of the model as a dictionary."""
-        # check for tiling preprocessing
-        tiling_config = self.details.get_preprocessing_by_type("tile")
         metadata = {
             "model_path": self.artifacts.get(self.format, {}).model_path if self.format in self.artifacts else "",
             "image_size": self.artifacts.get(self.format, {}).image_size if self.format in self.artifacts else [],
@@ -117,15 +109,6 @@ class Model:
             "algorithm": self.details.training_algorithm.lower(),
             "package": self.details.training_package.lower(),
         }
-        if use_model_internal_tiling and tiling_config:
-            metadata["tile_size"] = [
-                tiling_config.get("configuration", {}).get("height", None),
-                tiling_config.get("configuration", {}).get("width", None),
-            ]
-            metadata["stride"] = [
-                tiling_config.get("configuration", {}).get("y_stride", None),
-                tiling_config.get("configuration", {}).get("x_stride", None),
-            ]
         return metadata
 
 
@@ -142,10 +125,10 @@ class ModelCollection:
         models = {role: Model.from_dict(model_info) for role, model_info in data.items() if model_info is not None}
         return cls(models=models)
 
-    def get_metadata(self, use_model_internal_tiling: bool) -> Dict[str, Any]:
+    def get_metadata(self) -> Dict[str, Any]:
         configs = {}
         for role, model in self.models.items():
-            configs[role] = model.get_metadata(use_model_internal_tiling)
+            configs[role] = model.get_metadata()
         return configs
 
     def get_global_preprocessing(self) -> Dict[str, Any]:
@@ -194,6 +177,6 @@ class ModelSchemaV_2:
         return ModelCollection.from_dict(data)
 
     @staticmethod
-    def get_metadata(model_collection: ModelCollection, use_model_internal_tiling: bool = True) -> Dict[str, Any]:
+    def get_metadata(model_collection: ModelCollection) -> Dict[str, Any]:
         """Returns the metadata of the model collection."""
-        return model_collection.get_metadata(use_model_internal_tiling)
+        return model_collection.get_metadata()

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -5,6 +5,7 @@ import logging
 import traceback
 from abc import ABCMeta, abstractmethod
 
+# LMI AIS repo's modules
 from ad_core.anomaly_detector import AnomalyDetector
 from cls_core.classifier import Classifier
 from dataset_utils.representations import (
@@ -15,20 +16,21 @@ from dataset_utils.representations import (
     Point2d,
     Polygon,
 )
-
-# LMI AIS repo's modules
 from od_core.object_detector import ObjectDetector
+from preprocess_utils.preprocessor import Preprocessor
+from preprocess_utils.reconstructor import Reconstructor
 
-# local module
-# handle different model_roles schema according to gadget version
 from .core.schemas.schema_2 import ModelSchemaV_2
 
 
 class PipelineBase(metaclass=ABCMeta):
     logger = logging.getLogger(__name__)
     models: collections.OrderedDict
+    _preprocessing: collections.OrderedDict  # global preprocessing for all models
     version: str
     results: dict
+    preprocessor: Preprocessor
+    reconstructor: Reconstructor
 
     # Maps prediction keys to the specific classes and types needed for annotation.
     # This is used for uploading labels to label studio.
@@ -72,9 +74,14 @@ class PipelineBase(metaclass=ABCMeta):
             results: a dictionary of the results, e.g.,
                 {'outputs':{}, 'automation_keys':[], 'factory_keys':[], 'tags':[], 'should_archive':True, 'decision':None}
             version: the gadget version. It determines which model_roles handler to be used.
+            preprocessor: an instance of Preprocessor class for preprocessing inputs.
+            reconstructor: an instance of Reconstructor class for reconstructing outputs.
         """
         self.models = collections.OrderedDict()
+        self._preprocessing = collections.OrderedDict()
         self.version = kwargs.get("version", "2")
+        self.preprocessor = Preprocessor()
+        self.reconstructor = Reconstructor()
         self.init_results()
 
     def _load_model(self, model_name: str, metadata: dict, **kwargs):
@@ -131,6 +138,7 @@ class PipelineBase(metaclass=ABCMeta):
 
         Returns:
             dict: The parsed model roles.
+            dict: The global preprocessing steps.
         """
 
         # the format of model_roles from factory is:
@@ -188,10 +196,15 @@ class PipelineBase(metaclass=ABCMeta):
 
         # convert model_roles to the required format
         handler = self._MODEL_ROLES_HANDLERS[version]
+        use_global_preprocessing = kwargs.get("use_tiling_in_global_preprocessing", False)
+        include_tiling = not use_global_preprocessing  # use model's tiling
         if handler is None:
-            return model_roles
-        else:
-            return handler(model_roles).get_metadata()
+            if use_global_preprocessing:
+                raise ValueError(f"Unsupported version: {version} for loading global preprocessing")
+            return model_roles, None
+
+        instance = handler(model_roles)
+        return instance.get_metadata(include_tiling), instance.get_global_preprocessing()
 
     def load_models(self, model_roles: dict, configs: dict, filter: str = "-model", **kwargs):
         """load multiple models based on the provided model_roles, configs and filter.
@@ -203,10 +216,12 @@ class PipelineBase(metaclass=ABCMeta):
             model_roles (dict): a dictionary from gofactory or static_models.
             configs (dict): the configs from pipeline_def.json or the runtime.
             filter (str, optional): filter models by name. Defaults to '-model'.
+            use_tiling_in_global_preprocessing (bool, optional): whether to use tiling in global preprocessing or do tiling
+                inside AD models. Defaults to False for backward compatibility.
             verbose (bool, optional): whether to log the original and parsed model roles. Defaults to False.
         """
         # parse model_roles to match the required format for initializing AIS repo models
-        parsed_model_roles = self._parse_model_roles(model_roles, **kwargs)
+        parsed_model_roles, global_preprocessing = self._parse_model_roles(model_roles, **kwargs)
 
         if kwargs.get("verbose", False):
             self.logger.info(f"Original Model Roles: {json.dumps(model_roles, indent=4)}\n")
@@ -217,18 +232,39 @@ class PipelineBase(metaclass=ABCMeta):
         for model_key in target_model_keys:
             config_to_use = parsed_model_roles[model_key]
             model_source = "Static" if "static" in config_to_use["model_path"].split("/") else "GoFactory"
-            # TODO: handle tile configs
-            # keys_to_inherit = ['tile_size', 'stride']
-            # for key in keys_to_inherit:
-            #     if key not in config_to_use and key in configs[model_key]['metadata']:
-            #         self.logger.warning(
-            #             f"'{key}' not found in GoFactory config for '{model_key}'. Inheriting value from local config."
-            #         )
-            #         config_to_use[key] = configs[model_key]['metadata'][key]
-
             self._load_model(model_key, config_to_use, **kwargs)
+            if global_preprocessing:
+                self._preprocessing[model_key] = global_preprocessing[model_key]
             self.logger.info(f"Successfully loaded {model_source} model: {model_key}\n")
         self.logger.info(f"Final loaded models: {list(self.models.keys())}\n")
+
+    def preprocess(self, model_role, images):
+        """preprocess the image(s) based on the preprocessing steps in model_role.
+
+        Args:
+            model_role (str): the model role to be used for preprocessing.
+            images (numpy.ndarray | torch.Tensor | list[numpy.ndarray | torch.Tensor]): the image(s) to be preprocessed.
+
+        Returns:
+            list[numpy.ndarray | torch.Tensor]: the preprocessed image(s).
+            list[dict]: the preprocessing steps.
+        """
+        if model_role not in self._preprocessing:
+            raise ValueError(f"Not found global preprocessing steps for model role: {model_role}")
+
+        return self.preprocessor.preprocess(images, self._preprocessing[model_role])
+
+    def reconstruct(self, images, ops):
+        """reconstruct the images based on the preprocessing steps in ops.
+
+        Args:
+            images (list[numpy.ndarray | torch.Tensor]): the image(s) to be reconstructed.
+            ops (list[dict]): the preprocessing steps to be used for reconstruction.
+
+        Returns:
+            list[numpy.ndarray | torch.Tensor]: the reconstructed image(s).
+        """
+        return self.reconstructor.reconstruct(images, ops)
 
     def add_prediction(
         self,
@@ -381,6 +417,9 @@ class PipelineBase(metaclass=ABCMeta):
             self.logger.info(f"{model_name} has been cleaned up")
         self.models.clear()
         self.logger.info("pipeline is cleaned up")
+
+        self._preprocessing.clear()
+        self.logger.info("preprocessing is cleaned up")
 
     def update_results(self, key: str, value, sub_key=None, **kwargs):
         """

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -5,6 +5,7 @@ import logging
 import traceback
 from abc import ABCMeta, abstractmethod
 from logging import Logger
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy
@@ -147,24 +148,24 @@ class PipelineBase(metaclass=ABCMeta):
         #         "configs": {},
         #         "details": {
         #             "deployed": "2025-08-18T02:26:53.063Z",
-        #             "baseModel": "yolov8m.pt",
-        #             "trainingPackage": "Ultralytics8",
-        #             "trainingAlgorithm": "Yolo",
-        #             "confidenceThreshold": 0.5,
-        #             "globalPreprocessing": [
+        #             "base_model": "yolov8m.pt",
+        #             "training_package": "Ultralytics8",
+        #             "training_algorithm": "Yolo",
+        #             "confidence_threshold": 0.5,
+        #             "global_preprocessing": [
         #                 {
         #                     "type": "resize",
         #                     "configuration": {
         #                         "width": 640,
         #                         "height": 640,
-        #                         "preserveAspect": true
+        #                         "preserve_aspect": true
         #                     }
         #                 }
         #             ]
         #         },
         #         "artifacts": {
         #             "pt": {
-        #                 "imageSize": [],
+        #                 "image_size": [],
         #                 "model_path": "/app/models/top-od-model/ObjectDetection/yolo/1/model.pt"
         #             }
         #         },
@@ -190,28 +191,37 @@ class PipelineBase(metaclass=ABCMeta):
         # }
 
         version = kwargs.get("version", self.version)
-        if version not in self._MODEL_ROLES_HANDLERS:
-            raise ValueError(f"Unsupported version: {version}. Supported versions are: {list(self._MODEL_ROLES_HANDLERS.keys())}")
-
         use_model_internal_tiling = kwargs.get("use_model_internal_tiling", False)
-        if use_model_internal_tiling:
-            self.logger.warning("Use model internal tiling is deprecated. Please upgrade the Gadget and use global preprocessing instead.")
-            self.logger.warning("This will be removed in the future release.")
 
-        # convert model_roles to the required format
+        # Validate version
+        if version not in self._MODEL_ROLES_HANDLERS:
+            raise ValueError(f"Unsupported version: {version}")
+
         handler = self._MODEL_ROLES_HANDLERS[version]
+
+        # Version 1: Only supports model internal tiling
         if handler is None:
             if not use_model_internal_tiling:
-                raise ValueError(f"Unsupported version: {version} for loading global preprocessing")
+                raise ValueError(
+                    f"Gadget version {version} only supports model internal tiling. "
+                    f"Either set use_model_internal_tiling=True or upgrade to version 2."
+                )
+            self.logger.info("Using legacy model internal tiling (deprecated)")
             return model_roles, None
 
+        # Version 2+: Supports global preprocessing
         instance = handler(model_roles)
-        global_preprocessing = None if use_model_internal_tiling else instance.get_global_preprocessing()
-        return instance.get_metadata(use_model_internal_tiling), global_preprocessing
+
+        if use_model_internal_tiling:
+            self.logger.warning("Model internal tiling is deprecated. Consider upgrading Gadget to use global preprocessing.")
+            return instance.get_metadata(use_model_internal_tiling=True), None
+        else:
+            global_preprocessing = instance.get_global_preprocessing()
+            return instance.get_metadata(use_model_internal_tiling=False), global_preprocessing
 
     def load_models(self, model_roles: dict, configs: dict, filter: str = "-model", **kwargs: Any) -> None:
         """
-        Load multiple models based on the provided model_roles, configs and filter.
+        Load multiple models based on the provided model_roles, configs and filter. It also loads the global preprocessing for the models.
         The model_roles are used for loading models from the GoFactory or static models.
         The configs are used for loading pipeline configs from pipeline_def.json or the runtime.
         It also filters out not relevant models based on the provided filter string.
@@ -219,12 +229,12 @@ class PipelineBase(metaclass=ABCMeta):
         Args:
             model_roles (dict): a dictionary from gofactory or static_models.
             configs (dict): the configs from pipeline_def.json or the runtime.
-            filter (str, optional): filter models by name. Defaults to '-model'.
+            filter (str, optional): filter models by name. Defaults to "-model".
             verbose (bool, optional): whether to log the original and parsed model roles. Defaults to False.
             use_model_internal_tiling (bool, optional): whether to use model internal tiling.
                 Defaults to False. Set to True for old Gadget versions.
         """
-        # parse model_roles to match the required format for initializing AIS repo models
+        use_model_internal_tiling = kwargs.get("use_model_internal_tiling", False)
         parsed_model_roles, global_preprocessing = self._parse_model_roles(model_roles, **kwargs)
 
         if kwargs.get("verbose", False):
@@ -232,18 +242,30 @@ class PipelineBase(metaclass=ABCMeta):
             self.logger.info(f"Parsed Model Roles: {json.dumps(parsed_model_roles, indent=2)}\n")
 
         # filter configs to get target model keys
-        target_model_keys = [k for k in model_roles.keys() if f"{filter}" in k]
+        target_model_keys = [k for k in model_roles.keys() if filter in k]
         for model_key in target_model_keys:
             config_to_use = parsed_model_roles.get(model_key)
             if config_to_use is None:
-                self.logger.warning(f"Not found '{model_key}' in parsed model roles. Skipping.")
+                self.logger.warning(f"Not found '{model_key}' configs in parsed model roles. Skipping.")
                 continue
-            model_source = "Static" if "static" in config_to_use["model_path"].split("/") else "GoFactory"
+
+            model_source = "Static" if "static" in Path(config_to_use["model_path"]).parts else "GoFactory"
             self._load_model(model_key, config_to_use, **kwargs)
-            if global_preprocessing and model_key in global_preprocessing:
-                self._preprocessing[model_key] = global_preprocessing[model_key]
+
+            if use_model_internal_tiling:
+                self.logger.warning(f"Model '{model_key}' will use model internal tiling. This is deprecated.")
             elif global_preprocessing:
-                self.logger.warning(f"No preprocessing config found for '{model_key}'. Global preprocessing will be skipped.")
+                if model_key in global_preprocessing:
+                    self._preprocessing[model_key] = global_preprocessing[model_key]
+                    self.logger.info(f"Applied global preprocessing for '{model_key}'")
+                else:
+                    raise ValueError(
+                        f"Global preprocessing is enabled but no preprocessing config found for '{model_key}'. "
+                        f"Add preprocessing config in Gadget or static manifest."
+                    )
+            else:
+                raise RuntimeError("Invalid state: global_preprocessing is None but use_model_internal_tiling is False. ")
+
             self.logger.info(f"Successfully loaded {model_source} model: {model_key}\n")
         self.logger.info(f"Final loaded models: {list(self.models.keys())}\n")
 
@@ -354,13 +376,13 @@ class PipelineBase(metaclass=ABCMeta):
                 if not (len(data["classes"]) == len(data["confidences"]) == len(data["objects"])):
                     raise ValueError(f"Array length of 'classes', 'confidences' and 'objects' mismatch for {pred_type}.")
 
-                for idx, value_data in enumerate(data["objects"]):
-                    value_object = handler["value_factory"](value_data)
+                for obj, cls, conf in zip(data["objects"], data["classes"], data["confidences"]):
+                    value_object = handler["value_factory"](obj)
                     annotation = Annotation(
                         id=str(len(prediction_list)),
                         value=value_object,
-                        label_id=data["classes"][idx],
-                        confidence=float(data["confidences"][idx]),
+                        label_id=cls,
+                        confidence=float(conf),
                         type=handler["type"],
                     )
                     prediction_list.append(annotation.to_dict())
@@ -425,7 +447,7 @@ class PipelineBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def predict(self, configs: dict, inputs: dict) -> dict:
+    def predict(self, configs: Dict[str, Any], inputs: Dict[str, Any]) -> Dict[str, Any]:
         """
         the main function to run the pipeline.
         """
@@ -445,13 +467,13 @@ class PipelineBase(metaclass=ABCMeta):
         self._preprocessing.clear()
         self.logger.info("preprocessing is cleaned up")
 
-    def update_results(self, key: str, value, sub_key: Optional[str] = None, **kwargs: Any) -> None:
+    def update_results(self, key: str, value: Any, sub_key: Optional[str] = None, **kwargs: Any) -> None:
         """
         modifies self.results by applying rules for creation and updates.
 
         Args:
             key (str): the key of the self.results
-            value (obj): the value of the key to be updated
+            value (Any): the value of the key to be updated
             sub_key (str, optional): the key of sub dictionary to be updated. Defaults to None.
             to_factory (bool, optional): add the key to the gofactory. Defaults to False.
             to_automation (bool, optional): add the key to the automation. Defaults to False.

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -4,6 +4,11 @@ import json
 import logging
 import traceback
 from abc import ABCMeta, abstractmethod
+from logging import Logger
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import numpy
+import torch
 
 # LMI AIS repo's modules
 from ad_core.anomaly_detector import AnomalyDetector
@@ -25,12 +30,6 @@ from .core.schemas.schema_2 import ModelSchemaV_2
 
 class PipelineBase(metaclass=ABCMeta):
     logger = logging.getLogger(__name__)
-    models: collections.OrderedDict
-    _preprocessing: collections.OrderedDict  # global preprocessing for all models
-    version: str
-    results: dict
-    preprocessor: Preprocessor
-    reconstructor: Reconstructor
 
     # Maps prediction keys to the specific classes and types needed for annotation.
     # This is used for uploading labels to label studio.
@@ -65,7 +64,7 @@ class PipelineBase(metaclass=ABCMeta):
         "2": ModelSchemaV_2.from_dict,
     }
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         """
         init the pipeline.
         it has the following attributes:
@@ -73,6 +72,7 @@ class PipelineBase(metaclass=ABCMeta):
             models: a dictionary of model instances, e.g., {model_name: model_instance}
             results: a dictionary of the results, e.g.,
                 {'outputs':{}, 'automation_keys':[], 'factory_keys':[], 'tags':[], 'should_archive':True, 'decision':None}
+            _preprocessing: a dictionary of global preprocessing configs for each model role.
             version: the gadget version. It determines which model_roles handler to be used.
             preprocessor: an instance of Preprocessor class for preprocessing inputs.
             reconstructor: an instance of Reconstructor class for reconstructing outputs.
@@ -84,15 +84,13 @@ class PipelineBase(metaclass=ABCMeta):
         self.reconstructor = Reconstructor()
         self.init_results()
 
-    def _load_model(self, model_name: str, metadata: dict, **kwargs):
+    def _load_model(self, model_name: str, metadata: dict, **kwargs: Any) -> None:
         """load a model with the given metadata. Set default image size if not provided.
 
-        args:
+        Args:
             model_name (str): the name of the model to be loaded.
             metadata (dict): the metadata of the model to be loaded.
             kwargs (dict): additional arguments to be passed to the model constructor.
-        Raises:
-            ValueError: if the model_type is not supported.
         """
         if model_name in self.models:
             self.logger.info(f"{model_name} is already loaded")
@@ -127,18 +125,19 @@ class PipelineBase(metaclass=ABCMeta):
         else:
             raise ValueError(f"model_type {model_type} is not supported")
 
-    def _parse_model_roles(self, model_roles: dict, **kwargs):
+    def _parse_model_roles(self, model_roles: dict, **kwargs: Any) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
         """parse model_roles by version and convert it to match the required format for initializing AIS repo models.
 
         Args:
             model_roles (dict): the model roles to parse.
+            **kwargs (Any): additional arguments to be passed to the model constructor.
 
         Raises:
             ValueError: If the version is not supported.
 
         Returns:
             dict: The parsed model roles.
-            dict: The global preprocessing steps.
+            dict or None: The global preprocessing steps.
         """
 
         # the format of model_roles from factory is:
@@ -194,20 +193,25 @@ class PipelineBase(metaclass=ABCMeta):
         if version not in self._MODEL_ROLES_HANDLERS:
             raise ValueError(f"Unsupported version: {version}. Supported versions are: {list(self._MODEL_ROLES_HANDLERS.keys())}")
 
+        use_model_internal_tiling = kwargs.get("use_model_internal_tiling", False)
+        if use_model_internal_tiling:
+            self.logger.warning("Use model internal tiling is deprecated. Please upgrade the Gadget and use global preprocessing instead.")
+            self.logger.warning("This will be removed in the future release.")
+
         # convert model_roles to the required format
         handler = self._MODEL_ROLES_HANDLERS[version]
-        use_global_preprocessing = kwargs.get("use_tiling_in_global_preprocessing", False)
-        include_tiling = not use_global_preprocessing  # use model's tiling
         if handler is None:
-            if use_global_preprocessing:
+            if not use_model_internal_tiling:
                 raise ValueError(f"Unsupported version: {version} for loading global preprocessing")
             return model_roles, None
 
         instance = handler(model_roles)
-        return instance.get_metadata(include_tiling), instance.get_global_preprocessing()
+        global_preprocessing = None if use_model_internal_tiling else instance.get_global_preprocessing()
+        return instance.get_metadata(use_model_internal_tiling), global_preprocessing
 
-    def load_models(self, model_roles: dict, configs: dict, filter: str = "-model", **kwargs):
-        """load multiple models based on the provided model_roles, configs and filter.
+    def load_models(self, model_roles: dict, configs: dict, filter: str = "-model", **kwargs: Any) -> None:
+        """
+        Load multiple models based on the provided model_roles, configs and filter.
         The model_roles are used for loading models from the GoFactory or static models.
         The configs are used for loading pipeline configs from pipeline_def.json or the runtime.
         It also filters out not relevant models based on the provided filter string.
@@ -216,29 +220,36 @@ class PipelineBase(metaclass=ABCMeta):
             model_roles (dict): a dictionary from gofactory or static_models.
             configs (dict): the configs from pipeline_def.json or the runtime.
             filter (str, optional): filter models by name. Defaults to '-model'.
-            use_tiling_in_global_preprocessing (bool, optional): whether to use tiling in global preprocessing or do tiling
-                inside AD models. Defaults to False for backward compatibility.
             verbose (bool, optional): whether to log the original and parsed model roles. Defaults to False.
+            use_model_internal_tiling (bool, optional): whether to use model internal tiling.
+                Defaults to False. Set to True for old Gadget versions.
         """
         # parse model_roles to match the required format for initializing AIS repo models
         parsed_model_roles, global_preprocessing = self._parse_model_roles(model_roles, **kwargs)
 
         if kwargs.get("verbose", False):
-            self.logger.info(f"Original Model Roles: {json.dumps(model_roles, indent=4)}\n")
-            self.logger.info(f"Parsed Model Roles: {json.dumps(parsed_model_roles, indent=4)}\n")
+            self.logger.info(f"Original Model Roles: {json.dumps(model_roles, indent=2)}\n")
+            self.logger.info(f"Parsed Model Roles: {json.dumps(parsed_model_roles, indent=2)}\n")
 
         # filter configs to get target model keys
         target_model_keys = [k for k in model_roles.keys() if f"{filter}" in k]
         for model_key in target_model_keys:
-            config_to_use = parsed_model_roles[model_key]
+            config_to_use = parsed_model_roles.get(model_key)
+            if config_to_use is None:
+                self.logger.warning(f"Not found '{model_key}' in parsed model roles. Skipping.")
+                continue
             model_source = "Static" if "static" in config_to_use["model_path"].split("/") else "GoFactory"
             self._load_model(model_key, config_to_use, **kwargs)
-            if global_preprocessing:
+            if global_preprocessing and model_key in global_preprocessing:
                 self._preprocessing[model_key] = global_preprocessing[model_key]
+            elif global_preprocessing:
+                self.logger.warning(f"No preprocessing config found for '{model_key}'. Global preprocessing will be skipped.")
             self.logger.info(f"Successfully loaded {model_source} model: {model_key}\n")
         self.logger.info(f"Final loaded models: {list(self.models.keys())}\n")
 
-    def preprocess(self, model_role, images):
+    def preprocess(
+        self, model_role: str, images: Union[numpy.ndarray, torch.Tensor, List[Union[numpy.ndarray, torch.Tensor]]]
+    ) -> Tuple[List[Union[numpy.ndarray, torch.Tensor]], List[Dict[str, Any]]]:
         """preprocess the image(s) based on the preprocessing steps in model_role.
 
         Args:
@@ -254,7 +265,9 @@ class PipelineBase(metaclass=ABCMeta):
 
         return self.preprocessor.preprocess(images, self._preprocessing[model_role])
 
-    def reconstruct(self, images, ops):
+    def reconstruct(
+        self, images: List[Union[numpy.ndarray, torch.Tensor]], ops: List[Dict[str, Any]]
+    ) -> List[Union[numpy.ndarray, torch.Tensor]]:
         """reconstruct the images based on the preprocessing steps in ops.
 
         Args:
@@ -274,8 +287,8 @@ class PipelineBase(metaclass=ABCMeta):
         label: str,
         image_height: int,
         image_width: int,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """add a single prediction to results for uploading to Label Studio.
 
         Args:
@@ -300,8 +313,8 @@ class PipelineBase(metaclass=ABCMeta):
         image_width: int,
         key="outputs",
         sub_key="labels",
-    ):
-        """a helper functiomn to add a batch of predictions to results for Label Studio.
+    ) -> None:
+        """a helper function to add a batch of predictions to results for Label Studio.
 
         Args:
             predictions (dict): a dictionary of predictions with one of these keys: boxes, polygons, masks and keypoints. e.g.,
@@ -332,6 +345,15 @@ class PipelineBase(metaclass=ABCMeta):
             if pred_type in predictions:
                 data = predictions[pred_type]
 
+                # Validate structure
+                required_keys = ["objects", "classes", "confidences"]
+                if not all(k in data for k in required_keys):
+                    raise ValueError(f"Missing required keys for {pred_type}: {required_keys}")
+
+                # Validate lengths match
+                if not (len(data["classes"]) == len(data["confidences"]) == len(data["objects"])):
+                    raise ValueError(f"Array length of 'classes', 'confidences' and 'objects' mismatch for {pred_type}.")
+
                 for idx, value_data in enumerate(data["objects"]):
                     value_object = handler["value_factory"](value_data)
                     annotation = Annotation(
@@ -343,7 +365,7 @@ class PipelineBase(metaclass=ABCMeta):
                     )
                     prediction_list.append(annotation.to_dict())
 
-    def init_results(self):
+    def init_results(self) -> None:
         """
         init the output results
         """
@@ -359,7 +381,7 @@ class PipelineBase(metaclass=ABCMeta):
         }
 
     @classmethod
-    def track_exception(cls, logger=None):
+    def track_exception(cls, logger: Optional[Logger] = None) -> Callable:
         """track exceptions and log the error message to GoFactory.
 
         Args:
@@ -381,33 +403,35 @@ class PipelineBase(metaclass=ABCMeta):
                         self.update_results("tags", "ERROR", to_factory=True)
                         self.update_results("should_archive", True)
                         return self.results
+                    else:
+                        raise
 
             return wrapper
 
         return deco
 
     @abstractmethod
-    def warm_up(self, configs: dict):
+    def warm_up(self, configs: dict) -> None:
         """
         warm up the pipeline
         """
         pass
 
     @abstractmethod
-    def load(self, model_roles: dict, configs: dict):
+    def load(self, model_roles: dict, configs: dict) -> None:
         """
         load models
         """
         pass
 
     @abstractmethod
-    def predict(self, configs: dict, inputs: dict):
+    def predict(self, configs: dict, inputs: dict) -> dict:
         """
         the main function to run the pipeline.
         """
         pass
 
-    def clean_up(self):
+    def clean_up(self) -> None:
         """
         clean up the pipeline in REVERSED order, i.e., the last models get destroyed first
         """
@@ -421,7 +445,7 @@ class PipelineBase(metaclass=ABCMeta):
         self._preprocessing.clear()
         self.logger.info("preprocessing is cleaned up")
 
-    def update_results(self, key: str, value, sub_key=None, **kwargs):
+    def update_results(self, key: str, value, sub_key: Optional[str] = None, **kwargs: Any) -> None:
         """
         modifies self.results by applying rules for creation and updates.
 
@@ -447,7 +471,7 @@ class PipelineBase(metaclass=ABCMeta):
         if kwargs.get("to_automation", False) and key not in self.results["automation_keys"]:
             self.results["automation_keys"].append(key)
 
-    def check_return_types(self, check_sub_keys=None) -> bool:
+    def check_return_types(self, check_sub_keys: Optional[List[str]] = None) -> bool:
         """check if the result dictionary is json serializable
 
         Args:

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -61,7 +61,7 @@ class PipelineBase(metaclass=ABCMeta):
 
     # Maps gadget version to model_roles handler
     _MODEL_ROLES_HANDLERS = {
-        "1": None,  # currently handled by the base class
+        "1": None,  # no longer supported
         "2": ModelSchemaV_2.from_dict,
     }
 
@@ -126,8 +126,9 @@ class PipelineBase(metaclass=ABCMeta):
         else:
             raise ValueError(f"model_type {model_type} is not supported")
 
-    def _parse_model_roles(self, model_roles: dict, **kwargs: Any) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
-        """parse model_roles by version and convert it to match the required format for initializing AIS repo models.
+    def _parse_model_roles(self, model_roles: dict, **kwargs: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Parse model_roles by version and convert it to match the required format for initializing AIS repo models.
+        Also, it loads the global preprocessing steps.
 
         Args:
             model_roles (dict): the model roles to parse.
@@ -138,60 +139,9 @@ class PipelineBase(metaclass=ABCMeta):
 
         Returns:
             dict: The parsed model roles.
-            dict or None: The global preprocessing steps.
+            dict: The global preprocessing steps.
         """
-
-        # the format of model_roles from factory is:
-        # {
-        #     "top-od-model": {
-        #         "format": "pt",
-        #         "configs": {},
-        #         "details": {
-        #             "deployed": "2025-08-18T02:26:53.063Z",
-        #             "base_model": "yolov8m.pt",
-        #             "training_package": "Ultralytics8",
-        #             "training_algorithm": "Yolo",
-        #             "confidence_threshold": 0.5,
-        #             "global_preprocessing": [
-        #                 {
-        #                     "type": "resize",
-        #                     "configuration": {
-        #                         "width": 640,
-        #                         "height": 640,
-        #                         "preserve_aspect": true
-        #                     }
-        #                 }
-        #             ]
-        #         },
-        #         "artifacts": {
-        #             "pt": {
-        #                 "image_size": [],
-        #                 "model_path": "/app/models/top-od-model/ObjectDetection/yolo/1/model.pt"
-        #             }
-        #         },
-        #         "model_name": "yolo",
-        #         "model_role": "top-od-model",
-        #         "model_type": "ObjectDetection",
-        #         "model_version": "1"
-        #     }
-        # }
-
-        # However, the required format for initializing AIS repo models is:
-        # {
-        #     "top-od-model": {
-        #     "model_path": "/app/models/top-od-model/ObjectDetection/yolo/1/model.pt",
-        #     "image_size": [
-        #         640,
-        #         640
-        #     ],
-        #     "model_type": "objectdetection",
-        #     "algorithm": "yolo",
-        #     "package": "ultralytics"
-        #     }
-        # }
-
         version = kwargs.get("version", self.version)
-        use_model_internal_tiling = kwargs.get("use_model_internal_tiling", False)
 
         # Validate version
         if version not in self._MODEL_ROLES_HANDLERS:
@@ -199,25 +149,13 @@ class PipelineBase(metaclass=ABCMeta):
 
         handler = self._MODEL_ROLES_HANDLERS[version]
 
-        # Version 1: Only supports model internal tiling
+        # Version 1: No longer supported
         if handler is None:
-            if not use_model_internal_tiling:
-                raise ValueError(
-                    f"Gadget version {version} only supports model internal tiling. "
-                    f"Either set use_model_internal_tiling=True or upgrade to version 2."
-                )
-            self.logger.info("Using legacy model internal tiling (deprecated)")
-            return model_roles, None
+            raise ValueError(f"Gadget version {version} is no longer supported. Please upgrade to the latest version.")
 
         # Version 2+: Supports global preprocessing
         instance = handler(model_roles)
-
-        if use_model_internal_tiling:
-            self.logger.warning("Model internal tiling is deprecated. Consider upgrading Gadget to use global preprocessing.")
-            return instance.get_metadata(use_model_internal_tiling=True), None
-        else:
-            global_preprocessing = instance.get_global_preprocessing()
-            return instance.get_metadata(use_model_internal_tiling=False), global_preprocessing
+        return instance.get_metadata(), instance.get_global_preprocessing()
 
     def load_models(self, model_roles: dict, configs: dict, filter: str = "-model", **kwargs: Any) -> None:
         """
@@ -231,11 +169,10 @@ class PipelineBase(metaclass=ABCMeta):
             configs (dict): the configs from pipeline_def.json or the runtime.
             filter (str, optional): filter models by name. Defaults to "-model".
             verbose (bool, optional): whether to log the original and parsed model roles. Defaults to False.
-            use_model_internal_tiling (bool, optional): whether to use model internal tiling.
-                Defaults to False. Set to True for old Gadget versions.
         """
-        use_model_internal_tiling = kwargs.get("use_model_internal_tiling", False)
         parsed_model_roles, global_preprocessing = self._parse_model_roles(model_roles, **kwargs)
+        if not global_preprocessing:
+            raise ValueError("Global preprocessing is not defined in model roles.")
 
         if kwargs.get("verbose", False):
             self.logger.info(f"Original Model Roles: {json.dumps(model_roles, indent=2)}\n")
@@ -252,19 +189,14 @@ class PipelineBase(metaclass=ABCMeta):
             model_source = "Static" if "static" in Path(config_to_use["model_path"]).parts else "GoFactory"
             self._load_model(model_key, config_to_use, **kwargs)
 
-            if use_model_internal_tiling:
-                self.logger.warning(f"Model '{model_key}' will use model internal tiling. This is deprecated.")
-            elif global_preprocessing:
-                if model_key in global_preprocessing:
-                    self._preprocessing[model_key] = global_preprocessing[model_key]
-                    self.logger.info(f"Applied global preprocessing for '{model_key}'")
-                else:
-                    raise ValueError(
-                        f"Global preprocessing is enabled but no preprocessing config found for '{model_key}'. "
-                        f"Add preprocessing config in Gadget or static manifest."
-                    )
+            if model_key in global_preprocessing:
+                self._preprocessing[model_key] = global_preprocessing[model_key]
+                self.logger.info(f"Applied global preprocessing for '{model_key}'")
             else:
-                raise RuntimeError("Invalid state: global_preprocessing is None but use_model_internal_tiling is False. ")
+                raise ValueError(
+                    f"Global preprocessing is enabled but no preprocessing config found for '{model_key}'. "
+                    f"Add preprocessing config in Gadget or static manifest."
+                )
 
             self.logger.info(f"Successfully loaded {model_source} model: {model_key}\n")
         self.logger.info(f"Final loaded models: {list(self.models.keys())}\n")

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -6,7 +6,7 @@ import traceback
 from abc import ABCMeta, abstractmethod
 from logging import Logger
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy
 import torch
@@ -86,45 +86,42 @@ class PipelineBase(metaclass=ABCMeta):
         self.init_results()
 
     def _load_model(self, model_name: str, metadata: dict, **kwargs: Any) -> None:
-        """load a model with the given metadata. Set default image size if not provided.
+        """load a model with the given metadata.
 
         Args:
             model_name (str): the name of the model to be loaded.
             metadata (dict): the metadata of the model to be loaded.
             kwargs (dict): additional arguments to be passed to the model constructor.
         """
-        if model_name in self.models:
-            self.logger.info(f"{model_name} is already loaded")
+        required_keys = ["model_path", "image_size", "model_type", "package"]
+        missing_keys = [key for key in required_keys if not metadata.get(key)]
+        if missing_keys:
+            raise ValueError(f"Missing required metadata keys {missing_keys} for model: {model_name}")
+
         self.logger.info(f"Loading {model_name} from {metadata['model_path']}")
 
-        if not metadata.get("image_size"):
-            raise ValueError(f"image_size is required in metadata for model: {model_name}")
+        meta_copy = metadata.copy()
+        model_type = meta_copy["model_type"].lower()
 
-        # add version to metadata if not provided
-        model_type = metadata.get("model_type", "").lower()
-        if "version" not in metadata:
-            metadata["version"] = "v1"
-        if metadata.get("package") == "detectron2":
-            # detectron2 only has v0 models
-            metadata["version"] = "v0"
-        if model_type == "classification":
-            # classification only has v0 models
-            metadata["version"] = "v0"
+        # Default to v1, but downgrade to v0 for specific cases
+        meta_copy.setdefault("version", "v1")
+        if (meta_copy["package"] == "detectron2") or (model_type == "classification"):
+            meta_copy["version"] = "v0"
 
-        # check model type
-        if model_type == "anomalydetection":
-            self.models[model_name] = AnomalyDetector(metadata, **kwargs)
-        elif model_type in [
-            "objectdetection",
-            "instancesegmentation",
-            "keypointdetection",
-            "orientedobjectdetection",
-        ]:
-            self.models[model_name] = ObjectDetector(metadata, **kwargs)
-        elif model_type == "classification":
-            self.models[model_name] = Classifier(metadata, **kwargs)
-        else:
-            raise ValueError(f"model_type {model_type} is not supported")
+        model_classes: Dict[str, Type] = {
+            "anomalydetection": AnomalyDetector,
+            "classification": Classifier,
+            "objectdetection": ObjectDetector,
+            "instancesegmentation": ObjectDetector,
+            "keypointdetection": ObjectDetector,
+            "orientedobjectdetection": ObjectDetector,
+        }
+        model_class = model_classes.get(model_type)
+
+        if not model_class:
+            raise ValueError(f"model_type '{model_type}' is not supported")
+
+        self.models[model_name] = model_class(meta_copy, **kwargs)
 
     def _parse_model_roles(self, model_roles: dict, **kwargs: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Parse model_roles by version and convert it to match the required format for initializing AIS repo models.
@@ -298,15 +295,7 @@ class PipelineBase(metaclass=ABCMeta):
         for pred_type, handler in self._PREDICTION_HANDLERS.items():
             if pred_type in predictions:
                 data = predictions[pred_type]
-
-                # Validate structure
-                required_keys = ["objects", "classes", "confidences"]
-                if not all(k in data for k in required_keys):
-                    raise ValueError(f"Missing required keys for {pred_type}: {required_keys}")
-
-                # Validate lengths match
-                if not (len(data["classes"]) == len(data["confidences"]) == len(data["objects"])):
-                    raise ValueError(f"Array length of 'classes', 'confidences' and 'objects' mismatch for {pred_type}.")
+                self._validate_prediction_data(pred_type, data)
 
                 for obj, cls, conf in zip(data["objects"], data["classes"], data["confidences"]):
                     value_object = handler["value_factory"](obj)
@@ -318,6 +307,24 @@ class PipelineBase(metaclass=ABCMeta):
                         type=handler["type"],
                     )
                     prediction_list.append(annotation.to_dict())
+
+    def _validate_prediction_data(self, pred_type: str, data: dict) -> None:
+        """validate the structure and lengths of prediction data.
+
+        Args:
+            pred_type (str): the type of the prediction.
+            data (dict): the prediction data to validate.
+
+        Raises:
+            ValueError: if the structure or lengths are invalid.
+        """
+        required_keys = ["objects", "classes", "confidences"]
+        if not all(k in data for k in required_keys):
+            raise ValueError(f"Missing required keys for {pred_type}: {required_keys}")
+
+        # Validate lengths match
+        if not (len(data["classes"]) == len(data["confidences"]) == len(data["objects"])):
+            raise ValueError(f"Array length of 'classes', 'confidences' and 'objects' mismatch for {pred_type}.")
 
     def init_results(self) -> None:
         """

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -188,7 +188,7 @@ class PipelineBase(metaclass=ABCMeta):
 
             if model_key in global_preprocessing:
                 self._preprocessing[model_key] = global_preprocessing[model_key]
-                self.logger.info(f"Applied global preprocessing for '{model_key}'")
+                self.logger.info(f"Loaded global preprocessing for '{model_key}'")
             else:
                 raise ValueError(
                     f"Global preprocessing is enabled but no preprocessing config found for '{model_key}'. "

--- a/lmi_utils/preprocess_utils/base.py
+++ b/lmi_utils/preprocess_utils/base.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import torch
+
+
+class BaseProcessor:
+    def to_tensor_list(self, images: List[Union[torch.Tensor, np.ndarray]]) -> tuple[List[torch.Tensor], bool]:
+        """
+        Convert image list to tensors if needed.
+
+        Returns:
+            (tensor_list, is_numpy): List of tensors and flag indicating if input was numpy
+        """
+        is_numpy = isinstance(images[0], np.ndarray)
+        if is_numpy:
+            return [torch.from_numpy(img) for img in images], True
+        return images, False
+
+    def from_tensor_list(self, images: List[torch.Tensor], to_numpy: bool) -> List[Union[torch.Tensor, np.ndarray]]:
+        """Convert tensor list back to numpy if needed."""
+        if to_numpy:
+            return [img.cpu().numpy() for img in images]
+        return images
+
+    def validate_image_list(self, images: List[Union[torch.Tensor, np.ndarray]], stage: str = "processing") -> None:
+        """Validate that images is a proper list of tensors or arrays."""
+        if not isinstance(images, list):
+            raise TypeError("Images must be a list.")
+
+        if not images:
+            raise ValueError(f"No input images provided for {stage}.")
+
+        first_type = type(images[0])
+        if first_type not in (torch.Tensor, np.ndarray):
+            raise TypeError("Images must be torch.Tensors or np.ndarrays")
+        if not all(isinstance(img, first_type) for img in images):
+            raise TypeError("All images must be the same type")
+
+    def validate_handler_output(self, output: Any, handler_name: str, expected_type: str = "handler") -> None:
+        """Validate handler output format."""
+        if not isinstance(output, list):
+            raise TypeError(f"{expected_type.capitalize()} '{handler_name}' must return a list of images, got {type(output)}")
+        if not all(isinstance(img, torch.Tensor) for img in output):
+            raise TypeError(f"{expected_type.capitalize()} '{handler_name}' returned non-tensor images")
+
+    def validate_step_keys(self, step: Dict[str, Any], required_keys: set) -> None:
+        """Validate that a step dictionary contains required keys."""
+        if not isinstance(step, dict):
+            raise TypeError("Each processing step must be a dictionary.")
+        if not required_keys.issubset(step.keys()):
+            raise ValueError(f"Each step must contain keys: {required_keys}")

--- a/lmi_utils/preprocess_utils/base.py
+++ b/lmi_utils/preprocess_utils/base.py
@@ -52,3 +52,14 @@ class BaseProcessor:
             raise TypeError("Each processing step must be a dictionary.")
         if not required_keys.issubset(step.keys()):
             raise ValueError(f"Each step must contain keys: {required_keys}")
+
+    def validate_steps(self, steps: List[Dict[str, Any]]) -> None:
+        """Validate that steps is a proper list of metadata dictionaries."""
+        if not isinstance(steps, list):
+            raise TypeError("Steps must be a list.")
+        if not all(isinstance(step, dict) for step in steps):
+            raise TypeError("All steps must be dictionaries.")
+
+        # validate each step
+        for step in steps:
+            self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)

--- a/lmi_utils/preprocess_utils/base.py
+++ b/lmi_utils/preprocess_utils/base.py
@@ -5,6 +5,8 @@ import torch
 
 
 class BaseProcessor:
+    _STEP_REQUIRED_KEYS = {"type", "configuration"}
+
     def to_tensor_list(self, images: List[Union[torch.Tensor, np.ndarray]]) -> tuple[List[torch.Tensor], bool]:
         """
         Convert image list to tensors if needed.

--- a/lmi_utils/preprocess_utils/handlers/__init__.py
+++ b/lmi_utils/preprocess_utils/handlers/__init__.py
@@ -1,0 +1,9 @@
+from .resize import resize_handler, undo_resize_handler
+from .tile import tile_handler, undo_tile_handler
+
+__all__ = [
+    "resize_handler",
+    "undo_resize_handler",
+    "tile_handler",
+    "undo_tile_handler",
+]

--- a/lmi_utils/preprocess_utils/handlers/__init__.py
+++ b/lmi_utils/preprocess_utils/handlers/__init__.py
@@ -1,9 +1,9 @@
-from .resize import resize, undo_resize
-from .tile import tile, undo_tile
+from .resize import resize, revert_resize
+from .tile import revert_tile, tile
 
 __all__ = [
     "resize",
-    "undo_resize",
+    "revert_resize",
     "tile",
-    "undo_tile",
+    "revert_tile",
 ]

--- a/lmi_utils/preprocess_utils/handlers/__init__.py
+++ b/lmi_utils/preprocess_utils/handlers/__init__.py
@@ -1,9 +1,9 @@
-from .resize import resize_handler, undo_resize_handler
-from .tile import tile_handler, undo_tile_handler
+from .resize import resize, undo_resize
+from .tile import tile, undo_tile
 
 __all__ = [
-    "resize_handler",
-    "undo_resize_handler",
-    "tile_handler",
-    "undo_tile_handler",
+    "resize",
+    "undo_resize",
+    "tile",
+    "undo_tile",
 ]

--- a/lmi_utils/preprocess_utils/handlers/resize.py
+++ b/lmi_utils/preprocess_utils/handlers/resize.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict, List, Tuple
+
+import torch
+from gadget_utils.pipeline_utils import revert_mask_to_origin
+from image_utils.img_resize import resize_and_pad
+
+
+def resize_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
+    """
+    Wraps the user's custom 'resize_and_pad' function.
+
+    Args:
+        images (list[torch.Tensor]): List of input images (H, W, C).
+        config (dict): Configuration for resize_and_pad.
+    """
+    if not images:
+        raise ValueError("Cannot resize empty image list")
+
+    # Map config keys to function arguments
+    resize_configs = {
+        "width": config.get("width"),
+        "height": config.get("height"),
+        "preserve_aspect": config.get("preserve_aspect", False),
+        "mode": config.get("mode", "bilinear"),
+    }
+
+    output_images = []
+    image_ops_list = []
+    for img in images:
+        processed, ops = resize_and_pad(
+            img,
+            return_operators=True,
+            **resize_configs,
+        )
+
+        output_images.append(processed)
+        image_ops_list.append(ops)
+
+    return output_images, {"ops": image_ops_list}
+
+
+def undo_resize_handler(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+    """
+    Reverses the composite 'resize_and_pad' operation.
+    Args:
+        images (list[torch.Tensor]): List of input images (H, W, C).
+        meta (dict): Metadata containing 'ops' for each image.
+    """
+    if not images:
+        raise ValueError("No input images provided for undo resize operation.")
+
+    if "ops" not in meta:
+        raise KeyError("Metadata missing required key 'ops'")
+
+    image_ops_list = meta["ops"]
+    if len(images) != len(image_ops_list):
+        raise ValueError(f"Image count ({len(images)}) doesn't match ops count ({len(image_ops_list)})")
+
+    output_images = [revert_mask_to_origin(image, ops) for image, ops in zip(images, image_ops_list)]
+    return output_images

--- a/lmi_utils/preprocess_utils/handlers/resize.py
+++ b/lmi_utils/preprocess_utils/handlers/resize.py
@@ -13,9 +13,6 @@ def resize(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[tor
         images (list[torch.Tensor]): List of input images (H, W, C).
         config (dict): Configuration for resize_and_pad.
     """
-    if not images:
-        raise ValueError("Cannot resize empty image list")
-
     # Map config keys to function arguments
     resize_configs = {
         "width": config.get("width"),
@@ -44,11 +41,8 @@ def undo_resize(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.
     Reverses the composite 'resize_and_pad' operation.
     Args:
         images (list[torch.Tensor]): List of input images (H, W, C).
-        meta (dict): Metadata containing 'ops' for each image.
+        meta (dict): Configuration containing 'ops' for each image.
     """
-    if not images:
-        raise ValueError("No input images provided for undo resize operation.")
-
     if "ops" not in meta:
         raise KeyError("Metadata missing required key 'ops'")
 

--- a/lmi_utils/preprocess_utils/handlers/resize.py
+++ b/lmi_utils/preprocess_utils/handlers/resize.py
@@ -5,6 +5,7 @@ from gadget_utils.pipeline_utils import revert_mask_to_origin
 from image_utils.img_resize import resize_and_pad
 
 
+@torch.inference_mode()
 def resize(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
     """
     Wraps the user's custom 'resize_and_pad' function.
@@ -36,6 +37,7 @@ def resize(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[tor
     return output_images, {"ops": image_ops_list}
 
 
+@torch.inference_mode()
 def undo_resize(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     Reverses the composite 'resize_and_pad' operation.

--- a/lmi_utils/preprocess_utils/handlers/resize.py
+++ b/lmi_utils/preprocess_utils/handlers/resize.py
@@ -38,7 +38,7 @@ def resize(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[tor
 
 
 @torch.inference_mode()
-def undo_resize(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+def revert_resize(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     Reverses the composite 'resize_and_pad' operation.
     Args:

--- a/lmi_utils/preprocess_utils/handlers/resize.py
+++ b/lmi_utils/preprocess_utils/handlers/resize.py
@@ -5,7 +5,7 @@ from gadget_utils.pipeline_utils import revert_mask_to_origin
 from image_utils.img_resize import resize_and_pad
 
 
-def resize_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
+def resize(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
     """
     Wraps the user's custom 'resize_and_pad' function.
 
@@ -39,7 +39,7 @@ def resize_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[
     return output_images, {"ops": image_ops_list}
 
 
-def undo_resize_handler(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+def undo_resize(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     Reverses the composite 'resize_and_pad' operation.
     Args:

--- a/lmi_utils/preprocess_utils/handlers/tile.py
+++ b/lmi_utils/preprocess_utils/handlers/tile.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict, List, Tuple
+
+import torch
+from image_utils.tiler import Tiler
+
+
+def tile_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
+    """
+    Wraps Tiler.
+    Args:
+        images (list[torch.Tensor]): List of input images (H, W, C).
+        config (dict): Configuration for Tiler.
+    """
+    if not images:
+        raise ValueError("Cannot tile empty image list")
+
+    required_keys = {"tile_size", "stride"}
+    if not required_keys.issubset(config.keys()):
+        raise ValueError(f"Tiler configuration must contain keys: {required_keys}")
+
+    scale_mode = config.get("scale_mode", "padding")
+    overlap_mode = config.get("overlap_mode", "average")
+
+    output_images = []
+    tiler_metadata = []
+
+    for img in images:
+        if img.dim() != 3:
+            raise ValueError(f"Expected 3D tensor (H, W, C), got {img.dim()}D tensor with shape {img.shape}")
+
+        tiler = Tiler(tile_size=config["tile_size"], stride=config["stride"])
+        img_batch = img.permute(2, 0, 1).unsqueeze(0)  # Convert to [1, C, H, W]
+        tiles_batch = tiler.tile(img_batch, mode=scale_mode)  # Returns [N, C, H, W]
+
+        # Convert back to List of (H, W, C)
+        tiles_list_chw = list(torch.unbind(tiles_batch, dim=0))
+        tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
+
+        output_images.extend(tiles_list_hwc)
+
+        metadata = tiler.save_metadata()
+        metadata["overlap_mode"] = overlap_mode
+        metadata["scale_mode"] = scale_mode
+        tiler_metadata.append(metadata)
+
+    return output_images, {"tiler_metadata": tiler_metadata}
+
+
+def undo_tile_handler(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+    """
+    undoes the 'tile' operation.
+    Args:
+        images (list[torch.Tensor]): List of input tiles (H, W, C).
+        meta (dict): Metadata containing 'tiler_metadata'.
+    """
+    if not images:
+        raise ValueError("No input images provided for untile operation.")
+
+    if "tiler_metadata" not in meta:
+        raise KeyError(f"Metadata missing required key 'tiler_metadata'. Got keys: {list(meta.keys())}")
+
+    tiler_meta_list = meta["tiler_metadata"]
+    restored_images = []
+    cursor = 0
+
+    for tiler_meta in tiler_meta_list:
+        tiler = Tiler.from_dict(tiler_meta)
+        count = tiler_meta["n_tiles"][0] * tiler_meta["n_tiles"][1]
+
+        # Slice the batch
+        batch_slice_hwc = images[cursor : cursor + count]
+        cursor += count
+
+        # Integrity Check
+        if len(batch_slice_hwc) != count:
+            raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
+
+        # Prepare for Untile
+        batch_hwc = torch.stack(batch_slice_hwc)  # Stack -> [N, H, W, C]
+        batch_chw = batch_hwc.permute(0, 3, 1, 2)  # Permute -> [N, C, H, W]
+
+        # Untile the batch -> [1, C, H, W]
+        scale_mode = tiler_meta.get("scale_mode", "padding")
+        overlap_mode = tiler_meta.get("overlap_mode", "average")
+        restored_batch = tiler.untile(batch_chw, scale_mode=scale_mode, overlap_mode=overlap_mode)
+
+        # Convert back to (H, W, C)
+        restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
+        restored_images.append(restored_img)
+
+    if cursor != len(images):
+        raise RuntimeError(f"Tile reconstruction mismatch: processed {cursor} images, but received {len(images)}")
+
+    return restored_images

--- a/lmi_utils/preprocess_utils/handlers/tile.py
+++ b/lmi_utils/preprocess_utils/handlers/tile.py
@@ -54,7 +54,7 @@ def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch
 
 
 @torch.inference_mode()
-def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+def revert_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     undoes the 'tile' operation.
     Args:

--- a/lmi_utils/preprocess_utils/handlers/tile.py
+++ b/lmi_utils/preprocess_utils/handlers/tile.py
@@ -4,7 +4,7 @@ import torch
 from image_utils.tiler import Tiler
 
 
-def tile_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
+def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
     """
     Wraps Tiler.
     Args:
@@ -46,7 +46,7 @@ def tile_handler(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[Li
     return output_images, {"tiler_metadata": tiler_metadata}
 
 
-def undo_tile_handler(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
+def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     undoes the 'tile' operation.
     Args:

--- a/lmi_utils/preprocess_utils/handlers/tile.py
+++ b/lmi_utils/preprocess_utils/handlers/tile.py
@@ -4,6 +4,7 @@ import torch
 from image_utils.tiler import Tiler
 
 
+@torch.inference_mode()
 def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
     """
     Wraps Tiler.
@@ -11,9 +12,6 @@ def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch
         images (list[torch.Tensor]): List of input images (H, W, C).
         config (dict): Configuration for Tiler.
     """
-    if not images:
-        raise ValueError("Cannot tile empty image list")
-
     required_keys = {"tile_size", "stride"}
     if not required_keys.issubset(config.keys()):
         raise ValueError(f"Tiler configuration must contain keys: {required_keys}")
@@ -25,8 +23,15 @@ def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch
     tiler_metadata = []
 
     for img in images:
-        if img.dim() != 3:
-            raise ValueError(f"Expected 3D tensor (H, W, C), got {img.dim()}D tensor with shape {img.shape}")
+        ndim = img.dim()
+        if ndim not in {2, 3}:
+            raise ValueError(f"Input image must have 2 or 3 dimensions (H, W) or (H, W, C). Got {ndim} dimensions.")
+
+        # Handle single channel
+        add_channel = False
+        if ndim == 2:
+            add_channel = True
+            img = img.unsqueeze(-1)  # Add channel dimension for grayscale images
 
         tiler = Tiler(tile_size=config["tile_size"], stride=config["stride"])
         img_batch = img.permute(2, 0, 1).unsqueeze(0)  # Convert to [1, C, H, W]
@@ -35,10 +40,12 @@ def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch
         # Convert back to List of (H, W, C)
         tiles_list_chw = list(torch.unbind(tiles_batch, dim=0))
         tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
+        if add_channel:
+            tiles_list_hwc = [t.squeeze(-1) for t in tiles_list_hwc]  # Remove added channel
 
         output_images.extend(tiles_list_hwc)
 
-        metadata = tiler.save_metadata()
+        metadata = tiler.to_dict()
         metadata["overlap_mode"] = overlap_mode
         metadata["scale_mode"] = scale_mode
         tiler_metadata.append(metadata)
@@ -46,6 +53,7 @@ def tile(images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch
     return output_images, {"tiler_metadata": tiler_metadata}
 
 
+@torch.inference_mode()
 def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
     """
     undoes the 'tile' operation.
@@ -53,9 +61,6 @@ def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Te
         images (list[torch.Tensor]): List of input tiles (H, W, C).
         meta (dict): Metadata containing 'tiler_metadata'.
     """
-    if not images:
-        raise ValueError("No input images provided for untile operation.")
-
     if "tiler_metadata" not in meta:
         raise KeyError(f"Metadata missing required key 'tiler_metadata'. Got keys: {list(meta.keys())}")
 
@@ -76,7 +81,17 @@ def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Te
             raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
 
         # Prepare for Untile
-        batch_hwc = torch.stack(batch_slice_hwc)  # Stack -> [N, H, W, C]
+        batch_hwc = torch.stack(batch_slice_hwc)  # Stack -> [N, H, W, C] or [N, H, W,]
+
+        ndim = batch_hwc.dim()
+        if ndim not in {4, 3}:
+            raise ValueError(f"Tile batch must have 3 or 4 dimensions (N, H, W) or (N, H, W, C). Got {ndim} dimensions.")
+
+        # Handle single channel case
+        add_channel = False
+        if ndim == 3:
+            add_channel = True
+            batch_hwc = batch_hwc.unsqueeze(-1)
         batch_chw = batch_hwc.permute(0, 3, 1, 2)  # Permute -> [N, C, H, W]
 
         # Untile the batch -> [1, C, H, W]
@@ -86,6 +101,9 @@ def undo_tile(images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Te
 
         # Convert back to (H, W, C)
         restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
+        if add_channel:
+            restored_img = restored_img.squeeze(-1)  # Remove added channel
+
         restored_images.append(restored_img)
 
     if cursor != len(images):

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -15,8 +15,6 @@ class Preprocessor(BaseProcessor):
     called based on a list of processing steps.
     """
 
-    _STEP_REQUIRED_KEYS = {"type", "configuration"}
-
     def __init__(self):
         """
         Initializes the preprocessor and registers default handlers.
@@ -50,23 +48,21 @@ class Preprocessor(BaseProcessor):
         self._handlers[name] = handler_func
 
     def preprocess(
-        self, image: Union[np.ndarray, torch.Tensor], processing_steps: List[Dict[str, Any]]
+        self, images: Union[List[Union[np.ndarray, torch.Tensor]], np.ndarray, torch.Tensor], processing_steps: List[Dict[str, Any]]
     ) -> Tuple[List[Union[np.ndarray, torch.Tensor]], List[Dict[str, Any]]]:
         """
         Runs the preprocessing pipeline.
 
         Args:
-            image (np.ndarray | torch.Tensor): Input image in format (H, W, C).
+            images (np.ndarray | torch.Tensor | list): Input image(s) in format (H, W, C).
             processing_steps (list): List of config dictionaries.
 
         Returns:
             processed_imgs (list[np.ndarray | torch.Tensor]): list of (H, W, C).
             history (list[dict]): Metadata chain for reconstruction.
         """
-        if image is None:
-            raise ValueError("No input image provided for preprocessing.")
-
-        images = [image]
+        if not isinstance(images, list):
+            images = [images]
         self.validate_image_list(images, stage="preprocessing")
 
         # convert to tensor if needed
@@ -92,7 +88,7 @@ class Preprocessor(BaseProcessor):
                 raise TypeError(f"Handler '{op_name}' must return metadata as dict, got {type(metadata)}")
 
             # Save Metadata
-            step_record = {"op": op_name, "metadata": {"config": config, "parent_shapes": parent_shapes, **metadata}}
+            step_record = {"type": op_name, "configuration": {"config": config, "parent_shapes": parent_shapes, **metadata}}
             history.append(step_record)
             processed_imgs = new_images
 

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -78,7 +78,6 @@ class Preprocessor(BaseProcessor):
 
             # Call the handler
             handler = self._handlers[op_name]
-            parent_shapes = [img.shape[0:2] for img in processed_imgs]
             new_images, metadata = handler(processed_imgs, config)
 
             # Validate handler output
@@ -86,8 +85,8 @@ class Preprocessor(BaseProcessor):
             if not isinstance(metadata, dict):
                 raise TypeError(f"Handler '{op_name}' must return metadata as dict, got {type(metadata)}")
 
-            # Save Metadata
-            step_record = {"type": op_name, "configuration": {"config": config, "parent_shapes": parent_shapes, **metadata}}
+            # Save Metadata for reconstruction
+            step_record = {"type": op_name, "configuration": metadata}
             history.append(step_record)
             processed_imgs = new_images
 

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Dict, List, Tuple, Union
+
 import numpy as np
 import torch
 from image_utils.img_resize import resize_and_pad
@@ -19,23 +21,34 @@ class Preprocessor:
         self._handlers = {}
         self._register_default_handlers()
 
-    def _register_default_handlers(self):
+    def _register_default_handlers(self) -> None:
         """Registers the built-in processing functions."""
         self.register_handler("resize", self._resize_wrapper)
         self.register_handler("tile", self._tile_wrapper)
 
-    def register_handler(self, name: str, handler_func):
+    def register_handler(self, name: str, handler_func: Callable) -> None:
         """
         Registers a new handler function or overwrites an existing one.
 
-        The handler_func must accept 'image' as its first argument,
-        followed by keyword arguments matching its configuration.
+        Args:
+            name (str): Unique identifier for this handler (e.g., "resize", "tile").
+            handler_func (callable): Processing function with signature:
+                (images: list[torch.Tensor], config: dict) -> tuple[list[torch.Tensor], dict]
+
+                - images: List of (H, W, C) torch tensors
+                - config: Handler-specific configuration dictionary
+                - Returns: (processed_images, metadata_dict)
+                    - processed_images: List of (H, W, C) tensors
+                    - metadata_dict: Dictionary containing operation metadata
+
         """
         if not callable(handler_func):
             raise TypeError(f"Handler for '{name}' must be a callable function.")
         self._handlers[name] = handler_func
 
-    def preprocess(self, image, processing_steps):
+    def preprocess(
+        self, image: Union[np.ndarray, torch.Tensor], processing_steps: List[Dict[str, Any]]
+    ) -> Tuple[List[Union[np.ndarray, torch.Tensor]], List[Dict[str, Any]]]:
         """
         Runs the preprocessing pipeline.
 
@@ -44,15 +57,21 @@ class Preprocessor:
             processing_steps (list): List of config dictionaries.
 
         Returns:
-            current_images (list[np.ndarray | torch.Tensor]): Processed images (H, W, C).
-            ops (list[dict]): Metadata chain for reconstruction.
+            processed_imgs (list[np.ndarray | torch.Tensor]): list of (H, W, C).
+            history (list[dict]): Metadata chain for reconstruction.
         """
         if image is None:
             raise ValueError("Input image cannot be None.")
+        if not isinstance(image, (np.ndarray, torch.Tensor)):
+            raise TypeError("Input image must be a numpy array or torch tensor.")
 
+        # convert to tensor if needed
         is_numpy = isinstance(image, np.ndarray)
-        current_images = [image]
-        ops = []
+        if is_numpy:
+            image = torch.from_numpy(image)
+
+        processed_imgs = [image]
+        history = []
         required_keys = {"type", "configuration"}
         for step in processing_steps:
             if not required_keys.issubset(step.keys()):
@@ -63,58 +82,84 @@ class Preprocessor:
             if op_name not in self._handlers:
                 raise ValueError(f"Handler for '{op_name}' is not registered.")
 
+            # Call the handler
             handler = self._handlers[op_name]
-            parent_shapes = [img.shape[0:2] for img in current_images]
-            new_images, metadata = handler(current_images, config)
+            parent_shapes = [img.shape[0:2] for img in processed_imgs]
+            new_images, metadata = handler(processed_imgs, config)
+
+            # Validate handler output
+            if not isinstance(new_images, list):
+                raise TypeError(f"Handler '{op_name}' must return a list of images, got {type(new_images)}")
+            if not isinstance(metadata, dict):
+                raise TypeError(f"Handler '{op_name}' must return metadata as dict, got {type(metadata)}")
+            if not all(isinstance(img, torch.Tensor) for img in new_images):
+                raise TypeError(f"Handler '{op_name}' returned non-tensor images")
 
             # Save Metadata
             step_record = {"op": op_name, "metadata": {"config": config, "parent_shapes": parent_shapes, **metadata}}
-            ops.append(step_record)
-            current_images = new_images
+            history.append(step_record)
+            processed_imgs = new_images
 
         # Convert back to numpy if needed
         if is_numpy:
-            current_images = [img.cpu().numpy() if isinstance(img, torch.Tensor) else img for img in current_images]
+            processed_imgs = [img.cpu().numpy() for img in processed_imgs]
 
-        return current_images, ops
+        return processed_imgs, history
 
-    def _tile_wrapper(self, images, config):
+    def _tile_wrapper(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
         """
         Wraps Tiler.
-        Input: List of (H, W, C) numpy arrays or tensors.
-        Output: List of (H, W, C) tiles.
+        Args:
+            images (list[torch.Tensor]): List of input images (H, W, C).
+            config (dict): Configuration for Tiler.
         """
+        if not images:
+            raise ValueError("Cannot tile empty image list")
+
+        required_keys = {"tile_size", "stride"}
+        if not required_keys.issubset(config.keys()):
+            raise ValueError(f"Tiler configuration must contain keys: {required_keys}")
+
+        scale_mode = config.get("scale_mode", "padding")
+        overlap_mode = config.get("overlap_mode", "average")
+
         output_images = []
-        instances = []
+        tiler_metadata = []
 
         for img in images:
-            if not isinstance(img, torch.Tensor):
-                img = torch.from_numpy(img)
+            if img.dim() != 3:
+                raise ValueError(f"Expected 3D tensor (H, W, C), got {img.dim()}D tensor with shape {img.shape}")
 
-            tiler = Tiler(**config)
-
+            tiler = Tiler(tile_size=config["tile_size"], stride=config["stride"])
             img_batch = img.permute(2, 0, 1).unsqueeze(0)  # Convert to [1, C, H, W]
-            tiles_batch = tiler.tile(img_batch)  # Returns [N, C, H, W]
+            tiles_batch = tiler.tile(img_batch, mode=scale_mode)  # Returns [N, C, H, W]
 
             # Convert back to List of (H, W, C)
             tiles_list_chw = list(torch.unbind(tiles_batch, dim=0))
             tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
 
             output_images.extend(tiles_list_hwc)
-            instances.append(tiler)
 
-        return output_images, {"tiler_instances": instances}
+            metadata = tiler.save_metadata()
+            metadata["overlap_mode"] = overlap_mode
+            metadata["scale_mode"] = scale_mode
+            tiler_metadata.append(metadata)
 
-    def _resize_wrapper(self, images, config):
+        return output_images, {"tiler_metadata": tiler_metadata}
+
+    def _resize_wrapper(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
         """
         Wraps the user's custom 'resize_and_pad' function.
 
         Args:
-            images (list[np.ndarray | torch.Tensor]): List of input images (H, W, C).
+            images (list[torch.Tensor]): List of input images (H, W, C).
             config (dict): Configuration for resize_and_pad.
         """
+        if not images:
+            raise ValueError("Cannot resize empty image list")
+
         # Map config keys to function arguments
-        dt = {
+        resize_configs = {
             "width": config.get("width"),
             "height": config.get("height"),
             "preserve_aspect": config.get("preserve_aspect", False),
@@ -124,14 +169,10 @@ class Preprocessor:
         output_images = []
         image_ops_list = []
         for img in images:
-            # convert to tensor
-            if not isinstance(img, torch.Tensor):
-                img = torch.from_numpy(img)
-
             processed, ops = resize_and_pad(
                 img,
                 return_operators=True,
-                **dt,
+                **resize_configs,
             )
 
             output_images.append(processed)

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -1,5 +1,7 @@
 import numpy as np
+import torch
 from image_utils.img_resize import resize_and_pad
+from image_utils.tiler import Tiler
 
 
 class Preprocessor:
@@ -19,7 +21,8 @@ class Preprocessor:
 
     def _register_default_handlers(self):
         """Registers the built-in processing functions."""
-        self.register_handler("resize", resize_and_pad)
+        self.register_handler("resize", self._resize_wrapper)
+        self.register_handler("tile", self._tile_wrapper)
 
     def register_handler(self, name: str, handler_func):
         """
@@ -32,32 +35,103 @@ class Preprocessor:
             raise TypeError(f"Handler for '{name}' must be a callable function.")
         self._handlers[name] = handler_func
 
-    def preprocess(self, image: np.ndarray, processing_steps: list) -> np.ndarray:
+    def preprocess(self, image: np.ndarray | torch.Tensor, processing_steps: list) -> list[np.ndarray | torch.Tensor]:
         """
-        Applies a sequence of preprocessing steps to the input image.
+        Runs the preprocessing pipeline.
 
         Args:
-            image (np.ndarray): The input image to preprocess.
-            processing_steps (list): A list of dictionaries, each specifying
-                                     a processing step with its parameters.
+            image (np.ndarray | torch.Tensor): Input image in format (H, W, C).
+            processing_steps (list): List of config dictionaries.
 
         Returns:
-            np.ndarray: The preprocessed image.
+            final_images (list[np.ndarray | torch.Tensor]): Processed images (H, W, C).
+            ops (list[dict]): Metadata chain for reconstruction.
         """
-        im_out = image
-        operators = []
+        is_numpy = isinstance(image, np.ndarray)
+
+        # Initialize state with the single input image
+        current_images = [image]
+        ops = []
         for step in processing_steps:
             op_name = step.get("type")
             config = step.get("configuration", {})
+
             if op_name not in self._handlers:
                 raise ValueError(f"Handler for '{op_name}' is not registered.")
-            if not isinstance(config, dict):
-                raise TypeError(f"Configuration for '{op_name}' must be a dictionary.")
-            if config is None or config == {}:
-                raise ValueError(f"Configuration for '{op_name}' cannot be None or empty.")
 
-            handler_func = self._handlers[op_name]
-            # Pass the current image and step parameters to the handler
-            im_out, operators = handler_func(im_out, **config, operators=operators, return_operators=True)
+            handler = self._handlers[op_name]
 
-        return im_out, operators
+            parent_shapes = [img.shape[0:2] for img in current_images]
+            new_images, metadata = handler(current_images, config)
+
+            # Save Metadata
+            step_record = {"op": op_name, "metadata": {"config": config, "parent_shapes": parent_shapes, **metadata}}
+            ops.append(step_record)
+            current_images = new_images
+
+        # Convert back to numpy if needed
+        if is_numpy:
+            current_images = [img.cpu().numpy() if isinstance(img, torch.Tensor) else img for img in current_images]
+
+        return current_images, ops
+
+    def _tile_wrapper(self, images, config):
+        """
+        Wraps Tiler.
+        Input: List of (H, W, C) numpy arrays or tensors.
+        Output: List of (H, W, C) tiles.
+        """
+        output_images = []
+        instances = []
+
+        for img in images:
+            if not isinstance(img, torch.Tensor):
+                img = torch.from_numpy(img)
+
+            tiler = Tiler(**config)
+
+            img_batch = img.permute(2, 0, 1).unsqueeze(0)  # Convert to [1, C, H, W]
+            tiles_batch = tiler.tile(img_batch)  # Returns [N, C, H, W]
+
+            # Convert back to List of (H, W, C)
+            tiles_list_chw = list(torch.unbind(tiles_batch, dim=0))
+            tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
+
+            output_images.extend(tiles_list_hwc)
+            instances.append(tiler)
+
+        return output_images, {"tiler_instances": instances}
+
+    def _resize_wrapper(self, images, config):
+        """
+        Wraps the user's custom 'resize_and_pad' function.
+
+        Args:
+            images (list[np.ndarray | torch.Tensor]): List of input images (H, W, C).
+            config (dict): Configuration for resize_and_pad.
+        """
+        # Map config keys to function arguments
+        dt = {
+            "width": config.get("width"),
+            "height": config.get("height"),
+            "preserve_aspect": config.get("preserve_aspect", False),
+            "mode": config.get("mode", "bilinear"),
+        }
+
+        output_images = []
+        image_ops_list = []
+        for img in images:
+            # convert to tensor
+            if not isinstance(img, torch.Tensor):
+                img = torch.from_numpy(img)
+
+            processed, ops = resize_and_pad(
+                img,
+                return_operators=True,
+                **dt,
+            )
+
+            output_images.append(processed)
+            image_ops_list.append(ops)
+
+        return output_images, {"ops": image_ops_list}

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -2,8 +2,8 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 import torch
-from image_utils.img_resize import resize_and_pad
-from image_utils.tiler import Tiler
+
+from .handlers import resize_handler, tile_handler
 
 
 class Preprocessor:
@@ -23,8 +23,8 @@ class Preprocessor:
 
     def _register_default_handlers(self) -> None:
         """Registers the built-in processing functions."""
-        self.register_handler("resize", self._resize_wrapper)
-        self.register_handler("tile", self._tile_wrapper)
+        self.register_handler("resize", resize_handler)
+        self.register_handler("tile", tile_handler)
 
     def register_handler(self, name: str, handler_func: Callable) -> None:
         """
@@ -105,77 +105,3 @@ class Preprocessor:
             processed_imgs = [img.cpu().numpy() for img in processed_imgs]
 
         return processed_imgs, history
-
-    def _tile_wrapper(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
-        """
-        Wraps Tiler.
-        Args:
-            images (list[torch.Tensor]): List of input images (H, W, C).
-            config (dict): Configuration for Tiler.
-        """
-        if not images:
-            raise ValueError("Cannot tile empty image list")
-
-        required_keys = {"tile_size", "stride"}
-        if not required_keys.issubset(config.keys()):
-            raise ValueError(f"Tiler configuration must contain keys: {required_keys}")
-
-        scale_mode = config.get("scale_mode", "padding")
-        overlap_mode = config.get("overlap_mode", "average")
-
-        output_images = []
-        tiler_metadata = []
-
-        for img in images:
-            if img.dim() != 3:
-                raise ValueError(f"Expected 3D tensor (H, W, C), got {img.dim()}D tensor with shape {img.shape}")
-
-            tiler = Tiler(tile_size=config["tile_size"], stride=config["stride"])
-            img_batch = img.permute(2, 0, 1).unsqueeze(0)  # Convert to [1, C, H, W]
-            tiles_batch = tiler.tile(img_batch, mode=scale_mode)  # Returns [N, C, H, W]
-
-            # Convert back to List of (H, W, C)
-            tiles_list_chw = list(torch.unbind(tiles_batch, dim=0))
-            tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
-
-            output_images.extend(tiles_list_hwc)
-
-            metadata = tiler.save_metadata()
-            metadata["overlap_mode"] = overlap_mode
-            metadata["scale_mode"] = scale_mode
-            tiler_metadata.append(metadata)
-
-        return output_images, {"tiler_metadata": tiler_metadata}
-
-    def _resize_wrapper(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], Dict[str, Any]]:
-        """
-        Wraps the user's custom 'resize_and_pad' function.
-
-        Args:
-            images (list[torch.Tensor]): List of input images (H, W, C).
-            config (dict): Configuration for resize_and_pad.
-        """
-        if not images:
-            raise ValueError("Cannot resize empty image list")
-
-        # Map config keys to function arguments
-        resize_configs = {
-            "width": config.get("width"),
-            "height": config.get("height"),
-            "preserve_aspect": config.get("preserve_aspect", False),
-            "mode": config.get("mode", "bilinear"),
-        }
-
-        output_images = []
-        image_ops_list = []
-        for img in images:
-            processed, ops = resize_and_pad(
-                img,
-                return_operators=True,
-                **resize_configs,
-            )
-
-            output_images.append(processed)
-            image_ops_list.append(ops)
-
-        return output_images, {"ops": image_ops_list}

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 import numpy as np
 import torch
 
-from .handlers import resize_handler, tile_handler
+from .handlers import resize, tile
 
 
 class Preprocessor:
@@ -23,8 +23,8 @@ class Preprocessor:
 
     def _register_default_handlers(self) -> None:
         """Registers the built-in processing functions."""
-        self.register_handler("resize", resize_handler)
-        self.register_handler("tile", tile_handler)
+        self.register_handler("resize", resize)
+        self.register_handler("tile", tile)
 
     def register_handler(self, name: str, handler_func: Callable) -> None:
         """

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -64,14 +64,13 @@ class Preprocessor(BaseProcessor):
         if not isinstance(images, list):
             images = [images]
         self.validate_image_list(images, stage="preprocessing")
+        self.validate_steps(processing_steps)
 
         # convert to tensor if needed
         processed_imgs, is_numpy = self.to_tensor_list(images)
 
         history = []
         for step in processing_steps:
-            self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)
-
             op_name = step["type"]
             config = step["configuration"]
             if op_name not in self._handlers:

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -3,16 +3,19 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 import numpy as np
 import torch
 
+from .base import BaseProcessor
 from .handlers import resize, tile
 
 
-class Preprocessor:
+class Preprocessor(BaseProcessor):
     """
     A class to run a dynamic pipeline of preprocessing steps on an image.
 
     Handlers (processing functions) are registered with the instance and
     called based on a list of processing steps.
     """
+
+    _STEP_REQUIRED_KEYS = {"type", "configuration"}
 
     def __init__(self):
         """
@@ -61,21 +64,17 @@ class Preprocessor:
             history (list[dict]): Metadata chain for reconstruction.
         """
         if image is None:
-            raise ValueError("Input image cannot be None.")
-        if not isinstance(image, (np.ndarray, torch.Tensor)):
-            raise TypeError("Input image must be a numpy array or torch tensor.")
+            raise ValueError("No input image provided for preprocessing.")
+
+        images = [image]
+        self.validate_image_list(images, stage="preprocessing")
 
         # convert to tensor if needed
-        is_numpy = isinstance(image, np.ndarray)
-        if is_numpy:
-            image = torch.from_numpy(image)
+        processed_imgs, is_numpy = self.to_tensor_list(images)
 
-        processed_imgs = [image]
         history = []
-        required_keys = {"type", "configuration"}
         for step in processing_steps:
-            if not required_keys.issubset(step.keys()):
-                raise ValueError(f"Each processing step must contain keys: {required_keys}")
+            self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)
 
             op_name = step["type"]
             config = step["configuration"]
@@ -88,20 +87,13 @@ class Preprocessor:
             new_images, metadata = handler(processed_imgs, config)
 
             # Validate handler output
-            if not isinstance(new_images, list):
-                raise TypeError(f"Handler '{op_name}' must return a list of images, got {type(new_images)}")
+            self.validate_handler_output(new_images, op_name, expected_type="handler")
             if not isinstance(metadata, dict):
                 raise TypeError(f"Handler '{op_name}' must return metadata as dict, got {type(metadata)}")
-            if not all(isinstance(img, torch.Tensor) for img in new_images):
-                raise TypeError(f"Handler '{op_name}' returned non-tensor images")
 
             # Save Metadata
             step_record = {"op": op_name, "metadata": {"config": config, "parent_shapes": parent_shapes, **metadata}}
             history.append(step_record)
             processed_imgs = new_images
 
-        # Convert back to numpy if needed
-        if is_numpy:
-            processed_imgs = [img.cpu().numpy() for img in processed_imgs]
-
-        return processed_imgs, history
+        return self.from_tensor_list(processed_imgs, is_numpy), history

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -35,7 +35,7 @@ class Preprocessor:
             raise TypeError(f"Handler for '{name}' must be a callable function.")
         self._handlers[name] = handler_func
 
-    def preprocess(self, image: np.ndarray | torch.Tensor, processing_steps: list) -> list[np.ndarray | torch.Tensor]:
+    def preprocess(self, image, processing_steps):
         """
         Runs the preprocessing pipeline.
 
@@ -44,23 +44,26 @@ class Preprocessor:
             processing_steps (list): List of config dictionaries.
 
         Returns:
-            final_images (list[np.ndarray | torch.Tensor]): Processed images (H, W, C).
+            current_images (list[np.ndarray | torch.Tensor]): Processed images (H, W, C).
             ops (list[dict]): Metadata chain for reconstruction.
         """
-        is_numpy = isinstance(image, np.ndarray)
+        if image is None:
+            raise ValueError("Input image cannot be None.")
 
-        # Initialize state with the single input image
+        is_numpy = isinstance(image, np.ndarray)
         current_images = [image]
         ops = []
+        required_keys = {"type", "configuration"}
         for step in processing_steps:
-            op_name = step.get("type")
-            config = step.get("configuration", {})
+            if not required_keys.issubset(step.keys()):
+                raise ValueError(f"Each processing step must contain keys: {required_keys}")
 
+            op_name = step["type"]
+            config = step["configuration"]
             if op_name not in self._handlers:
                 raise ValueError(f"Handler for '{op_name}' is not registered.")
 
             handler = self._handlers[op_name]
-
             parent_shapes = [img.shape[0:2] for img in current_images]
             new_images, metadata = handler(current_images, config)
 

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -2,8 +2,8 @@ from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 import torch
-from gadget_utils.pipeline_utils import revert_mask_to_origin
-from image_utils.tiler import Tiler
+
+from .handlers import undo_resize_handler, undo_tile_handler
 
 
 class Reconstructor:
@@ -13,8 +13,8 @@ class Reconstructor:
 
     def register_default_undo_handlers(self):
         """Registers built-in undo handlers."""
-        self.register_undo_handler("tile", self._undo_tile)
-        self.register_undo_handler("resize", self._undo_resize)
+        self.register_undo_handler("tile", undo_tile_handler)
+        self.register_undo_handler("resize", undo_resize_handler)
 
     def register_undo_handler(self, name: str, undo_func: Callable) -> None:
         """Register an undo handler with validation"""
@@ -75,70 +75,3 @@ class Reconstructor:
         if is_numpy:
             return current_images[0].cpu().numpy()
         return current_images[0]
-
-    def _undo_tile(self, images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
-        """
-        undoes the 'tile' operation.
-        Args:
-            images (list[torch.Tensor]): List of input tiles (H, W, C).
-            meta (dict): Metadata containing 'tiler_metadata'.
-        """
-        if not images:
-            raise ValueError("No input images provided for untile operation.")
-
-        if "tiler_metadata" not in meta:
-            raise KeyError(f"Metadata missing required key 'tiler_metadata'. Got keys: {list(meta.keys())}")
-
-        tiler_meta_list = meta["tiler_metadata"]
-        restored_images = []
-        cursor = 0
-
-        for tiler_meta in tiler_meta_list:
-            tiler = Tiler.from_dict(tiler_meta)
-            count = tiler_meta["n_tiles"][0] * tiler_meta["n_tiles"][1]
-
-            # Slice the batch
-            batch_slice_hwc = images[cursor : cursor + count]
-            cursor += count
-
-            # Integrity Check
-            if len(batch_slice_hwc) != count:
-                raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
-
-            # Prepare for Untile
-            batch_hwc = torch.stack(batch_slice_hwc)  # Stack -> [N, H, W, C]
-            batch_chw = batch_hwc.permute(0, 3, 1, 2)  # Permute -> [N, C, H, W]
-
-            # Untile the batch -> [1, C, H, W]
-            scale_mode = tiler_meta.get("scale_mode", "padding")
-            overlap_mode = tiler_meta.get("overlap_mode", "average")
-            restored_batch = tiler.untile(batch_chw, scale_mode=scale_mode, overlap_mode=overlap_mode)
-
-            # Convert back to (H, W, C)
-            restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
-            restored_images.append(restored_img)
-
-        if cursor != len(images):
-            raise RuntimeError(f"Tile reconstruction mismatch: processed {cursor} images, but received {len(images)}")
-
-        return restored_images
-
-    def _undo_resize(self, images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
-        """
-        Reverses the composite 'resize_and_pad' operation.
-        Args:
-            images (list[torch.Tensor]): List of input images (H, W, C).
-            meta (dict): Metadata containing 'ops' for each image.
-        """
-        if not images:
-            raise ValueError("No input images provided for undo resize operation.")
-
-        if "ops" not in meta:
-            raise KeyError("Metadata missing required key 'ops'")
-
-        image_ops_list = meta["ops"]
-        if len(images) != len(image_ops_list):
-            raise ValueError(f"Image count ({len(images)}) doesn't match ops count ({len(image_ops_list)})")
-
-        output_images = [revert_mask_to_origin(image, ops) for image, ops in zip(images, image_ops_list)]
-        return output_images

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -3,21 +3,39 @@ from typing import Any, Callable, Dict, List, Union
 import numpy as np
 import torch
 
+from .base import BaseProcessor
 from .handlers import undo_resize, undo_tile
 
 
-class Reconstructor:
+class Reconstructor(BaseProcessor):
+    """
+    A class to reconstruct original images from processed images using undo handlers.
+    """
+
+    _STEP_REQUIRED_KEYS = {"op", "metadata"}
+
     def __init__(self):
         self._undo_handlers = {}
-        self.register_default_undo_handlers()
+        self._register_default_undo_handlers()
 
-    def register_default_undo_handlers(self):
+    def _register_default_undo_handlers(self):
         """Registers built-in undo handlers."""
         self.register_undo_handler("tile", undo_tile)
         self.register_undo_handler("resize", undo_resize)
 
     def register_undo_handler(self, name: str, undo_func: Callable) -> None:
-        """Register an undo handler with validation"""
+        """
+        Register an undo handler for a specific operation.
+
+        Args:
+            name (str): Operation name (must match forward handler name).
+            undo_func (callable): Undo function with signature:
+                (images: list[torch.Tensor], metadata: dict) -> list[torch.Tensor]
+
+                - images: List of processed (H, W, C) tensors
+                - metadata: Dictionary containing operation metadata
+                - Returns: List of (H, W, C) tensors
+        """
         if not callable(undo_func):
             raise TypeError(f"Undo handler for '{name}' must be callable.")
         self._undo_handlers[name] = undo_func
@@ -26,7 +44,7 @@ class Reconstructor:
         self, processed_images: List[Union[torch.Tensor, np.ndarray]], history: List[Dict[str, Any]]
     ) -> Union[torch.Tensor, np.ndarray]:
         """
-        reconstructs the original image from processed images and metadata.
+        Reconstructs the original image from processed images and metadata.
 
         Args:
             processed_images: List of (H, W, C) tensors or numpy arrays.
@@ -35,43 +53,27 @@ class Reconstructor:
         Returns:
             torch.Tensor | np.ndarray: The reconstructed image (H, W, C).
         """
-        if not processed_images:
-            raise ValueError("No input images provided for reconstruction.")
+        self.validate_image_list(processed_images, stage="reconstruction")
 
-        if not isinstance(processed_images, list):
-            raise TypeError("input images must be a list.")
-
-        first_type = type(processed_images[0])
-        if first_type not in (torch.Tensor, np.ndarray):
-            raise TypeError("Images must be torch.Tensors or np.ndarrays")
-        if not all(isinstance(img, first_type) for img in processed_images):
-            raise TypeError("All images must be the same type")
-
-        # convert to tensors if needed
-        is_numpy = isinstance(processed_images[0], np.ndarray)
-        current_images = processed_images
-        if is_numpy:
-            current_images = [torch.from_numpy(img) for img in processed_images]
+        current_images, is_numpy = self.to_tensor_list(processed_images)
 
         # Iterate BACKWARDS through history
-        required_keys = {"op", "metadata"}
         for step in reversed(history):
-            if not required_keys.issubset(step.keys()):
-                raise ValueError(f"Each operation step must contain keys: {required_keys}")
+            self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)
 
             op_name = step["op"]
             meta = step["metadata"]
+            if op_name not in self._undo_handlers:
+                raise ValueError(f"Undo handler for '{op_name}' is not registered.")
 
-            if op_name in self._undo_handlers:
-                undo_func = self._undo_handlers[op_name]
-                current_images = undo_func(current_images, meta)
-            else:
-                raise ValueError(f"No undo handler for {op_name}")
+            # run the undo operation
+            undo_func = self._undo_handlers[op_name]
+            current_images = undo_func(current_images, meta)
+
+            self.validate_handler_output(current_images, op_name, expected_type="undo handler")
 
         if len(current_images) != 1:
-            raise RuntimeError(f"Reconstruction expected returning 1 image, got {len(current_images)}")
+            raise RuntimeError(f"Reconstruction expected 1 image, got {len(current_images)}")
 
         # Return the single root image
-        if is_numpy:
-            return current_images[0].cpu().numpy()
-        return current_images[0]
+        return self.from_tensor_list(current_images, is_numpy)[0]

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -39,22 +39,22 @@ class Reconstructor(BaseProcessor):
         self._undo_handlers[name] = undo_func
 
     def reconstruct(
-        self, processed_images: List[Union[torch.Tensor, np.ndarray]], steps: List[Dict[str, Any]]
+        self, images: List[Union[torch.Tensor, np.ndarray]], steps: List[Dict[str, Any]]
     ) -> List[Union[torch.Tensor, np.ndarray]]:
         """
-        Reconstructs the original image from processed images and configuration.
+        Reconstructs the original image from images and history.
 
         Args:
-            processed_images: List of (H, W, C) tensors or numpy arrays.
+            images: List of (H, W, C) tensors or numpy arrays.
             steps: List of configuration dicts.
 
         Returns:
             List: The reconstructed image(s) (H, W, C).
         """
-        self.validate_image_list(processed_images, stage="reconstruction")
+        self.validate_image_list(images, stage="reconstruction")
         self.validate_steps(steps)
 
-        current_images, is_numpy = self.to_tensor_list(processed_images)
+        restored_images, is_numpy = self.to_tensor_list(images)
 
         # Iterate BACKWARDS through steps
         for step in reversed(steps):
@@ -65,8 +65,7 @@ class Reconstructor(BaseProcessor):
 
             # run the undo operation
             undo_func = self._undo_handlers[op_name]
-            current_images = undo_func(current_images, meta)
+            restored_images = undo_func(restored_images, meta)
+            self.validate_handler_output(restored_images, op_name, expected_type="undo handler")
 
-            self.validate_handler_output(current_images, op_name, expected_type="undo handler")
-
-        return self.from_tensor_list(current_images, is_numpy)
+        return self.from_tensor_list(restored_images, is_numpy)

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -1,67 +1,103 @@
+from typing import Any, Callable, Dict, List, Union
+
 import numpy as np
 import torch
 from gadget_utils.pipeline_utils import revert_mask_to_origin
+from image_utils.tiler import Tiler
 
 
 class Reconstructor:
     def __init__(self):
-        self._undo_handlers = {"tile": self._undo_tile, "resize": self._undo_resize}
+        self._undo_handlers = {}
+        self.register_default_undo_handlers()
 
-    def reconstruct(self, processed_images: list, ops: list) -> torch.Tensor:
+    def register_default_undo_handlers(self):
+        """Registers built-in undo handlers."""
+        self.register_undo_handler("tile", self._undo_tile)
+        self.register_undo_handler("resize", self._undo_resize)
+
+    def register_undo_handler(self, name: str, undo_func: Callable) -> None:
+        """Register an undo handler with validation"""
+        if not callable(undo_func):
+            raise TypeError(f"Undo handler for '{name}' must be callable.")
+        self._undo_handlers[name] = undo_func
+
+    def reconstruct(
+        self, processed_images: List[Union[torch.Tensor, np.ndarray]], history: List[Dict[str, Any]]
+    ) -> Union[torch.Tensor, np.ndarray]:
         """
         reconstructs the original image from processed images and metadata.
 
         Args:
             processed_images: List of (H, W, C) tensors or numpy arrays.
-            ops: List of metadata dicts.
+            history: List of metadata dicts.
 
         Returns:
             torch.Tensor | np.ndarray: The reconstructed image (H, W, C).
         """
-        if not len(processed_images) or processed_images is None:
+        if not processed_images:
             raise ValueError("No input images provided for reconstruction.")
-        if any(not isinstance(img, (np.ndarray, torch.Tensor)) for img in processed_images):
-            raise TypeError("All input images must be either numpy arrays or torch tensors.")
 
-        is_numpy = any(isinstance(img, np.ndarray) for img in processed_images)
+        if not isinstance(processed_images, list):
+            raise TypeError("input images must be a list.")
+
+        first_type = type(processed_images[0])
+        if first_type not in (torch.Tensor, np.ndarray):
+            raise TypeError("Images must be torch.Tensors or np.ndarrays")
+        if not all(isinstance(img, first_type) for img in processed_images):
+            raise TypeError("All images must be the same type")
+
+        # convert to tensors if needed
+        is_numpy = isinstance(processed_images[0], np.ndarray)
         current_images = processed_images
         if is_numpy:
-            current_images = [torch.from_numpy(img) if isinstance(img, np.ndarray) else img for img in processed_images]
+            current_images = [torch.from_numpy(img) for img in processed_images]
 
-        # Iterate BACKWARDS through ops
+        # Iterate BACKWARDS through history
         required_keys = {"op", "metadata"}
-        for step in reversed(ops):
+        for step in reversed(history):
             if not required_keys.issubset(step.keys()):
                 raise ValueError(f"Each operation step must contain keys: {required_keys}")
 
             op_name = step["op"]
             meta = step["metadata"]
+
             if op_name in self._undo_handlers:
                 undo_func = self._undo_handlers[op_name]
                 current_images = undo_func(current_images, meta)
             else:
                 raise ValueError(f"No undo handler for {op_name}")
 
+        if len(current_images) != 1:
+            raise RuntimeError(f"Reconstruction expected returning 1 image, got {len(current_images)}")
+
         # Return the single root image
         if is_numpy:
             return current_images[0].cpu().numpy()
         return current_images[0]
 
-    def _undo_tile(self, images, meta):
+    def _undo_tile(self, images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
         """
-        Input: List of (H, W, C) tiles.
-        Output: List of (H, W, C) restored parents.
+        undoes the 'tile' operation.
+        Args:
+            images (list[torch.Tensor]): List of input tiles (H, W, C).
+            meta (dict): Metadata containing 'tiler_metadata'.
         """
-        tiler_instances = meta["tiler_instances"]
+        if not images:
+            raise ValueError("No input images provided for untile operation.")
 
+        if "tiler_metadata" not in meta:
+            raise KeyError(f"Metadata missing required key 'tiler_metadata'. Got keys: {list(meta.keys())}")
+
+        tiler_meta_list = meta["tiler_metadata"]
         restored_images = []
         cursor = 0
 
-        for tiler in tiler_instances:
-            # 1. Derive count from Tiler state
-            count = tiler.n_tiles[0] * tiler.n_tiles[1]
+        for tiler_meta in tiler_meta_list:
+            tiler = Tiler.from_dict(tiler_meta)
+            count = tiler_meta["n_tiles"][0] * tiler_meta["n_tiles"][1]
 
-            # 2. Slice the batch
+            # Slice the batch
             batch_slice_hwc = images[cursor : cursor + count]
             cursor += count
 
@@ -69,29 +105,40 @@ class Reconstructor:
             if len(batch_slice_hwc) != count:
                 raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
 
-            # 3. Prepare for Untile (Stack & Permute)
-            # Stack -> [N, H, W, C]
-            batch_hwc = torch.stack(batch_slice_hwc)
-            # Permute -> [N, C, H, W]
-            batch_chw = batch_hwc.permute(0, 3, 1, 2)
+            # Prepare for Untile
+            batch_hwc = torch.stack(batch_slice_hwc)  # Stack -> [N, H, W, C]
+            batch_chw = batch_hwc.permute(0, 3, 1, 2)  # Permute -> [N, C, H, W]
 
-            # 4. Untile using the specific instance
-            # Returns [1, C, H, W]
-            restored_batch = tiler.untile(batch_chw)
+            # Untile the batch -> [1, C, H, W]
+            scale_mode = tiler_meta.get("scale_mode", "padding")
+            overlap_mode = tiler_meta.get("overlap_mode", "average")
+            restored_batch = tiler.untile(batch_chw, scale_mode=scale_mode, overlap_mode=overlap_mode)
 
-            # 5. Convert back to (H, W, C)
+            # Convert back to (H, W, C)
             restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
             restored_images.append(restored_img)
 
+        if cursor != len(images):
+            raise RuntimeError(f"Tile reconstruction mismatch: processed {cursor} images, but received {len(images)}")
+
         return restored_images
 
-    def _undo_resize(self, images, meta):
+    def _undo_resize(self, images: List[torch.Tensor], meta: Dict[str, Any]) -> List[torch.Tensor]:
         """
         Reverses the composite 'resize_and_pad' operation.
+        Args:
+            images (list[torch.Tensor]): List of input images (H, W, C).
+            meta (dict): Metadata containing 'ops' for each image.
         """
+        if not images:
+            raise ValueError("No input images provided for undo resize operation.")
+
+        if "ops" not in meta:
+            raise KeyError("Metadata missing required key 'ops'")
+
         image_ops_list = meta["ops"]
-        output_images = []
-        for image, ops in zip(images, image_ops_list):
-            image = revert_mask_to_origin(image, ops)
-            output_images.append(image)
+        if len(images) != len(image_ops_list):
+            raise ValueError(f"Image count ({len(images)}) doesn't match ops count ({len(image_ops_list)})")
+
+        output_images = [revert_mask_to_origin(image, ops) for image, ops in zip(images, image_ops_list)]
         return output_images

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from .base import BaseProcessor
-from .handlers import undo_resize, undo_tile
+from .handlers import revert_resize, revert_tile
 
 
 class Reconstructor(BaseProcessor):
@@ -18,8 +18,8 @@ class Reconstructor(BaseProcessor):
 
     def _register_default_undo_handlers(self):
         """Registers built-in undo handlers."""
-        self.register_undo_handler("tile", undo_tile)
-        self.register_undo_handler("resize", undo_resize)
+        self.register_undo_handler("tile", revert_tile)
+        self.register_undo_handler("resize", revert_resize)
 
     def register_undo_handler(self, name: str, undo_func: Callable) -> None:
         """

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Union
 import numpy as np
 import torch
 
-from .handlers import undo_resize_handler, undo_tile_handler
+from .handlers import undo_resize, undo_tile
 
 
 class Reconstructor:
@@ -13,8 +13,8 @@ class Reconstructor:
 
     def register_default_undo_handlers(self):
         """Registers built-in undo handlers."""
-        self.register_undo_handler("tile", undo_tile_handler)
-        self.register_undo_handler("resize", undo_resize_handler)
+        self.register_undo_handler("tile", undo_tile)
+        self.register_undo_handler("resize", undo_resize)
 
     def register_undo_handler(self, name: str, undo_func: Callable) -> None:
         """Register an undo handler with validation"""

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -39,28 +39,25 @@ class Reconstructor(BaseProcessor):
         self._undo_handlers[name] = undo_func
 
     def reconstruct(
-        self, processed_images: List[Union[torch.Tensor, np.ndarray]], history: List[Dict[str, Any]]
-    ) -> Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]:
+        self, processed_images: List[Union[torch.Tensor, np.ndarray]], steps: List[Dict[str, Any]]
+    ) -> List[Union[torch.Tensor, np.ndarray]]:
         """
         Reconstructs the original image from processed images and configuration.
 
         Args:
             processed_images: List of (H, W, C) tensors or numpy arrays.
-            history: List of configuration dicts.
+            steps: List of configuration dicts.
 
         Returns:
-            torch.Tensor | np.ndarray | list: The reconstructed image(s) (H, W, C).
+            List: The reconstructed image(s) (H, W, C).
         """
-        if not isinstance(processed_images, list):
-            processed_images = [processed_images]
         self.validate_image_list(processed_images, stage="reconstruction")
+        self.validate_steps(steps)
 
         current_images, is_numpy = self.to_tensor_list(processed_images)
 
-        # Iterate BACKWARDS through history
-        for step in reversed(history):
-            self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)
-
+        # Iterate BACKWARDS through steps
+        for step in reversed(steps):
             op_name = step["type"]
             meta = step["configuration"]
             if op_name not in self._undo_handlers:
@@ -72,5 +69,4 @@ class Reconstructor(BaseProcessor):
 
             self.validate_handler_output(current_images, op_name, expected_type="undo handler")
 
-        current_images = self.from_tensor_list(current_images, is_numpy)
-        return current_images[0] if len(current_images) == 1 else current_images
+        return self.from_tensor_list(current_images, is_numpy)

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -7,31 +7,35 @@ class Reconstructor:
     def __init__(self):
         self._undo_handlers = {"tile": self._undo_tile, "resize": self._undo_resize}
 
-    def reconstruct(self, final_images: list, ops: list) -> torch.Tensor:
+    def reconstruct(self, processed_images: list, ops: list) -> torch.Tensor:
         """
-        Reverses the pipeline.
+        reconstructs the original image from processed images and metadata.
 
         Args:
-            final_images: List of (H, W, C) tensors or numpy arrays.
+            processed_images: List of (H, W, C) tensors or numpy arrays.
             ops: List of metadata dicts.
 
         Returns:
             torch.Tensor | np.ndarray: The reconstructed image (H, W, C).
         """
-        if not len(final_images):
-            return
+        if not len(processed_images) or processed_images is None:
+            raise ValueError("No input images provided for reconstruction.")
+        if any(not isinstance(img, (np.ndarray, torch.Tensor)) for img in processed_images):
+            raise TypeError("All input images must be either numpy arrays or torch tensors.")
 
-        is_numpy = any(isinstance(img, np.ndarray) for img in final_images)
-
-        current_images = final_images
+        is_numpy = any(isinstance(img, np.ndarray) for img in processed_images)
+        current_images = processed_images
         if is_numpy:
-            current_images = [torch.from_numpy(img) if isinstance(img, np.ndarray) else img for img in final_images]
+            current_images = [torch.from_numpy(img) if isinstance(img, np.ndarray) else img for img in processed_images]
 
         # Iterate BACKWARDS through ops
+        required_keys = {"op", "metadata"}
         for step in reversed(ops):
+            if not required_keys.issubset(step.keys()):
+                raise ValueError(f"Each operation step must contain keys: {required_keys}")
+
             op_name = step["op"]
             meta = step["metadata"]
-
             if op_name in self._undo_handlers:
                 undo_func = self._undo_handlers[op_name]
                 current_images = undo_func(current_images, meta)
@@ -55,7 +59,6 @@ class Reconstructor:
 
         for tiler in tiler_instances:
             # 1. Derive count from Tiler state
-            # n_tiles is likely [rows, cols]
             count = tiler.n_tiles[0] * tiler.n_tiles[1]
 
             # 2. Slice the batch

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -12,8 +12,6 @@ class Reconstructor(BaseProcessor):
     A class to reconstruct original images from processed images using undo handlers.
     """
 
-    _STEP_REQUIRED_KEYS = {"op", "metadata"}
-
     def __init__(self):
         self._undo_handlers = {}
         self._register_default_undo_handlers()
@@ -30,10 +28,10 @@ class Reconstructor(BaseProcessor):
         Args:
             name (str): Operation name (must match forward handler name).
             undo_func (callable): Undo function with signature:
-                (images: list[torch.Tensor], metadata: dict) -> list[torch.Tensor]
+                (images: list[torch.Tensor], configuration: dict) -> list[torch.Tensor]
 
                 - images: List of processed (H, W, C) tensors
-                - metadata: Dictionary containing operation metadata
+                - configuration: Dictionary containing operation configuration
                 - Returns: List of (H, W, C) tensors
         """
         if not callable(undo_func):
@@ -42,17 +40,19 @@ class Reconstructor(BaseProcessor):
 
     def reconstruct(
         self, processed_images: List[Union[torch.Tensor, np.ndarray]], history: List[Dict[str, Any]]
-    ) -> Union[torch.Tensor, np.ndarray]:
+    ) -> Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]:
         """
-        Reconstructs the original image from processed images and metadata.
+        Reconstructs the original image from processed images and configuration.
 
         Args:
             processed_images: List of (H, W, C) tensors or numpy arrays.
-            history: List of metadata dicts.
+            history: List of configuration dicts.
 
         Returns:
-            torch.Tensor | np.ndarray: The reconstructed image (H, W, C).
+            torch.Tensor | np.ndarray | list: The reconstructed image(s) (H, W, C).
         """
+        if not isinstance(processed_images, list):
+            processed_images = [processed_images]
         self.validate_image_list(processed_images, stage="reconstruction")
 
         current_images, is_numpy = self.to_tensor_list(processed_images)
@@ -61,8 +61,8 @@ class Reconstructor(BaseProcessor):
         for step in reversed(history):
             self.validate_step_keys(step, self._STEP_REQUIRED_KEYS)
 
-            op_name = step["op"]
-            meta = step["metadata"]
+            op_name = step["type"]
+            meta = step["configuration"]
             if op_name not in self._undo_handlers:
                 raise ValueError(f"Undo handler for '{op_name}' is not registered.")
 
@@ -72,8 +72,5 @@ class Reconstructor(BaseProcessor):
 
             self.validate_handler_output(current_images, op_name, expected_type="undo handler")
 
-        if len(current_images) != 1:
-            raise RuntimeError(f"Reconstruction expected 1 image, got {len(current_images)}")
-
-        # Return the single root image
-        return self.from_tensor_list(current_images, is_numpy)[0]
+        current_images = self.from_tensor_list(current_images, is_numpy)
+        return current_images[0] if len(current_images) == 1 else current_images

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -1,0 +1,94 @@
+import numpy as np
+import torch
+from gadget_utils.pipeline_utils import revert_mask_to_origin
+
+
+class Reconstructor:
+    def __init__(self):
+        self._undo_handlers = {"tile": self._undo_tile, "resize": self._undo_resize}
+
+    def reconstruct(self, final_images: list, ops: list) -> torch.Tensor:
+        """
+        Reverses the pipeline.
+
+        Args:
+            final_images: List of (H, W, C) tensors or numpy arrays.
+            ops: List of metadata dicts.
+
+        Returns:
+            torch.Tensor | np.ndarray: The reconstructed image (H, W, C).
+        """
+        if not len(final_images):
+            return
+
+        is_numpy = any(isinstance(img, np.ndarray) for img in final_images)
+
+        current_images = final_images
+        if is_numpy:
+            current_images = [torch.from_numpy(img) if isinstance(img, np.ndarray) else img for img in final_images]
+
+        # Iterate BACKWARDS through ops
+        for step in reversed(ops):
+            op_name = step["op"]
+            meta = step["metadata"]
+
+            if op_name in self._undo_handlers:
+                undo_func = self._undo_handlers[op_name]
+                current_images = undo_func(current_images, meta)
+            else:
+                raise ValueError(f"No undo handler for {op_name}")
+
+        # Return the single root image
+        if is_numpy:
+            return current_images[0].cpu().numpy()
+        return current_images[0]
+
+    def _undo_tile(self, images, meta):
+        """
+        Input: List of (H, W, C) tiles.
+        Output: List of (H, W, C) restored parents.
+        """
+        tiler_instances = meta["tiler_instances"]
+
+        restored_images = []
+        cursor = 0
+
+        for tiler in tiler_instances:
+            # 1. Derive count from Tiler state
+            # n_tiles is likely [rows, cols]
+            count = tiler.n_tiles[0] * tiler.n_tiles[1]
+
+            # 2. Slice the batch
+            batch_slice_hwc = images[cursor : cursor + count]
+            cursor += count
+
+            # Integrity Check
+            if len(batch_slice_hwc) != count:
+                raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
+
+            # 3. Prepare for Untile (Stack & Permute)
+            # Stack -> [N, H, W, C]
+            batch_hwc = torch.stack(batch_slice_hwc)
+            # Permute -> [N, C, H, W]
+            batch_chw = batch_hwc.permute(0, 3, 1, 2)
+
+            # 4. Untile using the specific instance
+            # Returns [1, C, H, W]
+            restored_batch = tiler.untile(batch_chw)
+
+            # 5. Convert back to (H, W, C)
+            restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
+            restored_images.append(restored_img)
+
+        return restored_images
+
+    def _undo_resize(self, images, meta):
+        """
+        Reverses the composite 'resize_and_pad' operation.
+        """
+        image_ops_list = meta["ops"]
+        output_images = []
+        for image, ops in zip(images, image_ops_list):
+            image = revert_mask_to_origin(image, ops)
+            output_images.append(image)
+        return output_images

--- a/tests/lmi_utils/image_utils/test_img_resize.py
+++ b/tests/lmi_utils/image_utils/test_img_resize.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+import torch
+from image_utils.img_resize import resize_and_pad
+
+
+@pytest.mark.parametrize(
+    "input_shape, target_w, target_h",
+    [
+        ((100, 100, 3), 200, 200),
+        ((100, 100, 3), 50, 50),
+        ((100, 100, 3), 200, 50),
+        ((50, 100, 3), 50, 50),
+        ((10, 10, 3), 1000, 1000),
+    ],
+)
+def test_resize_and_pad_stretch(input_shape, target_w, target_h):
+    input_image = np.zeros(input_shape, dtype=np.uint8)
+    h, w = input_shape[:2]
+
+    output, ops = resize_and_pad(input_image, width=target_w, height=target_h, preserve_aspect=False, return_operators=True)
+
+    assert output.shape == (target_h, target_w, 3)
+    assert len(ops) == 1
+    assert ops[0]["resize"] == [target_w, target_h, w, h]
+
+
+@pytest.mark.parametrize(
+    "input_shape, target_w, target_h, expected_resize, expected_pad",
+    [
+        ((100, 100, 3), 200, 200, [200, 200], [0, 0]),
+        ((100, 50, 3), 100, 100, [50, 100], [50, 0]),
+        ((50, 100, 3), 100, 100, [100, 50], [0, 50]),
+        ((100, 200, 3), 50, 50, [50, 25], [0, 25]),
+    ],
+)
+def test_resize_and_pad_preserve_aspect(input_shape, target_w, target_h, expected_resize, expected_pad):
+    input_image = np.zeros(input_shape, dtype=np.uint8)
+    h, w = input_shape[:2]
+
+    output, ops = resize_and_pad(input_image, width=target_w, height=target_h, preserve_aspect=True, return_operators=True)
+
+    assert output.shape == (target_h, target_w, 3)
+
+    # Verify Resize Logic
+    # Operator format: [new_w, new_h, old_w, old_h]
+    assert ops[0]["resize"] == [expected_resize[0], expected_resize[1], w, h]
+
+    # Verify Padding Logic
+    exp_pad_w, exp_pad_h = expected_pad
+
+    if exp_pad_w or exp_pad_h:
+        assert len(ops) == 2
+        pad_l, pad_r, pad_t, pad_b = ops[1]["pad"]
+        assert pad_l + pad_r == exp_pad_w
+        assert pad_t + pad_b == exp_pad_h
+    else:
+        assert len(ops) == 1
+
+
+@pytest.mark.parametrize("input_type", ["numpy", "torch"])
+def test_resize_and_pad_polymorphism(input_type):
+    target_w, target_h = 100, 100
+
+    if input_type == "numpy":
+        input_image = np.zeros((50, 50), dtype=np.uint8)
+    else:
+        input_image = torch.zeros((50, 50), dtype=torch.uint8)
+
+    output, ops = resize_and_pad(input_image, width=target_w, height=target_h, preserve_aspect=True, return_operators=True)
+
+    # Verification
+    if input_type == "numpy":
+        assert isinstance(output, np.ndarray), "Input was Numpy, expected Numpy output"
+    else:
+        assert isinstance(output, torch.Tensor), "Input was Tensor, expected Tensor output"
+
+    assert output.shape == (100, 100)
+
+    # Check operator integrity
+    resize_op = ops[0]["resize"]
+    assert isinstance(resize_op[0], (int, np.integer))
+    assert isinstance(resize_op[2], (int, np.integer))
+
+    # Verify the values
+    assert resize_op == [100, 100, 50, 50]

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -49,7 +49,7 @@ class PipelineOD(PipelineBase):
         (
             [
                 {"type": "resize", "configuration": {"height": 640, "width": 640}},
-                {"type": "tile", "configuration": {"height": 320, "width": 320, "yStride": 320, "xStride": 320}},
+                {"type": "tile", "configuration": {"height": 320, "width": 320, "y_stride": 320, "x_stride": 320}},
             ],
             ["resize", "tile"],
         ),
@@ -66,13 +66,11 @@ def test_pipeline_OD(preprocessing_steps, expected_types):
             "format": "pt",
             "configs": {},
             "details": {
-                "base_model": "yolo11n-seg.pt",
                 "training_package": "Ultralytics",
                 "training_algorithm": "Yolo",
                 "global_preprocessing": preprocessing_steps,
             },
             "artifacts": {"pt": {"image_size": [640, 640], "model_path": model_path}},
-            "model_name": "yolo",
             "model_role": "mock-model",
             "model_type": "ObjectDetection",
             "model_version": "1",
@@ -150,7 +148,7 @@ class PipelineAD(PipelineBase):
         (
             [
                 {"type": "resize", "configuration": {"height": 224, "width": 448}},
-                {"type": "tile", "configuration": {"height": 224, "width": 224, "yStride": 112, "xStride": 112}},
+                {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
             ],
             ["resize", "tile"],
         ),
@@ -167,13 +165,11 @@ def test_pipeline_AD(preprocessing_steps, expected_types):
             "format": "pt",
             "configs": {},
             "details": {
-                "base_model": "model_v1_trace.pt",
                 "training_package": "Anomalib1",
                 "training_algorithm": "Patchcore",
                 "global_preprocessing": preprocessing_steps,
             },
             "artifacts": {"pt": {"image_size": [224, 224], "model_path": model_path}},
-            "model_name": "patchcore",
             "model_role": "mock-model",
             "model_type": "AnomalyDetection",
             "model_version": "1",

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -8,7 +8,7 @@ from lmi_utils.pipeline_base.pipeline_base import PipelineBase
 
 class PipelineOD(PipelineBase):
     def load(self, model_roles: dict, configs: dict):
-        self.load_models(model_roles, configs, use_model_internal_tiling=False)
+        self.load_models(model_roles, configs)
 
     def warm_up(self, configs: dict):
         pass
@@ -106,7 +106,7 @@ def test_pipeline_OD(preprocessing_steps, expected_types):
 
 class PipelineAD(PipelineBase):
     def load(self, model_roles: dict, configs: dict):
-        self.load_models(model_roles, configs, use_model_internal_tiling=False)
+        self.load_models(model_roles, configs)
 
     def warm_up(self, configs: dict):
         pass
@@ -201,3 +201,10 @@ def test_pipeline_AD(preprocessing_steps, expected_types):
         assert orig_shape == h_shape, f"Shape mismatch: {orig_shape} vs {h_shape}"
 
     print(f"Test with steps {expected_types} passed!")
+
+
+def test_version_1_error():
+    pipeline = PipelineOD(version="1")
+    model_roles = {"mock-model": {"model_role": "mock-model"}}
+    with pytest.raises(ValueError, match="Gadget version 1 is no longer supported"):
+        pipeline.load(model_roles, {})

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -6,10 +6,9 @@ import pytest
 from lmi_utils.pipeline_base.pipeline_base import PipelineBase
 
 
-class Pipeline(PipelineBase):
+class PipelineOD(PipelineBase):
     def load(self, model_roles: dict, configs: dict):
-        # We use use_tiling_in_global_preprocessing=True to trigger global tiling
-        self.load_models(model_roles, configs, use_tiling_in_global_preprocessing=True)
+        self.load_models(model_roles, configs, use_model_internal_tiling=False)
 
     def warm_up(self, configs: dict):
         pass
@@ -56,7 +55,7 @@ class Pipeline(PipelineBase):
         ),
     ],
 )
-def test_pipeline_flow(preprocessing_steps, expected_types):
+def test_pipeline_OD(preprocessing_steps, expected_types):
     # Asset paths
     model_path = os.path.abspath("tests/assets/models/od/yolo11n-seg.pt")
     image_dir = os.path.abspath("tests/assets/images/coco")
@@ -67,7 +66,6 @@ def test_pipeline_flow(preprocessing_steps, expected_types):
             "format": "pt",
             "configs": {},
             "details": {
-                "deployed": "2026-01-28",
                 "base_model": "yolo11n-seg.pt",
                 "training_package": "Ultralytics",
                 "training_algorithm": "Yolo",
@@ -81,7 +79,7 @@ def test_pipeline_flow(preprocessing_steps, expected_types):
         }
     }
 
-    pipeline = Pipeline(version="2")
+    pipeline = PipelineOD(version="2")
     pipeline.load(model_roles, {})
 
     # Load images
@@ -104,5 +102,106 @@ def test_pipeline_flow(preprocessing_steps, expected_types):
         orig_shape = original.shape[:2]
         recon_shape = reconstructed.shape[:2]
         assert orig_shape == recon_shape, f"Shape mismatch: {orig_shape} vs {recon_shape}"
+
+    print(f"Test with steps {expected_types} passed!")
+
+
+class PipelineAD(PipelineBase):
+    def load(self, model_roles: dict, configs: dict):
+        self.load_models(model_roles, configs, use_model_internal_tiling=False)
+
+    def warm_up(self, configs: dict):
+        pass
+
+    def predict(self, configs: dict, inputs: dict):
+        """
+        Mock predict:
+        1. Preprocess inputs
+        2. Inference
+        3. Reconstruct
+        """
+        images = inputs.get("images", [])
+        model_role = "mock-model"
+        assert model_role in self.models and len(self.models) == 1
+
+        # 1. Preprocess
+        preprocessed_images, ops_list = self.preprocess(model_role, images)
+
+        # 2. Mock inference
+        scores = []
+        for im in preprocessed_images:
+            scores.append(self.models[model_role].predict(im))
+
+        # 3. Reconstruct
+        heatmap = self.reconstruct(scores, ops_list)
+
+        return {
+            "outputs": {
+                "annotated": heatmap,
+            },
+            "ops_list": ops_list,
+        }
+
+
+@pytest.mark.parametrize(
+    "preprocessing_steps, expected_types",
+    [
+        ([{"type": "resize", "configuration": {"height": 224, "width": 224}}], ["resize"]),
+        (
+            [
+                {"type": "resize", "configuration": {"height": 224, "width": 448}},
+                {"type": "tile", "configuration": {"height": 224, "width": 224, "yStride": 112, "xStride": 112}},
+            ],
+            ["resize", "tile"],
+        ),
+    ],
+)
+def test_pipeline_AD(preprocessing_steps, expected_types):
+    # Asset paths
+    model_path = os.path.abspath("tests/assets/models/ad/model_v1_trace.pt")
+    image_dir = os.path.abspath("tests/assets/images/nvtec-ad")
+
+    # Mock model_roles (Schema V2)
+    model_roles = {
+        "mock-model": {
+            "format": "pt",
+            "configs": {},
+            "details": {
+                "base_model": "model_v1_trace.pt",
+                "training_package": "Anomalib1",
+                "training_algorithm": "Patchcore",
+                "global_preprocessing": preprocessing_steps,
+            },
+            "artifacts": {"pt": {"image_size": [224, 224], "model_path": model_path}},
+            "model_name": "patchcore",
+            "model_role": "mock-model",
+            "model_type": "AnomalyDetection",
+            "model_version": "1",
+        }
+    }
+
+    pipeline = PipelineAD(version="2")
+    pipeline.load(model_roles, {})
+
+    # Load images
+    image_files = [os.path.join(image_dir, f) for f in os.listdir(image_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+    assert len(image_files) > 0, "No images found in assets"
+
+    images = [cv2.cvtColor(cv2.imread(f), cv2.COLOR_BGR2RGB) for f in image_files]
+
+    # Run predict
+    results = pipeline.predict({}, {"images": images})
+    heatmap = results["outputs"]["annotated"]
+    ops_list = results["ops_list"]
+
+    # Verify operators
+    actual_types = [op.get("type") for op in ops_list]
+    assert actual_types == expected_types, f"Operator mismatch: {actual_types} != {expected_types}"
+
+    # Verify shapes
+    for original, h in zip(images, heatmap):
+        orig_shape = original.shape[:2]
+        h_shape = h.shape[:2]
+        assert orig_shape == h_shape, f"Shape mismatch: {orig_shape} vs {h_shape}"
 
     print(f"Test with steps {expected_types} passed!")

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -1,0 +1,108 @@
+import os
+
+import cv2
+import pytest
+
+from lmi_utils.pipeline_base.pipeline_base import PipelineBase
+
+
+class Pipeline(PipelineBase):
+    def load(self, model_roles: dict, configs: dict):
+        # We use use_tiling_in_global_preprocessing=True to trigger global tiling
+        self.load_models(model_roles, configs, use_tiling_in_global_preprocessing=True)
+
+    def warm_up(self, configs: dict):
+        pass
+
+    def predict(self, configs: dict, inputs: dict):
+        """
+        Mock predict:
+        1. Preprocess inputs
+        2. Inference
+        3. Reconstruct
+        """
+        images = inputs.get("images", [])
+        model_role = "mock-model"
+        assert model_role in self.models and len(self.models) == 1
+
+        # 1. Preprocess
+        preprocessed_images, ops_list = self.preprocess(model_role, images)
+
+        # 2. Mock inference
+        for im in preprocessed_images:
+            self.models[model_role].predict(im, 0.5)
+
+        # 3. Reconstruct
+        reconstructed_images = self.reconstruct(preprocessed_images, ops_list)
+
+        return {
+            "outputs": {
+                "annotated": reconstructed_images,
+            },
+            "ops_list": ops_list,
+        }
+
+
+@pytest.mark.parametrize(
+    "preprocessing_steps, expected_types",
+    [
+        ([{"type": "resize", "configuration": {"height": 640, "width": 640}}], ["resize"]),
+        (
+            [
+                {"type": "resize", "configuration": {"height": 640, "width": 640}},
+                {"type": "tile", "configuration": {"height": 320, "width": 320, "yStride": 320, "xStride": 320}},
+            ],
+            ["resize", "tile"],
+        ),
+    ],
+)
+def test_pipeline_flow(preprocessing_steps, expected_types):
+    # Asset paths
+    model_path = os.path.abspath("tests/assets/models/od/yolo11n-seg.pt")
+    image_dir = os.path.abspath("tests/assets/images/coco")
+
+    # Mock model_roles (Schema V2)
+    model_roles = {
+        "mock-model": {
+            "format": "pt",
+            "configs": {},
+            "details": {
+                "deployed": "2026-01-28",
+                "base_model": "yolo11n-seg.pt",
+                "training_package": "Ultralytics",
+                "training_algorithm": "Yolo",
+                "global_preprocessing": preprocessing_steps,
+            },
+            "artifacts": {"pt": {"image_size": [640, 640], "model_path": model_path}},
+            "model_name": "yolo",
+            "model_role": "mock-model",
+            "model_type": "ObjectDetection",
+            "model_version": "1",
+        }
+    }
+
+    pipeline = Pipeline(version="2")
+    pipeline.load(model_roles, {})
+
+    # Load images
+    image_files = [os.path.join(image_dir, f) for f in os.listdir(image_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+    assert len(image_files) > 0, "No images found in assets"
+
+    images = [cv2.cvtColor(cv2.imread(f), cv2.COLOR_BGR2RGB) for f in image_files]
+
+    # Run predict
+    results = pipeline.predict({}, {"images": images})
+    reconstructed_images = results["outputs"]["annotated"]
+    ops_list = results["ops_list"]
+
+    # Verify operators
+    actual_types = [op.get("type") for op in ops_list]
+    assert actual_types == expected_types, f"Operator mismatch: {actual_types} != {expected_types}"
+
+    # Verify shapes
+    for original, reconstructed in zip(images, reconstructed_images):
+        orig_shape = original.shape[:2]
+        recon_shape = reconstructed.shape[:2]
+        assert orig_shape == recon_shape, f"Shape mismatch: {orig_shape} vs {recon_shape}"
+
+    print(f"Test with steps {expected_types} passed!")

--- a/tests/lmi_utils/preprocess_utils/test_error_handling.py
+++ b/tests/lmi_utils/preprocess_utils/test_error_handling.py
@@ -5,64 +5,120 @@ from preprocess_utils.preprocessor import Preprocessor
 from preprocess_utils.reconstructor import Reconstructor
 
 
+@pytest.fixture
+def prep():
+    """Returns a fresh Preprocessor instance for each test."""
+    return Preprocessor()
+
+
+@pytest.fixture
+def recon():
+    """Returns a fresh Reconstructor instance for each test."""
+    return Reconstructor()
+
+
+# ==========================================
+# Group 1: Input Validation
+# Tests related to data types and dimensions
+# ==========================================
+
+
 @pytest.mark.parametrize("invalid_input", [123, "string", None, 5.6, [None]])
-def test_preprocessor_invalid_image_type(invalid_input):
-    """Test that preprocessor rejects invalid image types."""
-    prep = Preprocessor()
+def test_preprocessor_invalid_inputs(prep, invalid_input):
+    """Test that both Preprocessor reject invalid image types."""
     with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
         prep.preprocess([invalid_input], [])
 
 
-def test_one_dim_image_tiling():
+def test_preprocessor_one_dim_image(prep):
     """Test that preprocessor rejects one-dimensional images."""
-    prep = Preprocessor()
     image = np.zeros((10,), dtype=np.uint8)
-    tiler_meta = {
-        "tile_size": [8, 8],
-        "stride": [8, 8],
-    }
-
+    tiler_meta = {"tile_size": [8, 8], "stride": [8, 8]}
     ops = [{"type": "tile", "configuration": tiler_meta}]
+
     with pytest.raises(ValueError, match="Input image must have 2 or 3 dimensions"):
         prep.preprocess([image], ops)
 
 
 @pytest.mark.parametrize(
-    "invalid_step",
+    "bad_input, error_type, match_msg",
     [
-        {"configuration": {}},
-        {"type": "resize"},
+        ([], ValueError, "No input images provided"),
+        (["not_an_image"], TypeError, "Images must be torch.Tensors"),
+        ([torch.zeros(10, 10, 3), np.zeros((10, 10, 3))], TypeError, "All images must be the same type"),
+        (np.zeros((10, 10, 3)), TypeError, "Images must be a list"),
     ],
 )
-def test_preprocessor_invalid_step_keys(invalid_step):
-    """Test that preprocessor validates step structure."""
-    prep = Preprocessor()
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
+def test_reconstructor_invalid_inputs(recon, bad_input, error_type, match_msg):
+    """Test that reconstructor validates input structure and consistency."""
+    with pytest.raises(error_type, match=match_msg):
+        recon.reconstruct(bad_input, [])
+
+
+# ==========================================
+# Group 2: Step Configuration
+# Tests related to step dict structure
+# ==========================================
+
+
+@pytest.mark.parametrize("invalid_step", [{"configuration": {}}, {"type": "resize"}])
+def test_invalid_step_keys(prep, recon, invalid_step):
+    """Test that both classes validate step structure (must have type and configuration)."""
+    im = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="Steps must be a list"):
+        prep.preprocess(im, "not_a_list")
+    with pytest.raises(TypeError, match="Steps must be a list"):
+        recon.reconstruct([im], "not_a_list")
+
+    with pytest.raises(TypeError, match="All steps must be dictionaries"):
+        prep.preprocess(im, ["not_a_dict"])
+    with pytest.raises(TypeError, match="All steps must be dictionaries"):
+        recon.reconstruct([im], ["not_a_dict"])
+
     with pytest.raises(ValueError, match="Each step must contain keys"):
-        prep.preprocess(image, [invalid_step])
+        prep.preprocess(im, [invalid_step])
+    with pytest.raises(ValueError, match="Each step must contain keys"):
+        recon.reconstruct([im], [invalid_step])
 
 
-def test_preprocessor_unregistered_handler():
-    """Test that preprocessor rejects unregistered handlers."""
-    prep = Preprocessor()
+# ==========================================
+# Group 3: Handler Registry
+# Tests related to registering/retrieving handlers
+# ==========================================
+
+
+def test_unregistered_handler(prep, recon):
+    """Test that classes reject operations with unknown handlers."""
     image = np.zeros((10, 10, 3), dtype=np.uint8)
+
     with pytest.raises(ValueError, match="Handler for 'unknown' is not registered"):
         prep.preprocess(image, [{"type": "unknown", "configuration": {}}])
 
+    with pytest.raises(ValueError, match="Undo handler for 'unknown' is not registered"):
+        recon.reconstruct([image], [{"type": "unknown", "configuration": {}}])
 
-def test_preprocessor_register_non_callable():
-    """Test that only callable handlers can be registered."""
-    prep = Preprocessor()
+
+def test_register_non_callable(prep, recon):
+    """Test that only callable functions can be registered."""
     with pytest.raises(TypeError, match="must be a callable function"):
         prep.register_handler("test", "not_callable")
 
+    with pytest.raises(TypeError, match="Undo handler for 'test' must be callable"):
+        recon.register_undo_handler("test", "not_callable")
 
-def test_preprocessor_handler_invalid_returns():
-    """Test that handlers must return (list of tensors, dict)."""
-    prep = Preprocessor()
+
+# ==========================================
+# Group 4: Handler Compliance
+# Tests ensuring custom handlers return valid data
+# ==========================================
+
+
+def test_preprocessor_handler_returns(prep):
+    """Test that preprocessor handlers return (list of tensors, dict)."""
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
-    # Handler returns single image instead of list
+    # 1. Returns single image instead of list
     def returns_non_list(images, config):
         return images[0], {}
 
@@ -70,7 +126,7 @@ def test_preprocessor_handler_invalid_returns():
     with pytest.raises(TypeError, match="Handler 'bad1' must return a list of images"):
         prep.preprocess(image, [{"type": "bad1", "configuration": {}}])
 
-    # Handler returns non-dict metadata
+    # 2. Returns non-dict metadata
     def returns_non_dict_metadata(images, config):
         return images, "not_a_dict"
 
@@ -78,7 +134,7 @@ def test_preprocessor_handler_invalid_returns():
     with pytest.raises(TypeError, match="Handler 'bad2' must return metadata as dict"):
         prep.preprocess(image, [{"type": "bad2", "configuration": {}}])
 
-    # Handler returns numpy arrays instead of tensors
+    # 3. Returns numpy arrays instead of tensors
     def returns_numpy(images, config):
         return [np.zeros((10, 10, 3))], {}
 
@@ -87,79 +143,36 @@ def test_preprocessor_handler_invalid_returns():
         prep.preprocess(image, [{"type": "bad3", "configuration": {}}])
 
 
-def test_reconstructor_invalid_inputs():
-    """Test that reconstructor validates input images."""
-    recon = Reconstructor()
-
-    # Empty list
-    with pytest.raises(ValueError, match="No input images provided for reconstruction"):
-        recon.reconstruct([], [])
-
-    # Invalid image type
-    with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
-        recon.reconstruct(["not_an_image"], [])
-
-    # Mixed image types
-    with pytest.raises(TypeError, match="All images must be the same type"):
-        recon.reconstruct([torch.zeros((10, 10, 3)), np.zeros((10, 10, 3))], [])
-
-
-@pytest.mark.parametrize(
-    "invalid_step",
-    [
-        {"configuration": {}},
-        {"type": "resize"},
-    ],
-)
-def test_reconstructor_invalid_step_keys(invalid_step):
-    """Test that reconstructor validates step structure."""
-    recon = Reconstructor()
+def test_reconstructor_handler_returns(recon):
+    """Test that reconstructor undo handlers return list of tensors."""
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with pytest.raises(ValueError, match="Each step must contain keys"):
-        recon.reconstruct([image], [invalid_step])
 
-
-def test_reconstructor_unregistered_undo_handler():
-    """Test that reconstructor rejects unregistered undo handlers."""
-    recon = Reconstructor()
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with pytest.raises(ValueError, match="Undo handler for 'unknown' is not registered"):
-        recon.reconstruct([image], [{"type": "unknown", "configuration": {}}])
-
-
-def test_reconstructor_register_non_callable():
-    """Test that only callable undo handlers can be registered."""
-    recon = Reconstructor()
-    with pytest.raises(TypeError, match="Undo handler for 'test' must be callable"):
-        recon.register_undo_handler("test", "not_callable")
-
-
-def test_reconstructor_undo_handler_invalid_returns():
-    """Test that undo handlers must return list of tensors."""
-    recon = Reconstructor()
-
-    # Undo handler returns single image instead of list
+    # 1. Returns single image instead of list
     def returns_non_list(images, metadata):
         return images[0]
 
     recon.register_undo_handler("bad1", returns_non_list)
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
     with pytest.raises(TypeError, match="Undo handler 'bad1' must return a list of images"):
         recon.reconstruct([image], [{"type": "bad1", "configuration": {}}])
 
-    # Undo handler returns numpy arrays instead of tensors
+    # 2. Returns numpy arrays instead of tensors
     def returns_numpy(images, metadata):
         return [np.zeros((10, 10, 3))]
 
     recon.register_undo_handler("bad2", returns_numpy)
-    image = torch.zeros((10, 10, 3))
+    tensor_image = torch.zeros((10, 10, 3))
     with pytest.raises(TypeError, match="Undo handler 'bad2' returned non-tensor images"):
-        recon.reconstruct([image], [{"type": "bad2", "configuration": {}}])
+        recon.reconstruct([tensor_image], [{"type": "bad2", "configuration": {}}])
 
 
-def test_reconstructor_tile_integrity_failure():
+# ==========================================
+# Group 5: Reconstruction Integrity
+# Tests for logic specific to rebuilding images
+# ==========================================
+
+
+def test_tile_count_integrity(recon):
     """Test RuntimeError when tile count doesn't match images provided."""
-    recon = Reconstructor()
     image = torch.zeros((16, 16, 3))
 
     tiler_meta = {
@@ -167,7 +180,6 @@ def test_reconstructor_tile_integrity_failure():
         "tile_size": [8, 8],
         "stride": [8, 8],
     }
-
     meta = {"tiler_metadata": [tiler_meta]}
     ops = [{"type": "tile", "configuration": meta}]
 

--- a/tests/lmi_utils/preprocess_utils/test_error_handling.py
+++ b/tests/lmi_utils/preprocess_utils/test_error_handling.py
@@ -4,36 +4,46 @@ import torch
 from preprocess_utils.preprocessor import Preprocessor
 from preprocess_utils.reconstructor import Reconstructor
 
-# --- Preprocessor Error Handling Tests ---
 
-
-def test_preprocessor_null_image():
-    prep = Preprocessor()
-    with pytest.raises(ValueError, match="No input image provided for preprocessing"):
-        prep.preprocess(None, [])
-
-
-def test_preprocessor_invalid_image_type():
+@pytest.mark.parametrize("invalid_input", [123, "string", None, 5.6, [None]])
+def test_preprocessor_invalid_image_type(invalid_input):
     """Test that preprocessor rejects invalid image types."""
     prep = Preprocessor()
     with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
-        prep.preprocess("not_an_image", [])
+        prep.preprocess([invalid_input], [])
 
 
-def test_preprocessor_invalid_step_keys():
+def test_one_dim_image_tiling():
+    """Test that preprocessor rejects one-dimensional images."""
+    prep = Preprocessor()
+    image = np.zeros((10,), dtype=np.uint8)
+    tiler_meta = {
+        "tile_size": [8, 8],
+        "stride": [8, 8],
+    }
+
+    ops = [{"type": "tile", "configuration": tiler_meta}]
+    with pytest.raises(ValueError, match="Input image must have 2 or 3 dimensions"):
+        prep.preprocess([image], ops)
+
+
+@pytest.mark.parametrize(
+    "invalid_step",
+    [
+        {"configuration": {}},
+        {"type": "resize"},
+    ],
+)
+def test_preprocessor_invalid_step_keys(invalid_step):
+    """Test that preprocessor validates step structure."""
     prep = Preprocessor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    # Missing 'type'
     with pytest.raises(ValueError, match="Each step must contain keys"):
-        prep.preprocess(image, [{"configuration": {}}])
-
-    # Missing 'configuration'
-    with pytest.raises(ValueError, match="Each step must contain keys"):
-        prep.preprocess(image, [{"type": "resize"}])
+        prep.preprocess(image, [invalid_step])
 
 
 def test_preprocessor_unregistered_handler():
+    """Test that preprocessor rejects unregistered handlers."""
     prep = Preprocessor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
     with pytest.raises(ValueError, match="Handler for 'unknown' is not registered"):
@@ -41,167 +51,125 @@ def test_preprocessor_unregistered_handler():
 
 
 def test_preprocessor_register_non_callable():
+    """Test that only callable handlers can be registered."""
     prep = Preprocessor()
     with pytest.raises(TypeError, match="must be a callable function"):
         prep.register_handler("test", "not_callable")
 
 
-def test_preprocessor_handler_returns_non_list():
-    """Test that handlers must return a list of images."""
+def test_preprocessor_handler_invalid_returns():
+    """Test that handlers must return (list of tensors, dict)."""
     prep = Preprocessor()
-
-    def bad_handler(images, config):
-        return images[0], {}  # Returns single image, not list
-
-    prep.register_handler("bad", bad_handler)
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
-    with pytest.raises(TypeError, match="Handler 'bad' must return a list of images"):
-        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
+    # Handler returns single image instead of list
+    def returns_non_list(images, config):
+        return images[0], {}
+
+    prep.register_handler("bad1", returns_non_list)
+    with pytest.raises(TypeError, match="Handler 'bad1' must return a list of images"):
+        prep.preprocess(image, [{"type": "bad1", "configuration": {}}])
+
+    # Handler returns non-dict metadata
+    def returns_non_dict_metadata(images, config):
+        return images, "not_a_dict"
+
+    prep.register_handler("bad2", returns_non_dict_metadata)
+    with pytest.raises(TypeError, match="Handler 'bad2' must return metadata as dict"):
+        prep.preprocess(image, [{"type": "bad2", "configuration": {}}])
+
+    # Handler returns numpy arrays instead of tensors
+    def returns_numpy(images, config):
+        return [np.zeros((10, 10, 3))], {}
+
+    prep.register_handler("bad3", returns_numpy)
+    with pytest.raises(TypeError, match="Handler 'bad3' returned non-tensor images"):
+        prep.preprocess(image, [{"type": "bad3", "configuration": {}}])
 
 
-def test_preprocessor_handler_returns_non_dict_metadata():
-    """Test that handlers must return metadata as dict."""
-    prep = Preprocessor()
-
-    def bad_handler(images, config):
-        return images, "not_a_dict"  # Returns string instead of dict
-
-    prep.register_handler("bad", bad_handler)
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    with pytest.raises(TypeError, match="Handler 'bad' must return metadata as dict"):
-        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
-
-
-def test_preprocessor_handler_returns_non_tensors():
-    """Test that handlers must return torch tensors."""
-    prep = Preprocessor()
-
-    def bad_handler(images, config):
-        return [np.zeros((10, 10, 3))], {}  # Returns numpy array
-
-    prep.register_handler("bad", bad_handler)
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    with pytest.raises(TypeError, match="Handler 'bad' returned non-tensor images"):
-        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
-
-
-# --- Reconstructor Error Handling Tests ---
-
-
-def test_reconstructor_empty_images():
+def test_reconstructor_invalid_inputs():
+    """Test that reconstructor validates input images."""
     recon = Reconstructor()
+
+    # Empty list
     with pytest.raises(ValueError, match="No input images provided for reconstruction"):
         recon.reconstruct([], [])
 
-
-def test_reconstructor_non_list_input():
-    """Test that reconstructor requires a list of images."""
-    recon = Reconstructor()
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with pytest.raises(TypeError, match="Images must be a list"):
-        recon.reconstruct(image, [])  # Passing single image instead of list
-
-
-def test_reconstructor_invalid_image_type():
-    recon = Reconstructor()
+    # Invalid image type
     with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
         recon.reconstruct(["not_an_image"], [])
 
-
-def test_reconstructor_mixed_image_types():
-    """Test that all images must be the same type."""
-    recon = Reconstructor()
+    # Mixed image types
     with pytest.raises(TypeError, match="All images must be the same type"):
         recon.reconstruct([torch.zeros((10, 10, 3)), np.zeros((10, 10, 3))], [])
 
 
-def test_reconstructor_invalid_step_keys():
+@pytest.mark.parametrize(
+    "invalid_step",
+    [
+        {"configuration": {}},
+        {"type": "resize"},
+    ],
+)
+def test_reconstructor_invalid_step_keys(invalid_step):
+    """Test that reconstructor validates step structure."""
     recon = Reconstructor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    # Missing 'op'
     with pytest.raises(ValueError, match="Each step must contain keys"):
-        recon.reconstruct([image], [{"metadata": {}}])
-
-    # Missing 'metadata'
-    with pytest.raises(ValueError, match="Each step must contain keys"):
-        recon.reconstruct([image], [{"op": "resize"}])
+        recon.reconstruct([image], [invalid_step])
 
 
 def test_reconstructor_unregistered_undo_handler():
+    """Test that reconstructor rejects unregistered undo handlers."""
     recon = Reconstructor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
     with pytest.raises(ValueError, match="Undo handler for 'unknown' is not registered"):
-        recon.reconstruct([image], [{"op": "unknown", "metadata": {}}])
+        recon.reconstruct([image], [{"type": "unknown", "configuration": {}}])
 
 
 def test_reconstructor_register_non_callable():
-    """Test that undo handlers must be callable."""
+    """Test that only callable undo handlers can be registered."""
     recon = Reconstructor()
     with pytest.raises(TypeError, match="Undo handler for 'test' must be callable"):
         recon.register_undo_handler("test", "not_callable")
 
 
-def test_reconstructor_undo_handler_returns_non_list():
-    """Test that undo handlers must return a list of images."""
+def test_reconstructor_undo_handler_invalid_returns():
+    """Test that undo handlers must return list of tensors."""
     recon = Reconstructor()
 
-    def bad_undo_handler(images, metadata):
-        return images[0]  # Returns single image, not list
+    # Undo handler returns single image instead of list
+    def returns_non_list(images, metadata):
+        return images[0]
 
-    recon.register_undo_handler("bad", bad_undo_handler)
+    recon.register_undo_handler("bad1", returns_non_list)
     image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(TypeError, match="Undo handler 'bad1' must return a list of images"):
+        recon.reconstruct([image], [{"type": "bad1", "configuration": {}}])
 
-    with pytest.raises(TypeError, match="Undo handler 'bad' must return a list of images"):
-        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
+    # Undo handler returns numpy arrays instead of tensors
+    def returns_numpy(images, metadata):
+        return [np.zeros((10, 10, 3))]
 
-
-def test_reconstructor_undo_handler_returns_non_tensors():
-    """Test that undo handlers must return torch tensors."""
-    recon = Reconstructor()
-
-    def bad_undo_handler(images, metadata):
-        return [np.zeros((10, 10, 3))]  # Returns numpy array
-
-    recon.register_undo_handler("bad", bad_undo_handler)
+    recon.register_undo_handler("bad2", returns_numpy)
     image = torch.zeros((10, 10, 3))
-
-    with pytest.raises(TypeError, match="Undo handler 'bad' returned non-tensor images"):
-        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
-
-
-def test_reconstructor_multiple_images_after_reconstruction():
-    """Test that reconstruction must result in exactly 1 image."""
-    recon = Reconstructor()
-
-    def bad_undo_handler(images, metadata):
-        # Returns 2 images instead of combining to 1
-        return [torch.zeros((10, 10, 3)), torch.zeros((10, 10, 3))]
-
-    recon.register_undo_handler("bad", bad_undo_handler)
-    image = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    with pytest.raises(RuntimeError, match="Reconstruction expected 1 image, got 2"):
-        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
+    with pytest.raises(TypeError, match="Undo handler 'bad2' returned non-tensor images"):
+        recon.reconstruct([image], [{"type": "bad2", "configuration": {}}])
 
 
 def test_reconstructor_tile_integrity_failure():
-    """
-    Test RuntimeError when tile count doesn't match images provided.
-    """
+    """Test RuntimeError when tile count doesn't match images provided."""
     recon = Reconstructor()
     image = torch.zeros((16, 16, 3))
 
-    # Create metadata dict instead of mock object
     tiler_meta = {
         "n_tiles": [2, 2],  # Expects 4 tiles
+        "tile_size": [8, 8],
+        "stride": [8, 8],
     }
 
     meta = {"tiler_metadata": [tiler_meta]}
-    ops = [{"op": "tile", "metadata": meta}]
+    ops = [{"type": "tile", "configuration": meta}]
 
     # Provide only 1 image instead of 4
     with pytest.raises(RuntimeError, match="Expected 4 tiles, found 1"):

--- a/tests/lmi_utils/preprocess_utils/test_error_handling.py
+++ b/tests/lmi_utils/preprocess_utils/test_error_handling.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pytest
+import torch
+from preprocess_utils.preprocessor import Preprocessor
+from preprocess_utils.reconstructor import Reconstructor
+
+# --- Preprocessor Error Handling Tests ---
+
+
+def test_preprocessor_null_image():
+    prep = Preprocessor()
+    with pytest.raises(ValueError, match="Input image cannot be None"):
+        prep.preprocess(None, [])
+
+
+def test_preprocessor_invalid_step_keys():
+    prep = Preprocessor()
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    # Missing 'type'
+    with pytest.raises(ValueError, match="Each processing step must contain keys"):
+        prep.preprocess(image, [{"configuration": {}}])
+
+    # Missing 'configuration'
+    with pytest.raises(ValueError, match="Each processing step must contain keys"):
+        prep.preprocess(image, [{"type": "resize"}])
+
+
+def test_preprocessor_unregistered_handler():
+    prep = Preprocessor()
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="Handler for 'unknown' is not registered"):
+        prep.preprocess(image, [{"type": "unknown", "configuration": {}}])
+
+
+def test_preprocessor_register_non_callable():
+    prep = Preprocessor()
+    with pytest.raises(TypeError, match="must be a callable function"):
+        prep.register_handler("test", "not_callable")
+
+
+# --- Reconstructor Error Handling Tests ---
+
+
+def test_reconstructor_empty_images():
+    recon = Reconstructor()
+    with pytest.raises(ValueError, match="No input images provided"):
+        recon.reconstruct([], [])
+
+
+def test_reconstructor_invalid_image_type():
+    recon = Reconstructor()
+    with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
+        recon.reconstruct(["not_an_image"], [])
+    with pytest.raises(TypeError, match="All images must be the same type"):
+        recon.reconstruct([torch.zeros((10, 10, 3)), np.zeros((10, 10, 3))], [])
+
+
+def test_reconstructor_invalid_ops_keys():
+    recon = Reconstructor()
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    # Missing 'op'
+    with pytest.raises(ValueError, match="Each operation step must contain keys"):
+        recon.reconstruct([image], [{"metadata": {}}])
+
+    # Missing 'metadata'
+    with pytest.raises(ValueError, match="Each operation step must contain keys"):
+        recon.reconstruct([image], [{"op": "resize"}])
+
+
+def test_reconstructor_unsupported_undo():
+    recon = Reconstructor()
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="No undo handler for unknown"):
+        recon.reconstruct([image], [{"op": "unknown", "metadata": {}}])
+
+
+def test_reconstructor_tile_integrity_failure():
+    """
+    Test RuntimeError when tile count doesn't match images provided.
+    """
+    recon = Reconstructor()
+    image = torch.zeros((16, 16, 3))
+
+    # Create metadata dict instead of mock object
+    tiler_meta = {
+        "n_tiles": [2, 2],  # Expects 4 tiles
+    }
+
+    meta = {"tiler_metadata": [tiler_meta]}
+    ops = [{"op": "tile", "metadata": meta}]
+
+    # Provide only 1 image instead of 4
+    with pytest.raises(RuntimeError, match="Expected 4 tiles, found 1"):
+        recon.reconstruct([image], ops)

--- a/tests/lmi_utils/preprocess_utils/test_error_handling.py
+++ b/tests/lmi_utils/preprocess_utils/test_error_handling.py
@@ -9,8 +9,15 @@ from preprocess_utils.reconstructor import Reconstructor
 
 def test_preprocessor_null_image():
     prep = Preprocessor()
-    with pytest.raises(ValueError, match="Input image cannot be None"):
+    with pytest.raises(ValueError, match="No input image provided for preprocessing"):
         prep.preprocess(None, [])
+
+
+def test_preprocessor_invalid_image_type():
+    """Test that preprocessor rejects invalid image types."""
+    prep = Preprocessor()
+    with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
+        prep.preprocess("not_an_image", [])
 
 
 def test_preprocessor_invalid_step_keys():
@@ -18,11 +25,11 @@ def test_preprocessor_invalid_step_keys():
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
     # Missing 'type'
-    with pytest.raises(ValueError, match="Each processing step must contain keys"):
+    with pytest.raises(ValueError, match="Each step must contain keys"):
         prep.preprocess(image, [{"configuration": {}}])
 
     # Missing 'configuration'
-    with pytest.raises(ValueError, match="Each processing step must contain keys"):
+    with pytest.raises(ValueError, match="Each step must contain keys"):
         prep.preprocess(image, [{"type": "resize"}])
 
 
@@ -39,41 +46,146 @@ def test_preprocessor_register_non_callable():
         prep.register_handler("test", "not_callable")
 
 
+def test_preprocessor_handler_returns_non_list():
+    """Test that handlers must return a list of images."""
+    prep = Preprocessor()
+
+    def bad_handler(images, config):
+        return images[0], {}  # Returns single image, not list
+
+    prep.register_handler("bad", bad_handler)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="Handler 'bad' must return a list of images"):
+        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
+
+
+def test_preprocessor_handler_returns_non_dict_metadata():
+    """Test that handlers must return metadata as dict."""
+    prep = Preprocessor()
+
+    def bad_handler(images, config):
+        return images, "not_a_dict"  # Returns string instead of dict
+
+    prep.register_handler("bad", bad_handler)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="Handler 'bad' must return metadata as dict"):
+        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
+
+
+def test_preprocessor_handler_returns_non_tensors():
+    """Test that handlers must return torch tensors."""
+    prep = Preprocessor()
+
+    def bad_handler(images, config):
+        return [np.zeros((10, 10, 3))], {}  # Returns numpy array
+
+    prep.register_handler("bad", bad_handler)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="Handler 'bad' returned non-tensor images"):
+        prep.preprocess(image, [{"type": "bad", "configuration": {}}])
+
+
 # --- Reconstructor Error Handling Tests ---
 
 
 def test_reconstructor_empty_images():
     recon = Reconstructor()
-    with pytest.raises(ValueError, match="No input images provided"):
+    with pytest.raises(ValueError, match="No input images provided for reconstruction"):
         recon.reconstruct([], [])
+
+
+def test_reconstructor_non_list_input():
+    """Test that reconstructor requires a list of images."""
+    recon = Reconstructor()
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(TypeError, match="Images must be a list"):
+        recon.reconstruct(image, [])  # Passing single image instead of list
 
 
 def test_reconstructor_invalid_image_type():
     recon = Reconstructor()
     with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
         recon.reconstruct(["not_an_image"], [])
+
+
+def test_reconstructor_mixed_image_types():
+    """Test that all images must be the same type."""
+    recon = Reconstructor()
     with pytest.raises(TypeError, match="All images must be the same type"):
         recon.reconstruct([torch.zeros((10, 10, 3)), np.zeros((10, 10, 3))], [])
 
 
-def test_reconstructor_invalid_ops_keys():
+def test_reconstructor_invalid_step_keys():
     recon = Reconstructor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
     # Missing 'op'
-    with pytest.raises(ValueError, match="Each operation step must contain keys"):
+    with pytest.raises(ValueError, match="Each step must contain keys"):
         recon.reconstruct([image], [{"metadata": {}}])
 
     # Missing 'metadata'
-    with pytest.raises(ValueError, match="Each operation step must contain keys"):
+    with pytest.raises(ValueError, match="Each step must contain keys"):
         recon.reconstruct([image], [{"op": "resize"}])
 
 
-def test_reconstructor_unsupported_undo():
+def test_reconstructor_unregistered_undo_handler():
     recon = Reconstructor()
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with pytest.raises(ValueError, match="No undo handler for unknown"):
+    with pytest.raises(ValueError, match="Undo handler for 'unknown' is not registered"):
         recon.reconstruct([image], [{"op": "unknown", "metadata": {}}])
+
+
+def test_reconstructor_register_non_callable():
+    """Test that undo handlers must be callable."""
+    recon = Reconstructor()
+    with pytest.raises(TypeError, match="Undo handler for 'test' must be callable"):
+        recon.register_undo_handler("test", "not_callable")
+
+
+def test_reconstructor_undo_handler_returns_non_list():
+    """Test that undo handlers must return a list of images."""
+    recon = Reconstructor()
+
+    def bad_undo_handler(images, metadata):
+        return images[0]  # Returns single image, not list
+
+    recon.register_undo_handler("bad", bad_undo_handler)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="Undo handler 'bad' must return a list of images"):
+        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
+
+
+def test_reconstructor_undo_handler_returns_non_tensors():
+    """Test that undo handlers must return torch tensors."""
+    recon = Reconstructor()
+
+    def bad_undo_handler(images, metadata):
+        return [np.zeros((10, 10, 3))]  # Returns numpy array
+
+    recon.register_undo_handler("bad", bad_undo_handler)
+    image = torch.zeros((10, 10, 3))
+
+    with pytest.raises(TypeError, match="Undo handler 'bad' returned non-tensor images"):
+        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
+
+
+def test_reconstructor_multiple_images_after_reconstruction():
+    """Test that reconstruction must result in exactly 1 image."""
+    recon = Reconstructor()
+
+    def bad_undo_handler(images, metadata):
+        # Returns 2 images instead of combining to 1
+        return [torch.zeros((10, 10, 3)), torch.zeros((10, 10, 3))]
+
+    recon.register_undo_handler("bad", bad_undo_handler)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(RuntimeError, match="Reconstruction expected 1 image, got 2"):
+        recon.reconstruct([image], [{"op": "bad", "metadata": {}}])
 
 
 def test_reconstructor_tile_integrity_failure():

--- a/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
@@ -38,7 +38,7 @@ def test_tiling_lossless_reconstruction(pipeline, input_type):
     assert isinstance(restored_image, type(input_image))
     if input_type == "torch":
         assert restored_image.shape == input_image.shape
-        assert torch.allclose(restored_image.float(), input_image.float())
+        assert torch.allclose(restored_image, input_image)
     else:
         assert restored_image.shape == input_image.shape
         assert np.allclose(restored_image, input_image)
@@ -72,73 +72,113 @@ def test_nested_pipeline_flow(pipeline, input_type):
 
 
 @pytest.mark.parametrize(
-    "shape, steps, expected_final_count, expected_final_shape, seed",
+    "input_shape, tile_configs, expected_count, final_shape",
     [
-        # Simple case: 77x64 -> 32x32 -> 16x16
-        (
-            (77, 64, 3),
-            [
-                {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
-                {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
-            ],
-            24,
-            (16, 16, 3),
-            42,
-        ),
-        # Case with overlap: 100x100 -> 50x50 -> 25x25
-        (
-            (100, 100, 3),
-            [
-                {"type": "tile", "configuration": {"tile_size": 50, "stride": 25}},
-                {"type": "tile", "configuration": {"tile_size": 25, "stride": 25}},
-            ],
-            36,
-            (25, 25, 3),
-            43,
-        ),
-        # Non-square: 128x64 -> 64x32 -> 32x16
-        (
-            (128, 64, 3),
-            [
-                {"type": "tile", "configuration": {"tile_size": [64, 32], "stride": [64, 32]}},
-                {"type": "tile", "configuration": {"tile_size": [32, 16], "stride": [32, 16]}},
-            ],
-            16,
-            (32, 16, 3),
-            44,
-        ),
-        # Triple nesting: 128x128 -> 64x64 -> 32x32 -> 16x16
-        (
-            (128, 128, 3),
-            [
-                {"type": "tile", "configuration": {"tile_size": 64, "stride": 64}},
-                {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
-                {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
-            ],
-            64,
-            (16, 16, 3),
-            45,
-        ),
+        ((77, 64, 3), [(32, 32), (16, 16)], 24, (16, 16, 3)),
+        ((100, 100, 3), [(50, 25), (25, 25)], 36, (25, 25, 3)),
+        ((128, 64, 3), [([64, 32], [64, 32]), ([32, 16], [32, 16])], 16, (32, 16, 3)),
+        ((128, 128, 3), [(64, 64), (32, 32), (16, 16)], 64, (16, 16, 3)),
     ],
+    ids=["simple", "overlap", "non_square", "triple_nesting"],
 )
-def test_nested_tiling_lossless(pipeline, shape, steps, expected_final_count, expected_final_shape, seed):
+def test_nested_tiling_lossless(pipeline, input_shape, tile_configs, expected_count, final_shape):
     prep, recon = pipeline
+    steps = [{"type": "tile", "configuration": {"tile_size": ts, "stride": st}} for ts, st in tile_configs]
 
-    # Use the seed to ensure different random images
-    rng = np.random.default_rng(seed)
-    input_image = rng.integers(0, 256, shape, dtype=np.uint8)
-
+    input_image = np.random.randint(0, 256, input_shape, dtype=np.uint8)
     final_images, ops = prep.preprocess(input_image, steps)
 
     # Ensure the number of tiles is right
-    assert len(final_images) == expected_final_count
+    assert len(final_images) == expected_count
 
     # Ensure the shapes of final images are right
     for img in final_images:
-        assert img.shape == expected_final_shape
+        assert img.shape == final_shape
 
     restored_image = recon.reconstruct(final_images, ops)
 
     assert isinstance(restored_image, np.ndarray)
     assert restored_image.shape == input_image.shape
     assert np.allclose(restored_image, input_image)
+
+
+@pytest.mark.parametrize("input_type", ["numpy", "torch"])
+def test_incremental_reconstruction(pipeline, input_type):
+    """Test that reconstruction works correctly at each stage of a multi-step pipeline."""
+
+    def check_integrity(original, restored):
+        is_list = isinstance(original, list)
+        if not is_list:
+            original = [original]
+        is_list_restored = isinstance(restored, list)
+        if not is_list_restored:
+            restored = [restored]
+        assert len(original) == len(restored)
+        for o, r in zip(original, restored):
+            if isinstance(o, torch.Tensor):
+                assert torch.allclose(r, o)
+            else:
+                assert np.allclose(r, o)
+
+    prep, recon = pipeline
+
+    if input_type == "torch":
+        input_images = [
+            torch.randint(0, 256, (128, 128, 3), dtype=torch.uint8),
+            torch.randint(0, 256, (121, 130, 3), dtype=torch.uint8),
+            torch.randint(0, 256, (150, 140, 3), dtype=torch.uint8),
+        ]
+    else:
+        input_images = [
+            np.random.randint(0, 256, (128, 128, 3), dtype=np.uint8),
+            np.random.randint(0, 256, (121, 130, 3), dtype=np.uint8),
+            np.random.randint(0, 256, (150, 140, 3), dtype=np.uint8),
+        ]
+
+    steps = [
+        {"type": "resize", "configuration": {"width": 64, "height": 64}},
+        {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
+        {"type": "tile", "configuration": {"tile_size": 16, "stride": 8}},
+        {"type": "tile", "configuration": {"tile_size": 8, "stride": 4}},
+    ]
+
+    intermediate_states = []
+    for i in range(len(steps)):
+        images, ops = prep.preprocess(input_images, steps[: i + 1])
+        intermediate_states.append((images, ops))
+
+    # verify reconstruction at each stage
+    for i in range(len(intermediate_states) - 1, 0, -1):  # skip resize because lossy
+        inputs = intermediate_states[i - 1][0]
+        images, ops = intermediate_states[i]
+        restored = recon.reconstruct(images, ops[-1:])
+        check_integrity(inputs, restored)
+
+
+def test_tiling_signle_channel_image(pipeline):
+    prep, recon = pipeline
+
+    input_images = [
+        torch.randint(0, 256, (100, 100), dtype=torch.uint8),  # Single channel image
+        torch.randint(0, 256, (120, 130, 1), dtype=torch.uint8),  # Single channel with channel dim
+        torch.randint(0, 256, (80, 90, 3), dtype=torch.uint8),  # Regular 3-channel image
+    ]
+
+    steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
+
+    final_images, ops = prep.preprocess(input_images, steps)
+
+    expected_tile_counts = [4, 9, 4]
+    assert len(final_images) == sum(expected_tile_counts)
+    for i in range(len(input_images)):
+        expected_shape = (50, 50) if input_images[i].dim() == 2 else (50, 50, input_images[i].shape[2])
+        for j in range(expected_tile_counts[i]):
+            idx = sum(expected_tile_counts[:i]) + j
+            assert final_images[idx].shape == expected_shape
+
+    restored_images = recon.reconstruct(final_images, ops)
+
+    for restored_image, input_image in zip(restored_images, input_images):
+        assert isinstance(restored_image, torch.Tensor)
+        assert restored_image.shape == input_image.shape
+        assert torch.allclose(restored_image, input_image)

--- a/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
@@ -69,5 +69,76 @@ def test_nested_pipeline_flow(pipeline, input_type):
     assert isinstance(restored_image, type(input_image))
     if input_type == "torch":
         assert restored_image.shape == (128, 128, 3)
-    else:
-        assert restored_image.shape == (128, 128, 3)
+
+
+@pytest.mark.parametrize(
+    "shape, steps, expected_final_count, expected_final_shape, seed",
+    [
+        # Simple case: 77x64 -> 32x32 -> 16x16
+        (
+            (77, 64, 3),
+            [
+                {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
+                {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
+            ],
+            24,
+            (16, 16, 3),
+            42,
+        ),
+        # Case with overlap: 100x100 -> 50x50 -> 25x25
+        (
+            (100, 100, 3),
+            [
+                {"type": "tile", "configuration": {"tile_size": 50, "stride": 25}},
+                {"type": "tile", "configuration": {"tile_size": 25, "stride": 25}},
+            ],
+            36,
+            (25, 25, 3),
+            43,
+        ),
+        # Non-square: 128x64 -> 64x32 -> 32x16
+        (
+            (128, 64, 3),
+            [
+                {"type": "tile", "configuration": {"tile_size": [64, 32], "stride": [64, 32]}},
+                {"type": "tile", "configuration": {"tile_size": [32, 16], "stride": [32, 16]}},
+            ],
+            16,
+            (32, 16, 3),
+            44,
+        ),
+        # Triple nesting: 128x128 -> 64x64 -> 32x32 -> 16x16
+        (
+            (128, 128, 3),
+            [
+                {"type": "tile", "configuration": {"tile_size": 64, "stride": 64}},
+                {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
+                {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
+            ],
+            64,
+            (16, 16, 3),
+            45,
+        ),
+    ],
+)
+def test_nested_tiling_lossless(pipeline, shape, steps, expected_final_count, expected_final_shape, seed):
+    prep, recon = pipeline
+
+    # Use the seed to ensure different random images
+    rng = np.random.default_rng(seed)
+    input_image = rng.integers(0, 256, shape, dtype=np.uint8)
+
+    final_images, ops = prep.preprocess(input_image, steps)
+
+    # Ensure the number of tiles is right
+    assert len(final_images) == expected_final_count
+
+    # Ensure the shapes of final images are right
+    for img in final_images:
+        assert img.shape == expected_final_shape
+
+    restored_image = recon.reconstruct(final_images, ops)
+
+    assert isinstance(restored_image, np.ndarray)
+    assert restored_image.shape == input_image.shape
+    assert np.allclose(restored_image, input_image)

--- a/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+import torch
+from preprocess_utils.preprocessor import Preprocessor
+from preprocess_utils.reconstructor import Reconstructor
+
+
+@pytest.fixture
+def pipeline():
+    """
+    Initializes the real Preprocessor and Reconstructor.
+    """
+    # Initialize classes
+    prep = Preprocessor()
+    recon = Reconstructor()
+
+    return prep, recon
+
+
+@pytest.mark.parametrize("input_type", ["numpy", "torch"])
+def test_tiling_lossless_reconstruction(pipeline, input_type):
+    prep, recon = pipeline
+
+    if input_type == "torch":
+        input_image = torch.randint(0, 256, (100, 100, 3), dtype=torch.uint8)
+    else:
+        input_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+
+    steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
+
+    final_images, ops = prep.preprocess(input_image, steps)
+
+    assert len(final_images) == 4
+    assert final_images[0].shape == (50, 50, 3)
+
+    restored_image = recon.reconstruct(final_images, ops)
+
+    assert isinstance(restored_image, type(input_image))
+    if input_type == "torch":
+        assert restored_image.shape == input_image.shape
+        assert torch.allclose(restored_image.float(), input_image.float())
+    else:
+        assert restored_image.shape == input_image.shape
+        assert np.allclose(restored_image, input_image)
+
+
+@pytest.mark.parametrize("input_type", ["numpy", "torch"])
+def test_nested_pipeline_flow(pipeline, input_type):
+    prep, recon = pipeline
+
+    if input_type == "torch":
+        input_image = torch.randint(0, 256, (128, 128, 3), dtype=torch.uint8)
+    else:
+        input_image = np.random.randint(0, 256, (128, 128, 3), dtype=np.uint8)
+
+    steps = [
+        {"type": "resize", "configuration": {"width": 64, "height": 64}},
+        {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
+        {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
+    ]
+
+    final_images, ops = prep.preprocess(input_image, steps)
+
+    assert len(final_images) == 16
+    assert final_images[0].shape == (16, 16, 3)
+
+    restored_image = recon.reconstruct(final_images, ops)
+
+    assert isinstance(restored_image, type(input_image))
+    if input_type == "torch":
+        assert restored_image.shape == (128, 128, 3)
+    else:
+        assert restored_image.shape == (128, 128, 3)

--- a/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
@@ -33,8 +33,10 @@ def test_tiling_lossless_reconstruction(pipeline, input_type):
     assert len(final_images) == 4
     assert final_images[0].shape == (50, 50, 3)
 
-    restored_image = recon.reconstruct(final_images, ops)
+    restored_images = recon.reconstruct(final_images, ops)
 
+    assert len(restored_images) == 1
+    restored_image = restored_images[0]
     assert isinstance(restored_image, type(input_image))
     if input_type == "torch":
         assert restored_image.shape == input_image.shape
@@ -64,7 +66,9 @@ def test_nested_pipeline_flow(pipeline, input_type):
     assert len(final_images) == 16
     assert final_images[0].shape == (16, 16, 3)
 
-    restored_image = recon.reconstruct(final_images, ops)
+    restored_images = recon.reconstruct(final_images, ops)
+    assert len(restored_images) == 1
+    restored_image = restored_images[0]
 
     assert isinstance(restored_image, type(input_image))
     if input_type == "torch":
@@ -95,7 +99,9 @@ def test_nested_tiling_lossless(pipeline, input_shape, tile_configs, expected_co
     for img in final_images:
         assert img.shape == final_shape
 
-    restored_image = recon.reconstruct(final_images, ops)
+    restored_images = recon.reconstruct(final_images, ops)
+    assert len(restored_images) == 1
+    restored_image = restored_images[0]
 
     assert isinstance(restored_image, np.ndarray)
     assert restored_image.shape == input_image.shape
@@ -155,7 +161,7 @@ def test_incremental_reconstruction(pipeline, input_type):
         check_integrity(inputs, restored)
 
 
-def test_tiling_signle_channel_image(pipeline):
+def test_tiling_images_with_varying_channels(pipeline):
     prep, recon = pipeline
 
     input_images = [

--- a/tests/lmi_utils/preprocess_utils/test_preprocessor.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocessor.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.INFO)
     "im, wh, par",
     [
         (torch.rand(100, 100, 3).numpy(), [151, 131], True),
-        (torch.rand(100, 100, 3).numpy(), [71, 75], False),
+        (torch.rand(100, 100, 3), [71, 75], False),
     ],
 )
 def test_preprocessor_resize(im, wh, par):
@@ -24,8 +24,10 @@ def test_preprocessor_resize(im, wh, par):
             "configuration": {"width": wh[0], "height": wh[1], "preserve_aspect": par},
         }
     ]
-    im_out, operators = preprocessor.preprocess(im, processing_steps)
+    ims, operators = preprocessor.preprocess(im, processing_steps)
+    im_out = ims[0]
     expected_w = wh[0] if wh[0] is not None else im.shape[1]
     expected_h = wh[1] if wh[1] is not None else im.shape[0]
     assert im_out.shape[1] == expected_w
     assert im_out.shape[0] == expected_h
+    assert isinstance(im_out, type(im))


### PR DESCRIPTION
1. support tiling for preprocessor
2. add reconstructor to revert back to original image
3. refactor and modify the resize_and_pad to handle tensors
4. In Tiler, tile and untile accept both string and enum argument types
5. add test cases