### PR TITLE
feat!: support gofactory 3 manifest schema.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 LMI AI Solutions is a Python monorepo providing unified wrappers for AI/ML model frameworks used in industrial computer vision: object detection, anomaly detection, and classification.
 
+## Working Rules
+
+- **No assumptions.** When something is unclear, ask before implementing. Do not invent based on guesses.
+- **Keep this file concise.** Prefer pointers to source files over duplicated detail. Remove anything derivable from the code itself.
+- **Update on significant changes.** When introducing a new domain, base class, top-level pattern, or breaking change to existing architecture, update this file in the same change.
+
 ## Commands
 
 ### Installation
@@ -44,26 +50,12 @@ All three domains (`od_core/`, `ad_core/`, `cls_core/`) share the same pattern: 
 
 Every backend implements exactly four abstract methods — `warmup`, `preprocess`, `forward`, `postprocess` — and the base class orchestrates the full inference pipeline.
 
-### ADBase (`ad_core/ad_base.py`)
+### Domain base classes
 
-- `predict(image, batch_size=None)` — accepts a single image, list, or BHWC numpy/tensor batch. When `batch_size` is set, delegates to `_run_batched_predict` which chunks inputs **before** preprocessing. Set `self.fixed_batch_size` on TRT subclasses for automatic zero-padding.
-- `annotate(img, ad_scores, ad_threshold, ad_max)` — GPU-accelerated turbo-colormap heatmap overlay; returns `uint8` HWC numpy.
-- `colormap_tensor` — lazily initialized `[256, 3]` turbo LUT on `self.device`.
-
-### Anomalib_Base (`anomalib_lmi/base.py`)
-
-Subclasses `ADBase`; shared by v1 and v2 backends. Adds:
-- `_load_tensorrt_model` — loads TRT engine, sets `fixed_batch_size`, shape, fp16.
-- `convert(model_path, export_path, fp16=True, convert_type="trt")` — `.pt` → ONNX → TRT.
-- `test(images_path, ...)` — evaluation with gamma-fit threshold suggestions, CSV stats, optional tiling, annotated outputs.
-
-### ODBase (`od_core/od_base.py`)
-
-- `predict(image, configs, operators=None, batch_size=None)` — returns `(results_dict, time_info)`. `results_dict` keys: `boxes`, `scores`, `classes`, `masks`, `segments`, `points` (each a per-image list). Fixed-batch TRT engines are zero-padded.
-- `annotate_image(results, image, ...)` — draws boxes, masks, segments, keypoints; handles OBB.
-- Helpers: `_parse_confidence_config`, `_apply_confidence_filter`, `_normalize_operators`, `_revert_coordinates`, `_aggregate_results`.
-
-`Results` (`od_core/results.py`) — all numeric fields stored as `torch.Tensor`; defaults to empty tensors so `to_dict()` is safe with zero detections.
+- AD: `ad_core/ad_base.py` — orchestrates AD inference, GPU heatmap annotation.
+- AD (Anomalib): `anomalib_lmi/base.py` — extends `ADBase` with TRT loading, `.pt` → ONNX → TRT export, and evaluation.
+- OD: `od_core/od_base.py` — orchestrates OD inference; `Results` (`od_core/results.py`) stores numeric fields as `torch.Tensor` (empty by default, so zero-detection cases are safe).
+- CLS: `cls_core/cls_base.py` — orchestrates classification inference.
 
 ### CI/CD
 

--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -218,16 +218,24 @@ OD model role from gofactory:
 ```json
 "od-model": {
     "format": "pt",
-    "configs": {},
-    "details": {
-        "training_package": "Ultralytics",
-        "training_algorithm": "Yolo",
-        "global_preprocessing": [{"type": "resize", "configuration": {"height": 640, "width": 640}}],
+    "configs": {
+        "to-fail": {"defect_a": true},
+        "confidence": {"defect_a": 0.5}
     },
-    "artifacts": {"pt": {"image_size": [640, 640], "model_path": model_path}},
+    "details": {
+        "classes": ["defect_a"],
+        "image_size": [640, 640],
+        "preprocessing": [
+            {"type": "resize", "configuration": {"height": 640, "width": 640, "preserve_aspect": true}}
+        ],
+        "training_package": "Ultralytics",
+        "training_algorithm": "Yolo"
+    },
+    "artifacts": {"pt": {"attributes": {}, "model_path": model_path}},
     "model_role": "od-model",
+    "model_name": "od-model",
     "model_type": "InstanceSegmentation",
-    "model_version": "1",
+    "model_version": "1"
 }
 ```
 
