### PR TITLE
feat: add pipeline_utils functions for subtractive masking / damping anomaly maps using instance segmentation

### DIFF
--- a/lmi_utils/gadget_utils/MASKING_README.md
+++ b/lmi_utils/gadget_utils/MASKING_README.md
@@ -1,0 +1,271 @@
+# AD Error Map Masking Functions
+
+This document describes the masking functions used to mask Anomaly Detection (AD) error maps based on Object Detection (OD) predictions.
+
+## Overview
+
+The masking module provides functionality to suppress AD error map responses in regions detected by an Object Detection model. This is useful for filtering out false positives in specific object regions and improving anomaly detection accuracy.
+
+## Core Functions
+
+### `blur_mask(mask: np.ndarray, kernel_size: int, distance_based: bool = False) -> np.ndarray`
+
+Blurs a mask using either Gaussian blur or distance transform-based soft weighting.
+
+**Parameters:**
+- `mask` (np.ndarray): Input binary or soft mask (values typically in [0, 1])
+- `kernel_size` (int): Size of the blur kernel
+  - For Gaussian blur: must be odd, values like 3, 5, 7, 11, etc.
+  - For distance-based blur: must be in [0, 3, 5]
+- `distance_based` (bool): If False (default), uses Gaussian blur. If True, uses distance transform-based soft weights.
+
+**Returns:**
+- np.ndarray: Blurred mask with same shape as input
+
+**Notes:**
+- When `distance_based=False`, uses OpenCV's `GaussianBlur`
+- When `distance_based=True`, applies distance transform and converts distances to soft weights using exponential decay (σ=5.0)
+- Invalid kernel sizes are automatically corrected with a warning
+- Gaussian blur kernel size will be incremented by 1 if even
+
+**Example:**
+```python
+import numpy as np
+from pipeline_utils import blur_mask
+
+# Gaussian blur
+mask = np.random.rand(256, 256)
+blurred = blur_mask(mask, kernel_size=11, distance_based=False)
+
+# Distance-based soft weights
+soft_mask = blur_mask(mask, kernel_size=5, distance_based=True)
+```
+
+---
+
+### `apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, class_names=None) -> tuple`
+
+Applies OD-based masks to suppress regions in an AD error map.
+
+**Parameters:**
+- `err_map` (np.ndarray): Anomaly Detection error map (H, W) or (H, W, C)
+- `od_predictions` (dict): Object Detection predictions containing:
+  - `masks`: Array of detection masks
+  - `classes`: List of class names for each detection
+  - `scores`: Confidence scores for each detection
+- `mask_config` (dict): Configuration dictionary with structure:
+  ```python
+  {
+      "global_weight": float,  # Global multiplier for all masks
+      "masking_params": {
+          "class_id": {
+              "weight": float,                    # Default: 1.0
+              "weight_by_confidence": bool,       # Default: True
+              "erode_kernel_size": int,           # Default: 0 (no erosion)
+              "blur_kernel_size": int,            # Default: 11
+              "multiply_by_mask": bool,           # Default: True
+              "simple_blur": bool,                # Default: True
+          }
+      }
+  }
+  ```
+- `class_names` (list, optional): List of class names to process. If None, processes all classes.
+
+**Returns:**
+- tuple: (masked_err_map, total_mask)
+  - `masked_err_map` (np.ndarray): Error map with suppressed regions
+  - `total_mask` (np.ndarray): Cumulative mask applied (clipped to [0, 1])
+
+**Configuration Details:**
+- `weight`: Per-class masking strength
+- `weight_by_confidence`: If True, multiplies weight by detection confidence score
+- `erode_kernel_size`: If > 0, applies morphological erosion to mask before blurring
+- `blur_kernel_size`: Controls blur intensity (larger = more blur)
+- `multiply_by_mask`: If True, scales error map by mask, else subtract mask from error map
+- `simple_blur`: If True, uses Gaussian blur; if False, uses distance-based soft weighting
+
+**Example:**
+```python
+from pipeline_utils import apply_ad_mask
+
+# Configuration for masking
+mask_config = {
+    "global_weight": 0.8,
+    "masking_params": {
+        "person": {
+            "weight": 1.0,
+            "weight_by_confidence": True,
+            "erode_kernel_size": 3,
+            "blur_kernel_size": 11,
+            "multiply_by_mask": True,
+            "simple_blur": True
+        },
+        "vehicle": {
+            "weight": 0.5,
+            "weight_by_confidence": True
+        }
+    }
+}
+
+# Apply masking
+masked_err_map, total_mask = apply_ad_mask(
+    err_map, 
+    od_predictions, 
+    mask_config,
+    class_names=["person", "vehicle"]
+)
+```
+
+---
+
+### `masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_role: str, configs: dict, class_names=None) -> tuple`
+
+Performs AD prediction with OD-based masking applied.
+
+**Parameters:**
+- `pipe`: Inference pipeline object with preprocessing/model prediction methods
+- `ad_inp` (np.ndarray): Input image for anomaly detection
+- `ad_model_role` (str or np.ndarray): Either model role name or pre-computed error map
+- `od_model_role` (str): Object detection model role name
+- `configs` (dict): Configuration dictionary containing model configs (passed to pipeline) and masking parameters
+- `class_names` (list, optional): Specific classes to use for masking
+
+**Returns:**
+- tuple: (masked_err_map, od_predictions, mask_img)
+  - `masked_err_map` (np.ndarray): Masked anomaly error map
+  - `od_predictions` (dict): Object detection predictions in original image space
+  - `mask_img` (np.ndarray): Visualization of applied mask as RGB image
+
+**Example:**
+```python
+from pipeline_utils import masked_ad_predict
+
+masked_err, od_preds, mask_vis = masked_ad_predict(
+    pipe,
+    input_image,
+    ad_model_role="anomaly_detector",
+    od_model_role="object_detector",
+    configs=configs,
+    class_names=["person"]
+)
+```
+
+---
+
+### `masked_ad_annotate(pipe, img, ad_model_role, od_model_role, err_map, od_predictions, configs, color=(152, 251, 152)) -> np.ndarray`
+
+Annotates an image with both AD error map heatmap and OD bounding boxes.
+
+**Parameters:**
+- `pipe`: Inference pipeline object
+- `img` (np.ndarray): Input image for annotation (BGR format)
+- `ad_model_role` (str): AD model role name
+- `od_model_role` (str): OD model role name
+- `err_map` (np.ndarray): Anomaly error map to visualize
+- `od_predictions` (dict): Object detection predictions (from OD .predict)
+- `configs` (dict): Configuration dictionary with thresholds and parameters
+- `color` (tuple, optional): RGB color for OD bounding boxes. Default: light green (152, 251, 152)
+
+**Returns:**
+- np.ndarray: Annotated image with AD heatmap and OD boxes
+
+**Configuration Expected:**
+```python
+configs["models"][ad_model_role]["configs"] should contain:
+  - "min_threshold": float  # Lower threshold for heatmap
+  - "max_threshold": float  # Upper threshold for heatmap
+```
+
+**Example:**
+```python
+from pipeline_utils import masked_ad_annotate
+
+annotated = masked_ad_annotate(
+    pipe,
+    img,
+    ad_model_role="anomaly_detector",
+    od_model_role="object_detector",
+    err_map=masked_err_map,
+    od_predictions=od_preds,
+    configs=configs,
+    color=(0, 255, 0)  # Green
+)
+```
+
+---
+
+## Workflow Example
+
+```python
+import numpy as np
+from pipeline_utils import masked_ad_predict, masked_ad_annotate
+
+# Define masking configuration
+mask_config = {
+    "global_weight": 0.9,
+    "masking_params": {
+        "defect": {"weight": 1.0, "blur_kernel_size": 15},
+        "scratch": {"weight": 0.7, "blur_kernel_size": 9}
+    }
+}
+
+# Configuration with model thresholds
+configs = {
+    "models": {
+        "ad_model": {"configs": {"min_threshold": 0.2, "max_threshold": 0.8}},
+        "od_model": {"configs": {"confidence": 0.5}}
+    },
+    "od_model": mask_config
+}
+
+# Step 1: Run masked AD prediction
+masked_err_map, od_preds, mask_vis = masked_ad_predict(
+    pipe,
+    input_image,
+    ad_model_role="ad_model",
+    od_model_role="od_model",
+    configs=configs
+)
+
+# Step 2: Annotate results
+result_img = masked_ad_annotate(
+    pipe,
+    input_image,
+    ad_model_role="ad_model",
+    od_model_role="od_model",
+    err_map=masked_err_map,
+    od_predictions=od_preds,
+    configs=configs
+)
+```
+
+## Key Design Principles
+
+1. **Hierarchical Masking**: Per-class configurations allow different suppression strategies for different object types
+2. **Confidence Weighting**: Detection confidence scores can modulate masking strength
+3. **Soft Boundaries**: Blur and distance-based smoothing prevent hard edges in masked regions
+4. **Flexible Suppression**: Masks can be applied additively or multiplicatively
+5. **Morphological Operations**: Erosion reduces over-masking of object boundaries
+
+## Performance Considerations
+
+- Distance-based blurring is more computationally expensive than Gaussian blur
+- Larger blur kernels increase processing time
+- Morphological erosion adds overhead proportional to kernel size
+
+## Common Configuration Patterns
+
+### Conservative Masking (Minimal Suppression)
+```python
+{"global_weight": 0.3, "masking_params": {"all_classes": {"weight": 0.5}}}
+```
+
+### Aggressive Masking (Strong Suppression)
+```python
+{"global_weight": 1.0, "masking_params": {"all_classes": {"weight": 1.0, "blur_kernel_size": 21}}}
+```
+
+### Distance-Based Soft Masking
+```python
+{"masking_params": {"all_classes": {"simple_blur": False, "blur_kernel_size": 5}}}
+```

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -726,8 +726,10 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
         base_mask = resize_image(mask, W=W, H=H)
         if erode_kernel:
             mask_bin = (base_mask > 0.5).astype(np.uint8)
