### PR TITLE
chore: guard legacy operators for OD predict

### DIFF
--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -269,10 +269,26 @@ class ODBase(abc.ABC):
         if not operators:
             return [[] for _ in range(batch_size)]
         if isinstance(operators[0], dict):
+            ODBase._reject_preprocessor_history(operators)
             return [list(operators) for _ in range(batch_size)]
         if len(operators) != batch_size:
             raise ValueError(f"operators length ({len(operators)}) must match batch size ({batch_size})")
+        for chain in operators:
+            if chain and isinstance(chain[0], dict):
+                ODBase._reject_preprocessor_history(chain)
         return operators
+
+    @staticmethod
+    def _reject_preprocessor_history(chain: list) -> None:
+        # Preprocessor.preprocess() returns history dicts with keys {"type","metadata"};
+        # od_base expects legacy revert_to_origin dicts keyed by op name (resize/pad/stretch/flip).
+        # Passing the former silently corrupts coordinates, so fail fast with a redirect.
+        if any(isinstance(op, dict) and "type" in op and "metadata" in op for op in chain):
+            raise ValueError(
+                "Operators appears to be a Preprocessor history (dicts with 'type'/'metadata'). "
+                "Use self.revert_preprocess(results, ops_list) to invert a Preprocessor pipeline. "
+                "Or, pass legacy revert_to_origin list of dicts with 'resize'/'pad'/'stretch'/'flip' keys."
+            )
 
     def _revert_coordinates(self, results: dict, operators: list, **kwargs) -> dict:
         """Revert prediction coordinates to the original pre-transform space.

--- a/tests/object_detectors/od_core/test_normalize_operators.py
+++ b/tests/object_detectors/od_core/test_normalize_operators.py
@@ -1,0 +1,41 @@
+import pytest
+
+from object_detectors.od_core.od_base import ODBase
+
+
+def test_none_operators_returns_empty_per_image():
+    assert ODBase._normalize_operators(None, 3) == [[], [], []]
+
+
+def test_single_chain_broadcasts_to_batch():
+    chain = [{"resize": [640, 640, 1280, 720]}, {"pad": [0, 0, 80, 80]}]
+    result = ODBase._normalize_operators(chain, 2)
+    assert result == [chain, chain]
+
+
+def test_per_image_chains_passthrough():
+    chains = [[{"resize": [640, 640, 1280, 720]}], [{"pad": [0, 0, 80, 80]}]]
+    assert ODBase._normalize_operators(chains, 2) == chains
+
+
+def test_length_mismatch_raises():
+    chains = [[{"resize": [640, 640, 1280, 720]}]]
+    with pytest.raises(ValueError, match="must match batch size"):
+        ODBase._normalize_operators(chains, 2)
+
+
+def test_preprocessor_history_flat_chain_rejected():
+    history = [
+        {"type": "resize", "metadata": [{"orig_size": [1280, 720], "new_size": [640, 640]}]},
+    ]
+    with pytest.raises(ValueError, match="Preprocessor history"):
+        ODBase._normalize_operators(history, 2)
+
+
+def test_preprocessor_history_per_image_rejected():
+    history_per_image = [
+        [{"type": "resize", "metadata": [{"orig_size": [1280, 720], "new_size": [640, 640]}]}],
+        [{"type": "tile", "metadata": [{"grid": [2, 2]}]}],
+    ]
+    with pytest.raises(ValueError, match="Preprocessor history"):
+        ODBase._normalize_operators(history_per_image, 2)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary

<!-- One sentence describing what this PR does and why. --> The schema of global preprocess metadata and the schema of legacy revert_to_origin are different.  Fail if the history ops are fed into OD predict().

**Type:** <!-- feat | fix | chore | refactor | test | docs | ci --> chore

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