@@ -265,19 +273,21 @@ AD model role from gofactory:
 ```json
 "ad-model": {
     "format": "pt",
-    "configs": {},
+    "configs": {"min_threshold": 0.0, "max_threshold": 1.0},
     "details": {
-        "training_package": "Anomalib1",
-        "training_algorithm": "Patchcore",
-        "global_preprocessing": [
-            {"type": "resize", "configuration": {"height": 224, "width": 448}},
-            {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
+        "image_size": [224, 224],
+        "preprocessing": [
+            {"type": "resize", "configuration": {"height": 224, "width": 448, "preserve_aspect": true}},
+            {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}}
         ],
+        "training_package": "Anomalib1",
+        "training_algorithm": "Patchcore"
     },
-    "artifacts": {"pt": {"image_size": [224, 224], "model_path": model_path}},
+    "artifacts": {"pt": {"attributes": {}, "model_path": model_path}},
     "model_role": "ad-model",
+    "model_name": "ad-model",
     "model_type": "AnomalyDetection",
-    "model_version": "1",
+    "model_version": "1"
 }
 ```
 

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -674,10 +674,30 @@ def load_pipeline_def(filepath):
     return kwargs
 
 
+def _resolve_artifact_paths(model: Dict[str, Any], manifest_dir: Path) -> None:
+    """Resolve relative artifact model_path values in-place against manifest_dir."""
+    for _, artifact_data in model.get("artifacts", {}).items():
+        raw_path = artifact_data.get("model_path")
+        if raw_path:
+            path_obj = Path(raw_path)
+            if not path_obj.is_absolute():
+                artifact_data["model_path"] = str((manifest_dir / path_obj).resolve())
+
+
 def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
     """
     Create models manifest from a static manifest json file.
+
+    Args:
+        manifest_json_path (str): path to the manifest JSON file.
+        **kwargs: optional keyword arguments. Recognized:
+            version (str): schema version of the manifest. Defaults to "3".
+                "2" expects flat fields under `details` and synthesizes a `configs` block;
+                "3" expects a manifest already shaped per schema_3 and only resolves
+                artifact paths.
     """
+    version = kwargs.get("version", "3")
+    logger.info(f"Loading static manifest from {manifest_json_path} with schema version {version}")
     manifest_path = Path(manifest_json_path).resolve()
     if not manifest_path.exists():
         raise FileNotFoundError(f"Manifest file not found: {manifest_path}")
@@ -685,7 +705,20 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
     with open(manifest_path, "r") as f:
         models: List[Dict[str, Any]] = json.load(f)
 
-    manifest = {}
+    manifest: Dict[str, Any] = {}
+
+    if version == "3":
+        for model in models:
+            role = model.get("model_role")
+            if role is None:
+                continue
+            _resolve_artifact_paths(model, manifest_path.parent)
+            manifest[role] = model
+        return manifest
+
+    if version != "2":
+        raise ValueError(f"Unsupported static manifest version: {version}")
+
     keys_to_copy = ["anomaly_size", "threshold_max", "threshold_min", "iou"]
 
     for model in models:
@@ -693,15 +726,7 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
         if role is None:
             continue
 
-        # Update model paths
-        artifacts = model.get("artifacts", {})
-        for _, artifact_data in artifacts.items():
-            raw_path = artifact_data.get("model_path")
-            if raw_path:
-                path_obj = Path(raw_path)
-                # Resolve relative paths against the JSON file's directory
-                if not path_obj.is_absolute():
-                    artifact_data["model_path"] = str((manifest_path.parent / path_obj).resolve())
+        _resolve_artifact_paths(model, manifest_path.parent)
 
         # Create object configs
         model["configs"] = {}