-            kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (erode_kernel, erode_kernel))
-            base_mask = cv2.erode(mask_bin, kernel).astype(np.float32)
+            kernel_size = abs(erode_kernel)
+            kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
+            size_transform = cv2.erode if erode_kernel > 0 else cv2.dilate
+            base_mask = size_transform(mask_bin, kernel).astype(np.float32)
 
         fp_mask = weight * blur_mask(base_mask, kernel_size=blur_kernel, distance_based=not simple_blur)
         total_mask += fp_mask

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -759,7 +759,7 @@ def masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_ro
 def masked_ad_annotate(pipe, img, ad_model_role, od_model_role, err_map, od_predictions, configs, color=(152, 251, 152)):
     fp_classes = pipe.models[od_model_role].model.names
     ad_configs = configs["models"][ad_model_role]["configs"]
-    err_threshold = ad_configs["min thereshold"]
+    err_threshold = ad_configs["min_threshold"]
     err_max = ad_configs["max_threshold"]
     annotated_img = pipe.models[ad_model_role].annotate(img, err_map, err_threshold, err_max)
     if not color:

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -749,7 +749,7 @@ def masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_ro
     od_predictions = {k: v[0] for k, v in pipe.revert_preprocess(od_predictions, ops).items()}
     ## Parse err_map
     err_map = (
-        pipe.models[ad_model_role].predict(ad_inp) if isinstance(ad_model_role, str) else ad_model_role  # ad_role is err_map
+        pipe.models[ad_model_role].predict(ad_inp)[0] if isinstance(ad_model_role, str) else ad_model_role  # ad_role is err_map
     )
     if not od_predictions or not od_predictions["masks"].any():
         return (err_map, od_predictions, np.zeros_like(ad_inp, dtype=np.uint8))
