### PR TITLE
fix: static manifest parsing for running pipeline unit-test

### DIFF
--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -218,12 +218,9 @@ OD model role from gofactory:
 ```json
 "od-model": {
     "format": "pt",
-    "configs": {
-        "to-fail": {"defect_a": true},
-        "confidence": {"defect_a": 0.5}
-    },
     "details": {
         "classes": ["defect_a"],
+        "confidence_threshold": 0.5,
         "image_size": [640, 640],
         "preprocessing": [
             {"type": "resize", "configuration": {"height": 640, "width": 640, "preserve_aspect": true}}
@@ -273,9 +270,10 @@ AD model role from gofactory:
 ```json
 "ad-model": {
     "format": "pt",
-    "configs": {"min_threshold": 0.0, "max_threshold": 1.0},
     "details": {
         "image_size": [224, 224],
+        "min_threshold": 0.0,
+        "max_threshold": 1.0,
         "preprocessing": [
             {"type": "resize", "configuration": {"height": 224, "width": 448, "preserve_aspect": true}},
             {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}}

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -707,19 +707,16 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
 
     manifest: Dict[str, Any] = {}
 
-    if version == "3":
-        for model in models:
-            role = model.get("model_role")
-            if role is None:
-                continue
-            _resolve_artifact_paths(model, manifest_path.parent)
-            manifest[role] = model
-        return manifest
-
-    if version != "2":
+    if version not in ["2", "3"]:
         raise ValueError(f"Unsupported static manifest version: {version}")
 
-    keys_to_copy = ["anomaly_size", "threshold_max", "threshold_min", "iou"]
+    manifest_v3 = version == "3"
+    keys_to_copy = (
+        ["anomaly_size", "min_threshold", "max_threshold", "iou"]
+        if manifest_v3 else
+        ["anomaly_size", "threshold_max", "threshold_min", "iou"]
+    )
+    classes_key = "classes" if manifest_v3 else "object_class"
 
     for model in models:
         role = model.get("model_role")
@@ -731,15 +728,16 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
         # Create object configs
         model["configs"] = {}
         details = model.get("details", {})
-        object_classes = details.get("object_class", [])
+        object_classes = details.get(classes_key, [])
 
         if object_classes:
             # Map config keys to their default values from details
             config_defaults = {
                 "confidence": details.get("confidence_threshold", 0.5),
-                "size": details.get("object_size", 1),
                 "to-fail": details.get("to_fail", True),
             }
+            if not manifest_v3:
+                config_defaults["size"] = details.get("object_size", 1)
 
             # Generate the dictionary for each config key
             for config_key, default_val in config_defaults.items():

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -713,8 +713,8 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
     manifest_v3 = version == "3"
     keys_to_copy = (
         ["anomaly_size", "min_threshold", "max_threshold", "iou"]
-        if manifest_v3 else
-        ["anomaly_size", "threshold_max", "threshold_min", "iou"]
+        if manifest_v3
+        else ["anomaly_size", "threshold_max", "threshold_min", "iou"]
     )
     classes_key = "classes" if manifest_v3 else "object_class"
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary

- Copy configs from "details" dict into "configs" dict for manifest version 3
- If model role dict contains "configs" dictionary, it will be ignored
- Fixes loading static manifest using `get_models_from_static_manifest` (Gadget expects configs to be in "details" dict in model role not "configs" dict. This is consistent with manifest from GoFactory.)

Example definition of static_manifest model role (no "configs" dictionary):
```python
[
    {
        "model_role": "OD",
        "model_type": "ObjectDetection",
        ...,
        "details": {
            "training_package": "Ultralytics",
            "training_algorithm": "Yolo",
            "classes": ["BBOX"],
            "confidence_threshold": 0.5,
            ...,
        }
    }, ...
]
``` 

**Type:** fix

## Breaking changes

- [x] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [x] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [x] `pre-commit run --all-files` passes
- [x] Docstrings / comments updated if public API changed