--- a/lmi_utils/pipeline_base/core/schemas/schema_3.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_3.py
@@ -1,0 +1,138 @@
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Annotated
+
+
+class Artifact(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    model_path: str = ""
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PreprocessStep(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    configuration: Dict[str, Any]
+    id: Optional[str] = None
+
+
+class Details(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    image_size: List[int] = Field(default_factory=list)
+    preprocessing: List[PreprocessStep] = Field(default_factory=list)
+    training_package: str = ""
+    training_algorithm: str = ""
+    confidence_threshold: Optional[float] = None
+    classes: Optional[List[str]] = None
+
+
+class ODConfigs(BaseModel):
+    """Configs for ObjectDetection / InstanceSegmentation."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    to_fail: Dict[str, bool] = Field(default_factory=dict, alias="to-fail")
+    confidence: Dict[str, float] = Field(default_factory=dict)
+
+
+class ADConfigs(BaseModel):
+    """Configs for AnomalyDetection."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    min_threshold: float
+    max_threshold: float
+
+
+class _ModelBase(BaseModel):
+    model_config = ConfigDict(extra="ignore", protected_namespaces=())
+
+    model_role: str
+    model_name: str
+    model_version: str
+    format: str
+    artifacts: Dict[str, Artifact] = Field(default_factory=dict)
+    details: Details
+
+    def get_metadata(self) -> Dict[str, Any]:
+        artifact = self.artifacts.get(self.format)
+        return {
+            "model_path": artifact.model_path if artifact else "",
+            "image_size": self.details.image_size,
+            "model_type": self.model_type.lower(),
+            "algorithm": self.details.training_algorithm.lower(),
+            "package": self.details.training_package.lower(),
+        }
+
+
+class ODModel(_ModelBase):
+    model_type: Literal["ObjectDetection", "InstanceSegmentation"]
+    configs: ODConfigs
+
+
+class ADModel(_ModelBase):
+    model_type: Literal["AnomalyDetection"]
+    configs: ADConfigs
+
+
+Model = Annotated[
+    Union[ODModel, ADModel],
+    Field(discriminator="model_type"),
+]
+
+
+class ModelCollection(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
+    models: Dict[str, Model]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ModelCollection":
+        return cls.model_validate({"models": {k: v for k, v in data.items() if v is not None}})
+
+    def get_metadata(self) -> Dict[str, Any]:
+        return {role: model.get_metadata() for role, model in self.models.items()}
+
+    def get_preprocessing(self) -> Dict[str, List[Dict[str, Any]]]:
+        supported = {"resize", "tile"}
+        tiling_keys = {"height", "width", "x_stride", "y_stride"}
+
+        out: Dict[str, List[Dict[str, Any]]] = {}
+        for role, model in self.models.items():
+            ops: List[Dict[str, Any]] = []
+            for step in model.details.preprocessing:
+                if step.type not in supported:
+                    raise ValueError(f"Unsupported type '{step.type}'.")
+                if step.type == "tile":
+                    if not tiling_keys.issubset(step.configuration.keys()):
+                        raise ValueError(f"Tiling configuration must contain keys: {tiling_keys}.")
+                    cfg = step.configuration
+                    ops.append(
+                        {
+                            "type": "tile",
+                            "configuration": {
+                                "tile_size": [cfg["height"], cfg["width"]],
+                                "stride": [cfg["y_stride"], cfg["x_stride"]],
+                            },
+                        }
+                    )
+                else:
+                    ops.append(step.model_dump(exclude_none=True))
+            out[role] = ops
+        return out
+
+
+class ModelSchemaV_3:
+    """Schema for model version 3."""
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> ModelCollection:
+        return ModelCollection.from_dict(data)
+
+    @staticmethod
+    def get_metadata(model_collection: ModelCollection) -> Dict[str, Any]:
+        return model_collection.get_metadata()

--- a/lmi_utils/pipeline_base/core/schemas/schema_3.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_3.py
@@ -97,7 +97,7 @@ class ModelCollection(BaseModel):
     def get_metadata(self) -> Dict[str, Any]:
         return {role: model.get_metadata() for role, model in self.models.items()}
 
-    def get_preprocessing(self) -> Dict[str, List[Dict[str, Any]]]:
+    def get_global_preprocessing(self) -> Dict[str, List[Dict[str, Any]]]:
         supported = {"resize", "tile"}
         tiling_keys = {"height", "width", "x_stride", "y_stride"}
 

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -26,6 +26,7 @@ from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 from object_detectors.od_core.object_detector import ObjectDetector
 
 from .core.schemas.schema_2 import ModelSchemaV_2
+from .core.schemas.schema_3 import ModelSchemaV_3
 
 
 class PipelineBase(metaclass=ABCMeta):
@@ -62,6 +63,7 @@ class PipelineBase(metaclass=ABCMeta):
     _MODEL_ROLES_HANDLERS = {
         "1": None,  # no longer supported
         "2": ModelSchemaV_2.from_dict,
+        "3": ModelSchemaV_3.from_dict,
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -79,7 +81,7 @@ class PipelineBase(metaclass=ABCMeta):
         """
         self.models = collections.OrderedDict()
         self._preprocessing = collections.OrderedDict()
-        self.version = kwargs.get("version", "2")
+        self.version = kwargs.get("version", "3")
         self.preprocessor = Preprocessor()
         self.reconstructor = Reconstructor()
         self.init_results()
@@ -209,7 +211,9 @@ class PipelineBase(metaclass=ABCMeta):
 
         Returns:
             list[ImageLike]: the preprocessed image(s).
-            list[dict]: the preprocessing steps.
+            list[dict]: the preprocessing steps, each with keys:
+                - "type" (str): the type of the preprocessing operation.
+                - "metadata" (list): the metadata returned by the preprocessing operation, used for reconstruction.
         """
         if model_role not in self._preprocessing:
             raise ValueError(f"Not found global preprocessing steps for model role: {model_role}")
@@ -220,7 +224,7 @@ class PipelineBase(metaclass=ABCMeta):
         """Invert preprocessing transforms on either image data (AD) or detection coordinates (OD).
 
         Dispatches based on the type of ``data``:
-        - ``list`` → invert spatial transforms on images or score maps (AD path).
+        - ``list`` → invert spatial transforms on images (AD path, including anomaly score maps).
         - ``dict`` → revert coordinates to original image space (OD path).
 
         Pairs with ``preprocess()`` as its inverse.
@@ -231,7 +235,8 @@ class PipelineBase(metaclass=ABCMeta):
             ops (list[dict]): Preprocessing history returned by preprocess().
 
         Returns:
-            type: list for AD path or dict for OD path.
+            list[ImageLike] for the AD path (reconstructed images), or
+            dict for the OD path (results with coordinates reverted to original image space).
         """
         if isinstance(data, dict):
             return self.reconstructor.reconstruct_coordinates(data, ops)

--- a/tests/lmi_utils/pipeline_base/schema3.json
+++ b/tests/lmi_utils/pipeline_base/schema3.json
@@ -1,0 +1,200 @@
+{
+  "top_seg_foreground": {
+    "format": "pt",
+    "configs": {
+      "to-fail": {
+        "board": true
+      },
+      "confidence": {
+        "board": 0.5
+      }
+    },
+    "details": {
+      "classes": [
+        "board"
+      ],
+      "image_size": [
+        640,
+        640
+      ],
+      "preprocessing": [
+        {
+          "id": "2f79f4ac-4d3d-47bf-913b-24ff9817e374",
+          "type": "resize",
+          "configuration": {
+            "width": 640,
+            "height": 640,
+            "preserve_aspect": true
+          }
+        }
+      ],
+      "training_package": "Ultralytics8",
+      "training_algorithm": "Yolo",
+      "confidence_threshold": 0.5
+    },
+    "artifacts": {
+      "pt": {
+        "attributes": {},
+        "model_path": "/app/models/top_seg_foreground/InstanceSegmentation/top-foreground/1/model.pt"
+      },
+      "onnx": {
+        "attributes": {},
+        "model_path": "/app/models/top_seg_foreground/InstanceSegmentation/top-foreground/1/model.onnx"
+      }
+    },
+    "model_name": "top-foreground",
+    "model_role": "top_seg_foreground",
+    "model_type": "InstanceSegmentation",
+    "model_version": "1"
+  },
+  "top_ad": {
+    "format": "torchscript",
+    "configs": {
+      "max_threshold": 24.5,
+      "min_threshold": 18.1
+    },
+    "details": {
+      "image_size": [
+        224,
+        224
+      ],
+      "preprocessing": [],
+      "training_package": "Anomalib1",
+      "training_algorithm": "PatchCore"
+    },
+    "artifacts": {
+      "onnx": {
+        "attributes": {},
+        "model_path": "/app/models/top_ad/AnomalyDetection/Anomaly/1/model.onnx"
+      },
+      "torchscript": {
+        "attributes": {},
+        "model_path": "/app/models/top_ad/AnomalyDetection/Anomaly/1/model.torchscript"
+      }
+    },
+    "model_name": "Anomaly",
+    "model_role": "top_ad",
+    "model_type": "AnomalyDetection",
+    "model_version": "1"
+  },
+  "top_od_defect": {
+    "format": "pt",
+    "configs": {
+      "to-fail": {
+        "IL_Grooves": true,
+        "KE_Wrinkle": true,
+        "LC_Die_Line": true,
+        "I3_Cold_Spot": true,
+        "L8_Tear_Drag": true,
+        "ZH_Streaking": true,
+        "ZK_Fish_Eyes": true,
+        "Operator_Hand": true,
+        "ZL_Water_Spots": true,
+        "K2_Damage_Gouge": true,
+        "KF_Blister_Edge": true,
+        "K7_Streaker_Bumps": true,
+        "ZP_Embossing_Shine": true,
+        "IF_Cleanout_Startup": true,
+        "I6_Cracks_Bad_Corners": true,
+        "KD_Cold_Shell_Deposit": true,
+        "ZG_Base_Color_Too_Dark": true,
+        "JW_Contamination_Rubber": true,
+        "LA_Blister_Core_Moisture": true,
+        "I9_Surface_Roughness_Pits": true,
+        "LB_Blister_Shell_Moisture": true,
+        "ACG_Embossing_Not_Centered": true,
+        "JH_Contamination_Hard_Plastic": true,
+        "I5_Embossing_Equipment_Failure": true,
+        "ACH_Embossing_Primary_not_at_edge": true
+      },
+      "confidence": {
+        "IL_Grooves": 0.5,
+        "KE_Wrinkle": 0.5,
+        "LC_Die_Line": 0.5,
+        "I3_Cold_Spot": 0.5,
+        "L8_Tear_Drag": 0.5,
+        "ZH_Streaking": 0.5,
+        "ZK_Fish_Eyes": 0.5,
+        "Operator_Hand": 0.5,
+        "ZL_Water_Spots": 0.5,
+        "K2_Damage_Gouge": 0.5,
+        "KF_Blister_Edge": 0.5,
+        "K7_Streaker_Bumps": 0.5,
+        "ZP_Embossing_Shine": 0.5,
+        "IF_Cleanout_Startup": 0.5,
+        "I6_Cracks_Bad_Corners": 0.5,
+        "KD_Cold_Shell_Deposit": 0.5,
+        "ZG_Base_Color_Too_Dark": 0.5,
+        "JW_Contamination_Rubber": 0.5,
+        "LA_Blister_Core_Moisture": 0.5,
+        "I9_Surface_Roughness_Pits": 0.5,
+        "LB_Blister_Shell_Moisture": 0.5,
+        "ACG_Embossing_Not_Centered": 0.5,
+        "JH_Contamination_Hard_Plastic": 0.5,
+        "I5_Embossing_Equipment_Failure": 0.5,
+        "ACH_Embossing_Primary_not_at_edge": 0.5
+      }
+    },
+    "details": {
+      "classes": [
+        "IL_Grooves",
+        "KE_Wrinkle",
+        "LC_Die_Line",
+        "I3_Cold_Spot",
+        "L8_Tear_Drag",
+        "ZH_Streaking",
+        "ZK_Fish_Eyes",
+        "Operator_Hand",
+        "ZL_Water_Spots",
+        "K2_Damage_Gouge",
+        "KF_Blister_Edge",
+        "K7_Streaker_Bumps",
+        "ZP_Embossing_Shine",
+        "IF_Cleanout_Startup",
+        "I6_Cracks_Bad_Corners",
+        "KD_Cold_Shell_Deposit",
+        "ZG_Base_Color_Too_Dark",
+        "JW_Contamination_Rubber",
+        "LA_Blister_Core_Moisture",
+        "I9_Surface_Roughness_Pits",
+        "LB_Blister_Shell_Moisture",
+        "ACG_Embossing_Not_Centered",
+        "JH_Contamination_Hard_Plastic",
+        "I5_Embossing_Equipment_Failure",
+        "ACH_Embossing_Primary_not_at_edge"
+      ],
+      "image_size": [
+        640,
+        640
+      ],
+      "preprocessing": [
+        {
+          "id": "48b25381-d9cf-491e-87f8-959fbdc84171",
+          "type": "resize",
+          "configuration": {
+            "width": 640,
+            "height": 640,
+            "preserve_aspect": true
+          }
+        }
+      ],
+      "training_package": "Ultralytics8",
+      "training_algorithm": "Yolo",
+      "confidence_threshold": 0.5
+    },
+    "artifacts": {
+      "pt": {
+        "attributes": {},
+        "model_path": "/app/models/top_od_defect/ObjectDetection/top-defect/1/model.pt"
+      },
+      "onnx": {
+        "attributes": {},
+        "model_path": "/app/models/top_od_defect/ObjectDetection/top-defect/1/model.onnx"
+      }
+    },
+    "model_name": "top-defect",
+    "model_role": "top_od_defect",
+    "model_type": "ObjectDetection",
+    "model_version": "1"
+  }
+}

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -54,35 +54,59 @@ class PipelineOD(PipelineBase):
         }
 
 
+def _build_od_model_roles(version, model_path, preprocessing_steps):
+    if version == "2":
+        return {
+            "mock-model": {
+                "format": "pt",
+                "configs": {},
+                "details": {
+                    "training_package": "Ultralytics",
+                    "training_algorithm": "Yolo",
+                    "global_preprocessing": preprocessing_steps,
+                },
+                "artifacts": {"pt": {"image_size": [640, 640], "model_path": model_path}},
+                "model_role": "mock-model",
+                "model_type": "InstanceSegmentation",
+                "model_version": "1",
+            }
+        }
+    if version == "3":
+        return {
+            "mock-model": {
+                "format": "pt",
+                "configs": {"to-fail": {}, "confidence": {}},
+                "details": {
+                    "image_size": [640, 640],
+                    "preprocessing": preprocessing_steps,
+                    "training_package": "Ultralytics",
+                    "training_algorithm": "Yolo",
+                },
+                "artifacts": {"pt": {"attributes": {}, "model_path": model_path}},
+                "model_role": "mock-model",
+                "model_name": "mock-model",
+                "model_type": "InstanceSegmentation",
+                "model_version": "1",
+            }
+        }
+    raise ValueError(f"Unsupported schema version: {version}")
+
+
 @pytest.mark.parametrize(
-    "preprocessing_steps, expected_types",
+    "version, preprocessing_steps, expected_types",
     [
-        ([{"type": "resize", "configuration": {"height": 640, "width": 640}}], ["resize"]),
+        ("2", [{"type": "resize", "configuration": {"height": 640, "width": 640}}], ["resize"]),
+        ("3", [{"type": "resize", "configuration": {"height": 640, "width": 640, "preserve_aspect": True}}], ["resize"]),
     ],
 )
-def test_pipeline_OD(preprocessing_steps, expected_types):
+def test_pipeline_OD(version, preprocessing_steps, expected_types):
     # Asset paths
     model_path = os.path.abspath("tests/assets/models/od/ultralytics/yolo11n-seg.pt")
     image_dir = os.path.abspath("tests/assets/images/coco")
 
-    # Mock model_roles (Schema V2)
-    model_roles = {
-        "mock-model": {
-            "format": "pt",
-            "configs": {},
-            "details": {
-                "training_package": "Ultralytics",
-                "training_algorithm": "Yolo",
-                "global_preprocessing": preprocessing_steps,
-            },
-            "artifacts": {"pt": {"image_size": [640, 640], "model_path": model_path}},
-            "model_role": "mock-model",
-            "model_type": "InstanceSegmentation",
-            "model_version": "1",
-        }
-    }
+    model_roles = _build_od_model_roles(version, model_path, preprocessing_steps)
 
-    pipeline = PipelineOD(version="2")
+    pipeline = PipelineOD(version=version)
     pipeline.load(model_roles, {})
 
     # Load images
@@ -141,11 +165,59 @@ class PipelineAD(PipelineBase):
         }
 
 
+def _build_ad_model_roles(version, model_path, preprocessing_steps):
+    if version == "2":
+        return {
+            "mock-model": {
+                "format": "pt",
+                "configs": {},
+                "details": {
+                    "training_package": "Anomalib1",
+                    "training_algorithm": "Patchcore",
+                    "global_preprocessing": preprocessing_steps,
+                },
+                "artifacts": {"pt": {"image_size": [224, 224], "model_path": model_path}},
+                "model_role": "mock-model",
+                "model_type": "AnomalyDetection",
+                "model_version": "1",
+            }
+        }
+    if version == "3":
+        return {
+            "mock-model": {
+                "format": "pt",
+                "configs": {"min_threshold": 0.0, "max_threshold": 1.0},
+                "details": {
+                    "image_size": [224, 224],
+                    "preprocessing": preprocessing_steps,
+                    "training_package": "Anomalib1",
+                    "training_algorithm": "Patchcore",
+                },
+                "artifacts": {"pt": {"attributes": {}, "model_path": model_path}},
+                "model_role": "mock-model",
+                "model_name": "mock-model",
+                "model_type": "AnomalyDetection",
+                "model_version": "1",
+            }
+        }
+    raise ValueError(f"Unsupported schema version: {version}")
+
+
 @pytest.mark.parametrize(
-    "preprocessing_steps, expected_types",
+    "version, preprocessing_steps, expected_types",
     [
-        ([{"type": "resize", "configuration": {"height": 224, "width": 224}}], ["resize"]),
+        ("2", [{"type": "resize", "configuration": {"height": 224, "width": 224}}], ["resize"]),
         (
+            "2",
+            [
+                {"type": "resize", "configuration": {"height": 224, "width": 448}},
+                {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
+            ],
+            ["resize", "tile"],
+        ),
+        ("3", [{"type": "resize", "configuration": {"height": 224, "width": 224}}], ["resize"]),
+        (
+            "3",
             [
                 {"type": "resize", "configuration": {"height": 224, "width": 448}},
                 {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
@@ -154,29 +226,14 @@ class PipelineAD(PipelineBase):
         ),
     ],
 )
-def test_pipeline_AD(preprocessing_steps, expected_types):
+def test_pipeline_AD(version, preprocessing_steps, expected_types):
     # Asset paths
     model_path = os.path.abspath("tests/assets/models/ad/model_v1_trace.pt")
     image_dir = os.path.abspath("tests/assets/images/nvtec-ad")
 
-    # Mock model_roles (Schema V2)
-    model_roles = {
-        "mock-model": {
-            "format": "pt",
-            "configs": {},
-            "details": {
-                "training_package": "Anomalib1",
-                "training_algorithm": "Patchcore",
-                "global_preprocessing": preprocessing_steps,
-            },
-            "artifacts": {"pt": {"image_size": [224, 224], "model_path": model_path}},
-            "model_role": "mock-model",
-            "model_type": "AnomalyDetection",
-            "model_version": "1",
-        }
-    }
+    model_roles = _build_ad_model_roles(version, model_path, preprocessing_steps)
 
-    pipeline = PipelineAD(version="2")
+    pipeline = PipelineAD(version=version)
     pipeline.load(model_roles, {})
 
     # Load images

--- a/tests/lmi_utils/pipeline_base/test_schema3.py
+++ b/tests/lmi_utils/pipeline_base/test_schema3.py
@@ -1,0 +1,92 @@
+import json
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from lmi_utils.pipeline_base.core.schemas.schema_3 import (
+    ADConfigs,
+    ADModel,
+    ModelCollection,
+    ModelSchemaV_3,
+    ODConfigs,
+    ODModel,
+)
+
+logger = logging.getLogger(__name__)
+
+KEYS = {"model_type", "model_path", "image_size", "algorithm", "package"}
+
+
+@pytest.fixture
+def schema3():
+    with open("tests/lmi_utils/pipeline_base/schema3.json", "r") as f:
+        return json.load(f)
+
+
+def test_schema3(schema3):
+    data = ModelSchemaV_3.from_dict(schema3)
+    models = data.get_metadata()
+
+    assert isinstance(data, ModelCollection)
+
+    for _key, model in models.items():
+        assert isinstance(model, dict)
+        assert set(model.keys()) == KEYS
+        assert len(model["model_path"]) > 0
+        assert len(model["image_size"]) > 0
+        assert len(model["algorithm"]) > 0
+        assert len(model["package"]) > 0
+
+    preprocessing = data.get_preprocessing()
+    assert isinstance(preprocessing, dict)
+    for _key, ops in preprocessing.items():
+        assert isinstance(ops, list)
+        for op in ops:
+            assert isinstance(op, dict)
+            assert "type" in op
+            assert "configuration" in op
+            assert op["type"] in {"resize", "tile"}
+            if op["type"] == "tile":
+                logger.info(f"Tile operation: {op['configuration']}")
+                assert set(op["configuration"]) == {"tile_size", "stride"}
+            if op["type"] == "resize":
+                logger.info(f"Resize operation: {op['configuration']}")
+                assert all(k in op["configuration"] for k in {"height", "width", "preserve_aspect"})
+
+
+def test_discriminator_routes_ad(schema3):
+    data = ModelSchemaV_3.from_dict(schema3)
+    ad = data.models["top_ad"]
+    assert isinstance(ad, ADModel)
+    assert isinstance(ad.configs, ADConfigs)
+    assert ad.configs.min_threshold == 18.1
+    assert ad.configs.max_threshold == 24.5
+
+
+def test_discriminator_routes_od_and_alias(schema3):
+    data = ModelSchemaV_3.from_dict(schema3)
+    od = data.models["top_od_defect"]
+    assert isinstance(od, ODModel)
+    assert isinstance(od.configs, ODConfigs)
+    # "to-fail" alias must populate the to_fail field
+    assert od.configs.to_fail["IL_Grooves"] is True
+    assert od.configs.confidence["IL_Grooves"] == 0.5
+
+
+def test_ad_model_missing_threshold_fails(schema3):
+    schema3["top_ad"]["configs"].pop("min_threshold")
+    with pytest.raises(ValidationError):
+        ModelSchemaV_3.from_dict(schema3)
+
+
+def test_unknown_model_type_fails(schema3):
+    schema3["top_ad"]["model_type"] = "Bogus"
+    with pytest.raises(ValidationError):
+        ModelSchemaV_3.from_dict(schema3)
+
+
+def test_none_entries_skipped(schema3):
+    schema3["disabled_model"] = None
+    mc = ModelSchemaV_3.from_dict(schema3)
+    assert "disabled_model" not in mc.models

--- a/tests/lmi_utils/pipeline_base/test_schema3.py
+++ b/tests/lmi_utils/pipeline_base/test_schema3.py
@@ -38,7 +38,7 @@ def test_schema3(schema3):
         assert len(model["algorithm"]) > 0
         assert len(model["package"]) > 0
 
-    preprocessing = data.get_preprocessing()
+    preprocessing = data.get_global_preprocessing()
     assert isinstance(preprocessing, dict)
     for _key, ops in preprocessing.items():
         assert isinstance(ops, list)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary

support gofactory 3 manifest schema. 
get_models_from_static_manifest() uses v3 by default.

**Type:** <!-- feat | fix | chore | refactor | test | docs | ci --> feat

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