@@ -759,11 +759,11 @@ def masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_ro
 
 
 def masked_ad_annotate(pipe, img, ad_model_role, od_model_role, err_map, od_predictions, configs, color=(152, 251, 152)):
-    fp_classes = pipe.models[od_model_role].model.names
+    fp_classes = configs["models"][od_model_role]["configs"]["confidence"].keys()
     ad_configs = configs["models"][ad_model_role]["configs"]
     err_threshold = ad_configs["min_threshold"]
     err_max = ad_configs["max_threshold"]
     annotated_img = pipe.models[ad_model_role].annotate(img, err_map, err_threshold, err_max)
     if not color:
         return annotated_img
-    return pipe.models[od_model_role].annotate_image(od_predictions, annotated_img, {c: color for c in fp_classes.values()})
+    return pipe.models[od_model_role].annotate_image(od_predictions, annotated_img, {c: color for c in fp_classes})

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -666,3 +666,102 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
         manifest[role] = model
 
     return manifest
+
+
+def blur_mask(mask: np.ndarray, kernel_size: int, distance_based: bool = False):
+    if not kernel_size:
+        return mask
+
+    if distance_based:
+        blur_kernel_options = np.array([0, 3, 5])
+        if kernel_size not in blur_kernel_options:
+            kernel_size = blur_kernel_options[abs(blur_kernel_options - kernel_size).argmin()]
+            logger.warning(
+                f"Blur kernel size must be in {list(blur_kernel_options)} when not using "
+                f"simple blur (Distance Transform); using {kernel_size} instead"
+            )
+        mask_bin = (mask > 0.5).astype(np.uint8)
+        dist = cv2.distanceTransform(1 - mask_bin, cv2.DIST_L2, kernel_size)
+        # convert distance to soft weights
+        sigma = 5.0
+        return np.exp(-(dist**2) / (2 * sigma**2))
+
+    # Gaussian blur
+    if not kernel_size % 2:
+        logger.warning(f"Blur kernel size must be odd when using simple (Gaussian) blur; using {kernel_size + 1} instead")
+        kernel_size += 1
+    return cv2.GaussianBlur(mask, (kernel_size, kernel_size), 0)
+
+
+def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, class_names=None):
+    DEFAULT_WEIGHT = 1
+    DEFAULT_CONF_WEIGHT = True
+    DEFAULT_ERODE_KERNEL = 0
+    DEFAULT_BLUR_KERNEL = 11
+    DEFAULT_REDUCE = True
+    DEFAULT_SIMPLE_BLUR = True
+
+    global_mult = mask_config["global_weight"]
+    mask_config = mask_config["masking_params"]
+    total_mask = np.zeros(err_map.shape)
+    for i, mask in enumerate(od_predictions["masks"]):
+        fp_class = od_predictions["classes"][i]
+        # If class_names is defined, fp_class should be in class_names
+        # (for using only specific classes from a model)
+        if class_names is not None and fp_class not in class_names:
+            continue
+        cls_mask_config = mask_config.get(fp_class, {})
+        use_conf_damp = cls_mask_config.get("weight_by_confidence", DEFAULT_CONF_WEIGHT)
+        conf_damp = od_predictions["scores"][i] if use_conf_damp else 1
+        weight = conf_damp * global_mult * cls_mask_config.get("weight", DEFAULT_WEIGHT)
+        if not weight:
+            continue
+
+        erode_kernel = cls_mask_config.get("erode_kernel_size", DEFAULT_ERODE_KERNEL)
+        blur_kernel = cls_mask_config.get("blur_kernel_size", DEFAULT_BLUR_KERNEL)
+        mask_mult = cls_mask_config.get("multiply_by_mask", DEFAULT_REDUCE)
+        simple_blur = cls_mask_config.get("simple_blur", DEFAULT_SIMPLE_BLUR)
+
+        H, W = err_map.shape[:2]
+        base_mask = resize_image(mask, W=W, H=H)
+        if erode_kernel:
+            mask_bin = (base_mask > 0.5).astype(np.uint8)
+            kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (erode_kernel, erode_kernel))
+            base_mask = cv2.erode(mask_bin, kernel).astype(np.float32)
+
+        fp_mask = weight * blur_mask(base_mask, kernel_size=blur_kernel, distance_based=not simple_blur)
+        total_mask += fp_mask
+        scale = err_map if mask_mult else 1  # err_map * (1 - mask) if mult
+        err_map -= scale * fp_mask
+
+    total_mask = np.clip(total_mask, 0, 1)
+    return err_map, total_mask
+
+
+def masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_role: str, configs: dict, class_names=None):
+    ## Get OD predictions
+    od_inp, ops = pipe.preprocess(od_model_role, [ad_inp])
+    conf = configs["models"][od_model_role]["configs"]["confidence"]
+    od_predictions, time_info = pipe.models[od_model_role].predict(od_inp[0], conf)
+    # Take first item from batch
+    od_predictions = {k: v[0] for k, v in pipe.revert_preprocess(od_predictions, ops).items()}
+    ## Parse err_map
+    err_map = (
+        pipe.models[ad_model_role].predict(ad_inp) if isinstance(ad_model_role, str) else ad_model_role  # ad_role is err_map
+    )
+    if not od_predictions or not od_predictions["masks"].any():
+        return (err_map, od_predictions, np.zeros_like(ad_inp, dtype=np.uint8))
+    masked_err_map, mask = apply_ad_mask(err_map, od_predictions, mask_config=configs[od_model_role], class_names=class_names)
+    mask_img = cv2.cvtColor((mask * 255).astype("uint8"), cv2.COLOR_GRAY2RGB)
+    return masked_err_map, od_predictions, mask_img
+
+
+def masked_ad_annotate(pipe, img, ad_model_role, od_model_role, err_map, od_predictions, configs, color=(152, 251, 152)):
+    fp_classes = pipe.models[od_model_role].model.names
+    ad_configs = configs["models"][ad_model_role]["configs"]
+    err_threshold = ad_configs["min thereshold"]
+    err_max = ad_configs["max_threshold"]
+    annotated_img = pipe.models[ad_model_role].annotate(img, err_map, err_threshold, err_max)
+    if not color:
+        return annotated_img
+    return pipe.models[od_model_role].annotate_image(od_predictions, annotated_img, {c: color for c in fp_classes.values()})

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -704,8 +704,10 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
     global_mult = mask_config["global_weight"]
     mask_config = mask_config["masking_params"]
     total_mask = np.zeros(err_map.shape)
+    if class_names is not None:
+        class_names = [c.lower() for c in class_names]
     for i, mask in enumerate(od_predictions["masks"]):
-        fp_class = od_predictions["classes"][i]
+        fp_class = od_predictions["classes"][i].lower()
         # If class_names is defined, fp_class should be in class_names
         # (for using only specific classes from a model)
         if class_names is not None and fp_class not in class_names:
@@ -731,10 +733,13 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
             size_transform = cv2.erode if erode_kernel > 0 else cv2.dilate
             base_mask = size_transform(mask_bin, kernel).astype(np.float32)
 
-        fp_mask = weight * blur_mask(base_mask, kernel_size=blur_kernel, distance_based=not simple_blur)
-        total_mask += fp_mask
-        scale = err_map if mask_mult else 1  # err_map * (1 - mask) if mult
-        err_map -= scale * fp_mask
+        fp_mask = np.clip(weight * blur_mask(base_mask, kernel_size=blur_kernel, distance_based=not simple_blur), 0, 1)
+        if mask_mult:
+            err_map *= 1 - fp_mask
+            total_mask = 1 - (1 - total_mask) * (1 - fp_mask)
+        else:
+            err_map -= fp_mask
+            total_mask += fp_mask
 
     total_mask = np.clip(total_mask, 0, 1)
     return err_map, total_mask

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -693,7 +693,7 @@ def blur_mask(mask: np.ndarray, kernel_size: int, distance_based: bool = False):
     return cv2.GaussianBlur(mask, (kernel_size, kernel_size), 0)
 
 
-def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, class_names=None):
+def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, class_names=None, defect_mask=None):
     DEFAULT_WEIGHT = 1
     DEFAULT_CONF_WEIGHT = True
     DEFAULT_ERODE_KERNEL = 0
@@ -706,6 +706,12 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
     total_mask = np.zeros(err_map.shape)
     if class_names is not None:
         class_names = [c.lower() for c in class_names]
+
+    # Resize defect_mask to err_map size
+    H, W = err_map.shape[:2]
+    if isinstance(defect_mask, np.ndarray):
+        defect_mask = resize_image(defect_mask, W=W, H=H)
+
     for i, mask in enumerate(od_predictions["masks"]):
         fp_class = od_predictions["classes"][i].lower()
         # If class_names is defined, fp_class should be in class_names
@@ -724,7 +730,6 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
         mask_mult = cls_mask_config.get("multiply_by_mask", DEFAULT_REDUCE)
         simple_blur = cls_mask_config.get("simple_blur", DEFAULT_SIMPLE_BLUR)
 
-        H, W = err_map.shape[:2]
         base_mask = resize_image(mask, W=W, H=H)
         if erode_kernel:
             mask_bin = (base_mask > 0.5).astype(np.uint8)
@@ -734,6 +739,8 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
             base_mask = size_transform(mask_bin, kernel).astype(np.float32)
 
         fp_mask = np.clip(weight * blur_mask(base_mask, kernel_size=blur_kernel, distance_based=not simple_blur), 0, 1)
+        if isinstance(defect_mask, np.ndarray):
+            fp_mask = np.clip(fp_mask - defect_mask, 0, 1)
         if mask_mult:
             err_map *= 1 - fp_mask
             total_mask = 1 - (1 - total_mask) * (1 - fp_mask)
@@ -745,20 +752,59 @@ def apply_ad_mask(err_map: np.ndarray, od_predictions: dict, mask_config: dict, 
     return err_map, total_mask
 
 
-def masked_ad_predict(pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_role: str, configs: dict, class_names=None):
+def masked_ad_predict(
+    pipe, ad_inp, ad_model_role: str | np.ndarray, od_model_role: str, configs: dict, class_names=None, known_defects=None
+):
+
+    def get_od_predictions(model_role, inp):
+        od_inp, ops = pipe.preprocess(model_role, [inp])
+        conf = configs["models"][model_role]["configs"]["confidence"]
+        od_predictions, time_info = pipe.models[model_role].predict(od_inp[0], conf)
+        # Take first item from batch
+        return {k: v[0] for k, v in pipe.revert_preprocess(od_predictions, ops).items()}
+
     ## Get OD predictions
-    od_inp, ops = pipe.preprocess(od_model_role, [ad_inp])
-    conf = configs["models"][od_model_role]["configs"]["confidence"]
-    od_predictions, time_info = pipe.models[od_model_role].predict(od_inp[0], conf)
-    # Take first item from batch
-    od_predictions = {k: v[0] for k, v in pipe.revert_preprocess(od_predictions, ops).items()}
+    od_predictions = get_od_predictions(od_model_role, ad_inp)
+
     ## Parse err_map
     err_map = (
         pipe.models[ad_model_role].predict(ad_inp)[0] if isinstance(ad_model_role, str) else ad_model_role  # ad_role is err_map
     )
     if not od_predictions or not od_predictions["masks"].any():
         return (err_map, od_predictions, np.zeros_like(ad_inp, dtype=np.uint8))
-    masked_err_map, mask = apply_ad_mask(err_map, od_predictions, mask_config=configs[od_model_role], class_names=class_names)
+
+    ## Parse known_defects (supported defect model_role, defect_names, defect_masks)
+    class_names = set(class_names or configs["models"][od_model_role]["configs"]["confidence"])
+    defect_mask = None
+    if isinstance(known_defects, list):
+        # Allow passing list of np.ndarray masks or list of defect names (str) to take from OD masks
+        first_item = known_defects[0] if known_defects else None
+        if isinstance(first_item, np.ndarray):  # Provide masks directly
+            defect_mask = np.max(known_defects, axis=0)
+        elif isinstance(first_item, str):  # Use masks from od_model_role
+            known_defect_names = {x.lower() for x in known_defects}
+            selected_masks = [
+                mask for i, mask in enumerate(od_predictions["masks"]) if od_predictions["classes"][i].lower() in known_defect_names
+            ]
+            defect_mask = np.max(selected_masks, axis=0) if selected_masks else None
+            class_names -= known_defect_names
+    elif known_defects is not None:
+        if isinstance(known_defects, np.ndarray):
+            defect_mask = known_defects
+        else:  # Interpret known_defects as a model_role
+            assert known_defects in pipe.models, f"{known_defects} is not a valid model_role"
+            assert known_defects != od_model_role, "Providing model known_defects as same role as od_model_role is not supported"
+            defect_mask = get_od_predictions(known_defects, ad_inp)["masks"]
+
+        defect_mask = np.asarray(defect_mask, dtype=np.float32)
+        if not len(defect_mask):
+            defect_mask = None
+        elif len(defect_mask.shape) == 3:
+            defect_mask = np.max(defect_mask, axis=0)
+
+    masked_err_map, mask = apply_ad_mask(
+        err_map, od_predictions, mask_config=configs[od_model_role], class_names=class_names, defect_mask=defect_mask
+    )
     mask_img = cv2.cvtColor((mask * 255).astype("uint8"), cv2.COLOR_GRAY2RGB)
     return masked_err_map, od_predictions, mask_img
 


### PR DESCRIPTION
## Summary

The new functions make it simple to suppress anomaly detector score in regions with a known, harmless, feature (detected by an Object Detection model). This is useful for filtering out false positives and improving anomaly detection accuracy. If features that are not considered defects are being flagged as anomalies are removed or suppressed in the anomaly mask, the AD threshold can be increased to catch more truly anomalous samples.

## Usage
The masking flow is implemented through three methods:

- `apply_ad_mask(...)`
- `masked_ad_predict(...)`
- `masked_ad_annotate(...)`

### `apply_ad_mask(...)`
Takes an anomaly map and object-detection predictions (segments/masks), then applies one mask at a time using class-specific configuration.
### `masked_ad_predict(...)`
Runs object detection and anomaly detection, then applies the mask logic to produce a masked anomaly map and a visualization of the combined mask.
### `masked_ad_annotate(...)`
Builds a final annotated image by overlaying anomaly visualization and object-detection annotations.

**Type:** feat

## Checklist

- [x] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [x] `pre-commit run --all-files` passes
- [x] Docstrings / comments updated if public API changed