### PR TITLE
refactor!(preprocess): unified typed metadata + step macros for forward/revert

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,6 @@
 
 ## Summary
 
-<!-- One sentence describing what this PR does and why. -->
-
-**Type:** <!-- feat | fix | chore | refactor | test | docs | ci -->
 
 ## Breaking changes
 

--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -17,6 +17,8 @@ This document covers all **breaking changes and new features** introduced after 
 **New Features**
 
 7. [Preprocessor & Reconstructor — batch processing with history-based reconstruction](#7-preprocessor--reconstructor--batch-processing-with-history-based-reconstruction)
+8. [Forward preprocessing — typed step builders (`lmi_utils.preprocess_utils.steps`)](#8-forward-preprocessing--typed-step-builders)
+9. [Revert path — typed history for manual reconstruction](#9-revert-path--typed-history-for-manual-reconstruction)
 
 
 ---
@@ -105,10 +107,7 @@ for boxes, scores, classes in zip(results["boxes"], results["scores"], results["
     ...  # process per image
 ```
 
-The `operators` parameter is also now formally typed:
-- `None` — no coordinate reversion (unchanged).
-- `list[dict]` — one operator chain applied to all images.
-- `list[list[dict]]` — per-image operator chains (must match batch size).
+The `operators` parameter is also now formally typed and uses the **unified preprocessing-history schema** — the same shape returned by `Preprocessor.preprocess()` and consumed by `Reconstructor`. See section 9 below.
 
 ---
 
@@ -223,7 +222,7 @@ OD model role from gofactory:
         "confidence_threshold": 0.5,
         "image_size": [640, 640],
         "preprocessing": [
-            {"type": "resize", "configuration": {"height": 640, "width": 640, "preserve_aspect": true}}
+            {"type": "resize", "id": "a1f2c3d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d", "configuration": {"height": 640, "width": 640, "preserve_aspect": true}}
         ],
         "training_package": "Ultralytics",
         "training_algorithm": "Yolo"
@@ -275,8 +274,8 @@ AD model role from gofactory:
         "min_threshold": 0.0,
         "max_threshold": 1.0,
         "preprocessing": [
-            {"type": "resize", "configuration": {"height": 224, "width": 448, "preserve_aspect": true}},
-            {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}}
+            {"type": "resize", "id": "7b2d4e6f-8a9c-4b1d-9e3f-5a6b7c8d9e0f", "configuration": {"height": 224, "width": 448, "preserve_aspect": true}},
+            {"type": "tile", "id": "c3e5f7a9-1b2d-4c6e-8f0a-2b4d6f8a0c1e", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}}
         ],
         "training_package": "Anomalib1",
         "training_algorithm": "Patchcore"
@@ -311,3 +310,79 @@ class MyADPipeline(PipelineBase):
         final_score = final_scores[0]
 
 ```
+
+---
+
+### 8. Forward preprocessing — typed step builders
+
+When you need to apply preprocessing **beyond what the model manifest declares** — e.g. an ad-hoc flip, an extra resize, or an explicit crop driven by an upstream detection — build the step list with `lmi_utils.preprocess_utils.steps`. Each alias is the typed `*Config` dataclass; calling it returns a `Config` instance that `Preprocessor.preprocess()` consumes directly.
+
+**Forward aliases:**
+
+| Alias | Required kwargs | Notes |
+|---|---|---|
+| `steps.resize(width=..., height=..., preserve_aspect=False, mode="bilinear", id=None)` | — | Each dim defaults to the source image's matching dim |
+| `steps.crop(boxes=..., id=None)` | `boxes` | One `[x1, y1, x2, y2]` per image |
+| `steps.flip(lr=False, ud=False, id=None)` | — | Defaults to a no-op |
+| `steps.pad(width=None, height=None, pad=None, value=0, id=None)` | one of `width/height` or `pad` | `pad=[L, R, T, B]` for explicit padding |
+| `steps.tile(tile_size=..., stride=..., scale_mode="padding", overlap_mode="average", id=None)` | `tile_size`, `stride` | Scalars are broadcast to `[h, w]` |
+
+**Usage — inside a `PipelineBase` subclass:**
+
+```python
+from lmi_utils.preprocess_utils import steps
+
+class MyPipeline(PipelineBase):
+    def predict(self, configs, inputs):
+        image = inputs["image"]
+
+        ops = [
+            steps.crop(boxes=[[100, 50, 900, 700]]),
+            steps.resize(width=640, height=640, preserve_aspect=True),
+            steps.flip(lr=True),
+        ]
+
+        preprocessed, history = self.preprocessor.preprocess(image, ops)
+        # preprocessed: list of transformed images, ready for model.predict(...)
+        # history:      list of typed Meta objects — feed into the revert path (see section 9)
+```
+
+`Preprocessor.preprocess()` returns `(processed_images, history)` where `history: List[Meta]` is the typed record of what was done. That history is the only input the revert path needs.
+
+---
+
+### 9. Revert path — typed history for manual reconstruction
+
+To map coordinates back to the original image, the revert path needs to know what each preprocessing step did. That record is the **history**: a list of typed `Meta` objects, one per step. **If the `Preprocessor` did the preprocessing**, you already have this history — just feed it back (the typical flow is in section 7). 
+
+This section covers the other case: the image was preprocessed **outside** the `Preprocessor` (cropped by an earlier stage), so no history exists yet. You still want coordinates back in the original space, so you build the history yourself — one `Meta` per step — using the inverse aliases below.
+
+**Inverse aliases — build a `Meta` directly:**
+
+| Alias | Key fields (per-image lists, length B) |
+|---|---|
+| `steps.revert_crop(boxes=..., orig_sizes=...)` | `boxes` = `[x1, y1, x2, y2]` used; `orig_sizes` = `[W, H]` of the pre-crop canvas |
+| `steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...)` | `src_sizes` / `dst_sizes` = `[W, H]`; `pads` = `[L, R, T, B]` letterbox padding |
+| `steps.revert_pad(pads=...)` | `pads` = `[L, R, T, B]` applied |
+| `steps.revert_flip(lr=..., ud=..., sizes=...)` | `lr`, `ud` flags; `sizes` = `[W, H]` of the flipped image |
+| `steps.revert_tile(tile_sizes=..., strides=..., im_sizes=..., scale_sizes=..., n_tiles=..., batch_sizes=..., num_channels=..., scale_modes=..., overlap_modes=...)` | One entry per *source* image |
+
+**Example — image was cropped upstream; revert OD detections into the original frame:**
+
+```python
+from lmi_utils.preprocess_utils import steps
+
+# foreground_im was already cropped from the full-resolution image at [x1, y1, x2, y2];
+# original canvas was W x H. Build the matching history and let predict() revert for us.
+history = [steps.revert_crop(boxes=[[x1, y1, x2, y2]], orig_sizes=[[W, H]])]
+
+results, _ = model.predict(foreground_im, 0.5, operators=history)
+# results["boxes"][0] is now in the original (W, H) coordinate space.
+
+# Or run inference first and revert afterward — the same history works with revert_preprocess():
+results1, _ = model.predict(foreground_im, 0.5)      # coords still in crop space
+results2 = self.revert_preprocess(results1, history)
+# results2["boxes"][0] is now in the original (W, H) coordinate space.
+```
+
+> **Impact:** The revert path is now **typed-only**. Code that built legacy operator dicts must migrate to `Meta` instances — `revert_to_origin`, `revert_mask_to_origin`, `revert_masks_to_origin`, and `apply_operations` keep their names but raise `TypeError` on dict input.

--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -315,17 +315,17 @@ class MyADPipeline(PipelineBase):
 
 ### 8. Forward preprocessing — typed step builders
 
-When you need to apply preprocessing **beyond what the model manifest declares** — e.g. an ad-hoc flip, an extra resize, or an explicit crop driven by an upstream detection — build the step list with `lmi_utils.preprocess_utils.steps`. Each alias is the typed `*Config` dataclass; calling it returns a `Config` instance that `Preprocessor.preprocess()` consumes directly.
+When you need to apply preprocessing **beyond what the model manifest declares** — e.g. extra flip, resize or crop — build the step list with `lmi_utils.preprocess_utils.steps`.
 
-**Forward aliases:**
+**Forward step builders:**
 
-| Alias | Required kwargs | Notes |
+| Step builder | Required kwargs | Notes |
 |---|---|---|
-| `steps.resize(width=..., height=..., preserve_aspect=False, mode="bilinear", id=None)` | — | Each dim defaults to the source image's matching dim |
-| `steps.crop(boxes=..., id=None)` | `boxes` | One `[x1, y1, x2, y2]` per image |
-| `steps.flip(lr=False, ud=False, id=None)` | — | Defaults to a no-op |
-| `steps.pad(width=None, height=None, pad=None, value=0, id=None)` | one of `width/height` or `pad` | `pad=[L, R, T, B]` for explicit padding |
-| `steps.tile(tile_size=..., stride=..., scale_mode="padding", overlap_mode="average", id=None)` | `tile_size`, `stride` | Scalars are broadcast to `[h, w]` |
+| `steps.resize(width=..., height=..., preserve_aspect=False, mode="bilinear")` | — | Each dim defaults to the source image's matching dim |
+| `steps.crop(boxes=...)` | `boxes` | One `[x1, y1, x2, y2]` per image |
+| `steps.flip(lr=False, ud=False)` | — | Defaults to a no-op |
+| `steps.pad(width=None, height=None, pad=None, value=0)` | one of `width/height` or `pad` | `pad=[L, R, T, B]` for explicit padding |
+| `steps.tile(tile_size=..., stride=..., scale_mode="padding", overlap_mode="average")` | `tile_size`, `stride` | Scalars are broadcast to `[h, w]` |
 
 **Usage — inside a `PipelineBase` subclass:**
 
@@ -344,22 +344,20 @@ class MyPipeline(PipelineBase):
 
         preprocessed, history = self.preprocessor.preprocess(image, ops)
         # preprocessed: list of transformed images, ready for model.predict(...)
-        # history:      list of typed Meta objects — feed into the revert path (see section 9)
+        # history:      record of what each step did — feed into the revert path (see section 9)
 ```
-
-`Preprocessor.preprocess()` returns `(processed_images, history)` where `history: List[Meta]` is the typed record of what was done. That history is the only input the revert path needs.
 
 ---
 
 ### 9. Revert path — typed history for manual reconstruction
 
-To map coordinates back to the original image, the revert path needs to know what each preprocessing step did. That record is the **history**: a list of typed `Meta` objects, one per step. **If the `Preprocessor` did the preprocessing**, you already have this history — just feed it back (the typical flow is in section 7). 
+To map coordinates back to the original image, the revert path needs to know what each preprocessing step did. That record is the **history** — one entry per step. **If the `Preprocessor` did the preprocessing**, you already have the history — just feed it back (the typical flow is in section 7).
 
-This section covers the other case: the image was preprocessed **outside** the `Preprocessor` (cropped by an earlier stage), so no history exists yet. You still want coordinates back in the original space, so you build the history yourself — one `Meta` per step — using the inverse aliases below.
+This section covers the other case: the image was preprocessed **outside** the `Preprocessor` (e.g. cropped by an earlier stage), so no history exists yet. You still want coordinates back in the original space, so you build the history yourself — one entry per step — using the revert step builders below.
 
-**Inverse aliases — build a `Meta` directly:**
+**Revert step builders:**
 
-| Alias | Key fields (per-image lists, length B) |
+| Step builder | Key fields (per-image lists, length B) |
 |---|---|
 | `steps.revert_crop(boxes=..., orig_sizes=...)` | `boxes` = `[x1, y1, x2, y2]` used; `orig_sizes` = `[W, H]` of the pre-crop canvas |
 | `steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...)` | `src_sizes` / `dst_sizes` = `[W, H]`; `pads` = `[L, R, T, B]` letterbox padding |
@@ -385,4 +383,4 @@ results2 = self.revert_preprocess(results1, history)
 # results2["boxes"][0] is now in the original (W, H) coordinate space.
 ```
 
-> **Impact:** The revert path is now **typed-only**. Code that built legacy operator dicts must migrate to `Meta` instances — `revert_to_origin`, `revert_mask_to_origin`, `revert_masks_to_origin`, and `apply_operations` keep their names but raise `TypeError` on dict input.
+> **Impact:** The revert path is now **typed-only**. Code that built legacy operator dicts must migrate to the revert step builders above — `revert_to_origin`, `revert_mask_to_origin`, `revert_masks_to_origin`, and `apply_operations` keep their names but raise `TypeError` on dict input.

--- a/anomaly_detectors/anomalib_lmi/evaluate.py
+++ b/anomaly_detectors/anomalib_lmi/evaluate.py
@@ -143,16 +143,13 @@ def evaluate(
     if not os.path.exists(out_path):
         os.makedirs(out_path)
 
+    from lmi_utils.preprocess_utils import steps as pre_steps
+
     steps = []
     if tile is not None:
         if stride is None:
             raise ValueError("Must provide stride when using tiling")
-        steps = [
-            {
-                "type": "tile",
-                "configuration": {"tile_size": tile, "stride": stride, "overlap_mode": overlap_mode, "scale_mode": scale_mode},
-            }
-        ]
+        steps = [pre_steps.tile(tile_size=tile, stride=stride, overlap_mode=overlap_mode, scale_mode=scale_mode)]
     preprocessor = Preprocessor()
     reconstructor = Reconstructor()
 

--- a/lmi_utils/dataset_utils/ops/dataset_rotate.py
+++ b/lmi_utils/dataset_utils/ops/dataset_rotate.py
@@ -13,62 +13,20 @@ from lmi_utils.label_utils.bbox_utils import get_rotated_bbox, rotate
 logger = logging.getLogger(__name__)
 
 
-def order_points(pts):
-    """
-    Orders 4 points in the order:
-      top-left, top-right, bottom-right, bottom-left.
-
-    Args:
-        pts (np.array): A (4, 2) array of points.
-
-    Returns:
-        np.array: A (4, 2) array of ordered points.
-    """
-    # Initialize a list of coordinates that will be ordered.
-    rect = np.zeros((4, 2), dtype="float32")
-
-    # The top-left point will have the smallest sum, whereas
-    # the bottom-right will have the largest sum.
-    s = pts.sum(axis=1)
-    rect[0] = pts[np.argmin(s)]
-    rect[2] = pts[np.argmax(s)]
-
-    # The top-right point will have the smallest difference
-    # (y - x), whereas the bottom-left will have the largest difference.
-    diff = np.diff(pts, axis=1)
-    rect[1] = pts[np.argmin(diff)]
-    rect[3] = pts[np.argmax(diff)]
-
-    return rect
-
-
 def rotate_bbox_corners(corners, M):
-    """
-    Rotates the corners of a bounding box using the affine transformation
-    matrix M and sorts the resulting corners in the order:
-    top-left, top-right, bottom-right, bottom-left.
+    """Apply 2x3 affine ``M`` to (4, 2) corners. Input winding order is preserved.
 
     Args:
-        corners (array-like): A (4,2) array (or list) of bounding box corners.
+        corners (array-like): A (4, 2) array (or list) of bounding box corners.
         M (np.array): A 2x3 affine transformation matrix (e.g., from cv2.getRotationMatrix2D).
 
     Returns:
-        np.array: A (4,2) array of the rotated and ordered bounding box corners.
+        np.array: A (4, 2) array of transformed corners in the same winding as the input.
     """
-    # Convert corners to a numpy array of type float32.
     corners = np.array(corners, dtype="float32")
-
-    # Convert corners to homogeneous coordinates by appending a column of ones.
     ones = np.ones((corners.shape[0], 1), dtype="float32")
-    corners_hom = np.hstack([corners, ones])  # shape (4, 3)
-
-    # Apply the affine transformation to each corner.
-    rotated_corners = np.dot(M, corners_hom.T).T  # shape (4, 2)
-
-    # Order the rotated corners.
-    ordered_corners = order_points(rotated_corners)
-
-    return ordered_corners.astype(np.float32)
+    corners_hom = np.hstack([corners, ones])
+    return np.dot(M, corners_hom.T).T.astype(np.float32)
 
 
 def rotate_dataset(dataset, images, angle, counter_clockwise=False):

--- a/lmi_utils/eval_utils/benchmark_AD.py
+++ b/lmi_utils/eval_utils/benchmark_AD.py
@@ -12,6 +12,7 @@ import numpy as np
 from sklearn.metrics import auc, f1_score, precision_score, recall_score, roc_curve
 
 from anomaly_detectors.anomalib_lmi.v1.model import AnomalyModel as AnomalyModelV1
+from lmi_utils.preprocess_utils import parse_steps
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
@@ -458,9 +459,9 @@ def main() -> None:
     # Load and validate data
     good_list, bad_list = load_and_validate_data(args.data)
 
-    # Load preprocessing configurations
-    ops1 = load_preprocess(args.preprocess1)
-    ops2 = load_preprocess(args.preprocess2)
+    # Load preprocessing configurations and convert to typed Configs.
+    ops1 = parse_steps(load_preprocess(args.preprocess1))
+    ops2 = parse_steps(load_preprocess(args.preprocess2))
 
     # Create output directory
     output_dir = args.output_dir / datetime.now().strftime(r"%Y-%m-%d_%H-%M-%S")

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -91,7 +91,7 @@ def fit_im_to_size(im, W=None, H=None, value=0):
     h, w = im.shape[:2]
     if W is None:
         W = w
-    elif H is None:
+    if H is None:
         H = h
 
     is_numpy = isinstance(im, np.ndarray)
@@ -233,6 +233,7 @@ def uint16_to_int16(profile):
 def profile_to_3d(profile, resolution, offset):
     """
     convert profile image to 3d sensor space
+
     args:
         profile(np array | tensor): the profile image
         resolution(tuple): (x_resolution, y_resolution, z_resolution)
@@ -276,6 +277,7 @@ def profile_to_3d(profile, resolution, offset):
 def pts_to_3d(pts, profile, resolution, offset):
     """
     convert list of 2d pixel locations to 3d sensor space
+
     args:
         pts(numpy | tensor): array of (x,y) points, with shape of Nx2
         profile(same type as pts): the profile image
@@ -322,8 +324,9 @@ def plot_one_box(
     hide_bbox=False,
 ):
     """
-    description: Plots one bounding box and mask (optinal) on image img,
-                 this function comes from YoLov5 project.
+    description:
+        Plots one bounding box and mask (optinal) on image img,
+        this function comes from YoLov5 project.
     param:
         box:    a box likes [x1,y1,x2,y2]
         img:    a opencv image object in BGR format
@@ -371,7 +374,8 @@ def plot_one_box(
 
 def plot_one_rbox(box, img, color=None, label=None, line_thickness=None, hide_bbox=False):
     """
-    description: Plots one bounding rotated bbox on image img
+    description:
+        Plots one bounding rotated bbox on image img
     param:
         box:    a box likes [[x,y],[x,y],[x,y],[x,y]]
         img:    a opencv image object in BGR format
@@ -422,151 +426,187 @@ def plot_one_rbox(box, img, color=None, label=None, line_thickness=None, hide_bb
         )
 
 
+_RECONSTRUCTOR_SINGLETON = None
+
+
+def _get_op_for_meta(meta):
+    """Resolve a Meta instance to the matching registered ``Operation``. Lazy import to avoid cycles."""
+    global _RECONSTRUCTOR_SINGLETON
+    if _RECONSTRUCTOR_SINGLETON is None:
+        from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+        _RECONSTRUCTOR_SINGLETON = Reconstructor()
+    op = _RECONSTRUCTOR_SINGLETON._ops.get(type(meta))
+    if op is None:
+        raise ValueError(
+            f"unsupported meta type: {type(meta).__name__}. Registered: {sorted(t.__name__ for t in _RECONSTRUCTOR_SINGLETON._ops)}"
+        )
+    return op
+
+
+def _single_image_meta(meta):
+    """Slice a batched Meta down to its first source-image record.
+
+    Most pipeline_utils helpers operate on a single image; they pass per-step
+    Meta objects with batch size 1 (or take the first record from a larger batch).
+    """
+    from dataclasses import fields
+
+    fresh = type(meta).__new__(type(meta))
+    for f in fields(meta):
+        v = getattr(meta, f.name)
+        if isinstance(v, list):
+            object.__setattr__(fresh, f.name, v[:1])
+        else:
+            object.__setattr__(fresh, f.name, v)
+    return fresh
+
+
+def _validate_history(history: list) -> None:
+    from lmi_utils.preprocess_utils.operation import Meta
+
+    if not isinstance(history, list):
+        raise TypeError(f"operations must be a list, got {type(history).__name__}")
+    for i, entry in enumerate(history):
+        if not isinstance(entry, Meta):
+            raise TypeError(f"operations[{i}] must be a Meta instance, got {type(entry).__name__}")
+
+
 @torch.inference_mode()
 def revert_mask_to_origin(mask, operations: list):
     """
-    This func reverts a single mask image according to the operations list IN ORDER.
-    The operations list contains items as dictionary. The items are listed as follows:
-        1. <pad: [pad_left_pixels, pad_right_pixels, pad_top_pixels, pad_bottom_pixels]>
-        2. <resize: [resized_w, resized_h, orig_w, orig_h]>
-        3. <flip: [flip left right, flip up down, im width, im height]>
-    args:
-        mask: np.array or torch.Tensor, shape (H,W) or (H,W,C)
-        operations : list of dict
+    Revert a single mask image to original-image space using a preprocessing history.
+
+    Args:
+        mask: np.array or torch.Tensor, shape (H, W) or (H, W, C).
+        operations: list of typed ``Meta`` records (one per preprocessing step), batch size 1.
+
+    Returns:
+        Mask reverted to original-image space, same type as input.
     """
+    _validate_history(operations)
     is_numpy = isinstance(mask, np.ndarray)
-    for operator in reversed(operations):
-        if "resize" in operator:
-            _, _, nw, nh = operator["resize"]
-            mask = resize_image(mask, nw, nh)
-        if "pad" in operator:
-            mask = fit_im(mask, -np.array(operator["pad"]))
-        if "flip" in operator:
-            lr, ud, im_w, im_h = operator["flip"]
-            if is_numpy:
-                mask = torch.from_numpy(mask)
-            if lr:
-                mask = torch.flip(mask, [1])
-            if ud:
-                mask = torch.flip(mask, [0])
-            if is_numpy:
-                mask = mask.numpy()
-    return mask
+    if is_numpy:
+        mask = torch.from_numpy(mask)
+
+    one_channel = mask.ndim == 2
+    if one_channel:
+        mask = mask.unsqueeze(-1)
+
+    for entry in reversed(operations):
+        op = _get_op_for_meta(entry)
+        mask = op.revert_images([mask], _single_image_meta(entry))[0]
+
+    if one_channel:
+        mask = mask.squeeze(-1)
+    return mask.numpy() if is_numpy else mask
 
 
 @torch.inference_mode()
 def revert_masks_to_origin(masks, operations: list):
-    results = []
+    """
+    Revert a stack of instance masks (N, H, W) to original-image space.
+
+    Treats the stack as instance masks bound to a single source image — applies
+    each op's coord-space mask transform, not the image-space ``revert_images``
+    used by :func:`revert_mask_to_origin`. Routes through the Operation registry
+    so resize/pad/crop all do the right thing for instance masks.
+    """
+    _validate_history(operations)
     if len(masks) == 0:
-        return results
+        return []
     is_tensor = isinstance(masks[0], torch.Tensor)
     is_numpy = isinstance(masks, np.ndarray)
-    for m in masks:
-        results.append(revert_mask_to_origin(m, operations))
+
+    masks_t = masks if isinstance(masks, torch.Tensor) else torch.as_tensor(np.array(masks) if is_numpy else masks)
+    per_image = [{"masks": masks_t}]
+    for entry in reversed(operations):
+        op = _get_op_for_meta(entry)
+        per_image = op.revert_coords(per_image, _single_image_meta(entry))
+    out = per_image[0]["masks"]
+
     if is_tensor:
-        return torch.stack(results)
-    return np.stack(results) if is_numpy else results
+        return out
+    return out.cpu().numpy() if is_numpy else list(out)
 
 
 @torch.inference_mode()
 def revert_to_origin(pts, operations: list, **kwargs):
     """
-    revert the points to original image space.
-    This func executes operations in the REVERSED order.
-    The operations list contains items as dictionary. The supported items are listed following:
-        1. <stretch: [stretch_ratio_x, stretch_ratio_y]>
-        2. <pad: [pad_left, pad_right, pad_top, pad_bottom]>
-        3. <resize: [resized_w, resized_h, orig_w, orig_h]>
-        4. <flip: [flip left-right (True/False), flip up-down (True/False), image width, image height]>
-    args:
-        pts: Nx2 or Nx4, where each row =(X_i,Y_i)
-        operations : list of dict
+    Revert Nx2 points or Nx4 xyxy boxes to original-image space.
+
+    Args:
+        pts: torch.Tensor / np.ndarray / list of shape (N, 2) or (N, 4).
+        operations: list of typed ``Meta`` records (one per preprocessing step).
+
+    kwargs:
+        round (bool): round and clamp output to non-negative integers. Default True.
+        verbose (bool): log intermediate values after each op. Default False.
+
+    Returns:
+        Same shape and type as input.
     """
+    _validate_history(operations)
     if not len(pts):
         return pts
+
     is_tensor = isinstance(pts, torch.Tensor)
     is_numpy = isinstance(pts, np.ndarray)
     if not is_tensor:
         pts = torch.from_numpy(pts) if is_numpy else torch.as_tensor(pts)
 
-    if pts.ndim != 2 or (pts.shape[1] != 2 and pts.shape[1] != 4):
+    if pts.ndim != 2 or pts.shape[1] not in (2, 4):
         raise Exception(f"pts should be Nx2 or Nx4, got shape: {pts.shape}")
 
     verbose = kwargs.get("verbose", False)
-    r, c = pts.shape
-    for op in reversed(operations):
-        if "resize" in op:
-            tw, th, orig_w, orig_h = op["resize"]
-            r = torch.tensor([tw / orig_w, th / orig_h], device=pts.device)
-            if c == 4:
-                r = r.repeat(2).unsqueeze(0)
-            pts = pts / r
-        elif "pad" in op:
-            pad_L, pad_R, pad_T, pad_B = op["pad"]
-            p = torch.tensor([pad_L, pad_T], device=pts.device)
-            if c == 4:
-                p = p.repeat(2).unsqueeze(0)
-            pts = pts - p
-        elif "stretch" in op:
-            s = torch.tensor(op["stretch"], device=pts.device)
-            if c == 4:
-                s = s.repeat(2).unsqueeze(0)
-            pts = pts / s
-        elif "flip" in op:
-            lr, ud, im_w, im_h = op["flip"]
-            idx = [0, 2] if c == 4 else [0]
-            idy = [1, 3] if c == 4 else [1]
-            if lr:
-                pts[:, idx] = im_w - pts[:, idx]
-                if c == 4:
-                    pts[:, [0, 2]] = pts[:, [2, 0]]
-            if ud:
-                pts[:, idy] = im_h - pts[:, idy]
-                if c == 4:
-                    pts[:, [1, 3]] = pts[:, [3, 1]]
-        else:
-            raise Exception(f"unsupported operation: {op}")
-
+    field = "boxes" if pts.shape[1] == 4 else "segments"
+    wrapped = pts if field == "boxes" else [pts]
+    per_image = [{field: wrapped}]
+    for entry in reversed(operations):
+        op = _get_op_for_meta(entry)
+        per_image = op.revert_coords(per_image, _single_image_meta(entry))
         if verbose:
-            logger.info(f"after {op}, pts: {pts}")
+            logger.info(f"after {type(entry).__name__}, result: {per_image}")
+
+    out = per_image[0]["boxes"] if field == "boxes" else per_image[0]["segments"][0]
 
     if kwargs.get("round", True):
-        pts = pts.round().clamp(min=0)
+        out = out.round().clamp(min=0)
     if is_tensor:
+        return out
+    return out.cpu().numpy() if is_numpy else out.tolist()
+
+
+def apply_operations(pts, operations: list):
+    """
+    Forward-apply preprocessing ops to original-space Nx2 points or Nx4 boxes.
+
+    Inverse of :func:`revert_to_origin`. Dispatches to each op's ``apply_coords``.
+    """
+    _validate_history(operations)
+    if not len(pts):
         return pts
-    return pts.numpy() if is_numpy else pts.tolist()
 
+    is_tensor = isinstance(pts, torch.Tensor)
+    is_numpy = isinstance(pts, np.ndarray)
+    if not is_tensor:
+        pts = torch.from_numpy(pts) if is_numpy else torch.as_tensor(pts)
 
-def apply_operations(pts: np.ndarray, operations: list):
-    """
-    apply operations to pts.
-    The operations list contains each item as a dictionary. The items are listed as follows:
-        1. <stretch: [stretch_ratio_x, stretch_ratio_y]>
-        2. <pad: [pad_left_pixels, pad_right_pixels, pad_top_pixels, pad_bottom_pixels]>
-        3. <resize: [resized_w, resized_h, orig_w, orig_h]>
-        4. <flip: [flip left-right (True/False), flip up-down (True/False), image width, image height]>
-    args:
-        pts: Nx2 or Nx4, where each row =(X_i,Y_i)
-        operations : list of dict
-    """
-    new_ops = []
-    for op in operations:
-        if "resize" in op:
-            tw, th, orig_w, orig_h = op["resize"]
-            tmp = {"resize": [orig_w, orig_h, tw, th]}
-        elif "pad" in op:
-            pad_L, pad_R, pad_T, pad_B = op["pad"]
-            tmp = {"pad": [-pad_L, -pad_R, -pad_T, -pad_B]}
-        elif "stretch" in op:
-            sx, sy = op["stretch"]
-            tmp = {"stretch": [1 / sx, 1 / sy]}
-        elif "flip" in op:
-            lr, ud, im_w, im_h = op["flip"]
-            tmp = {"flip": [lr, ud, im_w, im_h]}
-        else:
-            raise Exception(f"unsupported operation: {op}")
-        new_ops.append(tmp)
-    return revert_to_origin(pts, new_ops[::-1])
+    if pts.ndim != 2 or pts.shape[1] not in (2, 4):
+        raise Exception(f"pts should be Nx2 or Nx4, got shape: {pts.shape}")
+
+    field = "boxes" if pts.shape[1] == 4 else "segments"
+    wrapped = pts if field == "boxes" else [pts]
+    per_image = [{field: wrapped}]
+    for entry in operations:
+        op = _get_op_for_meta(entry)
+        per_image = op.apply_coords(per_image, _single_image_meta(entry))
+
+    out = per_image[0]["boxes"] if field == "boxes" else per_image[0]["segments"][0]
+    out = out.round().clamp(min=0)
+    if is_tensor:
+        return out
+    return out.cpu().numpy() if is_numpy else out.tolist()
 
 
 def convert_key_to_int(dt):
@@ -684,6 +724,25 @@ def _resolve_artifact_paths(model: Dict[str, Any], manifest_dir: Path) -> None:
                 artifact_data["model_path"] = str((manifest_dir / path_obj).resolve())
 
 
+def _validate_preprocessing_steps(models: List[Dict[str, Any]]) -> None:
+    """Fail fast on bad preprocessing steps in a hand-authored static manifest."""
+    from lmi_utils.preprocess_utils._parser import STEP_TYPES
+
+    ignored = {"crop-to-label"}
+
+    for model in models:
+        role = model.get("model_role", "<unknown>")
+        details = model.get("details") or {}
+        steps = details.get("preprocessing") or []
+        for i, step in enumerate(steps):
+            op_type = step.get("type", "")
+            if op_type in ignored:
+                continue
+            cfg_cls = STEP_TYPES.get(op_type)
+            if cfg_cls is None:
+                raise ValueError(f"Model role '{role}': preprocessing step at index {i} has unknown type '{op_type}'.")
+
+
 def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
     """
     Create models manifest from a static manifest json file.
@@ -692,9 +751,8 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
         manifest_json_path (str): path to the manifest JSON file.
         **kwargs: optional keyword arguments. Recognized:
             version (str): schema version of the manifest. Defaults to "3".
-                "2" expects flat fields under `details` and synthesizes a `configs` block;
-                "3" expects a manifest already shaped per schema_3 and only resolves
-                artifact paths.
+                v3 additionally validates preprocessing steps (rejecting unknown
+                types) before building configs.
     """
     version = kwargs.get("version", "3")
     logger.info(f"Loading static manifest from {manifest_json_path} with schema version {version}")
@@ -711,6 +769,9 @@ def get_models_from_static_manifest(manifest_json_path: str, **kwargs):
         raise ValueError(f"Unsupported static manifest version: {version}")
 
     manifest_v3 = version == "3"
+    if manifest_v3:
+        _validate_preprocessing_steps(models)
+
     keys_to_copy = (
         ["anomaly_size", "min_threshold", "max_threshold", "iou"]
         if manifest_v3

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -426,127 +426,65 @@ def plot_one_rbox(box, img, color=None, label=None, line_thickness=None, hide_bb
         )
 
 
-_RECONSTRUCTOR_SINGLETON = None
+_RECONSTRUCTORS = {}  # interpolation mode -> Reconstructor (image-revert resampling)
 
 
-def _get_op_for_meta(meta):
-    """Resolve a Meta instance to the matching registered ``Operation``. Lazy import to avoid cycles."""
-    global _RECONSTRUCTOR_SINGLETON
-    if _RECONSTRUCTOR_SINGLETON is None:
+def _reconstructor(interpolation: str = "bilinear"):
+    """Return a shared ``Reconstructor`` whose resize op reverts images with ``interpolation``.
+
+    ``"nearest"`` preserves binary/label masks; ``"bilinear"`` suits continuous-tone images.
+    Lazy import to avoid cycles.
+    """
+    recon = _RECONSTRUCTORS.get(interpolation)
+    if recon is None:
+        from lmi_utils.preprocess_utils.ops import ResizeOperation
         from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
-        _RECONSTRUCTOR_SINGLETON = Reconstructor()
-    op = _RECONSTRUCTOR_SINGLETON._ops.get(type(meta))
-    if op is None:
-        raise ValueError(
-            f"unsupported meta type: {type(meta).__name__}. Registered: {sorted(t.__name__ for t in _RECONSTRUCTOR_SINGLETON._ops)}"
-        )
-    return op
-
-
-def _single_image_meta(meta):
-    """Slice a batched Meta down to its first source-image record.
-
-    Most pipeline_utils helpers operate on a single image; they pass per-step
-    Meta objects with batch size 1 (or take the first record from a larger batch).
-    """
-    from dataclasses import fields
-
-    fresh = type(meta).__new__(type(meta))
-    for f in fields(meta):
-        v = getattr(meta, f.name)
-        if isinstance(v, list):
-            object.__setattr__(fresh, f.name, v[:1])
-        else:
-            object.__setattr__(fresh, f.name, v)
-    return fresh
-
-
-def _validate_history(history: list) -> None:
-    from lmi_utils.preprocess_utils.operation import Meta
-
-    if not isinstance(history, list):
-        raise TypeError(f"operations must be a list, got {type(history).__name__}")
-    for i, entry in enumerate(history):
-        if not isinstance(entry, Meta):
-            raise TypeError(f"operations[{i}] must be a Meta instance, got {type(entry).__name__}")
+        recon = Reconstructor()
+        if interpolation != "bilinear":
+            recon.register(ResizeOperation(image_mode=interpolation))
+        _RECONSTRUCTORS[interpolation] = recon
+    return recon
 
 
 @torch.inference_mode()
-def revert_mask_to_origin(mask, operations: list):
+def revert_mask_to_origin(mask, operations: list, interpolation: str = "bilinear"):
     """
     Revert a single mask image to original-image space using a preprocessing history.
 
     Args:
         mask: np.array or torch.Tensor, shape (H, W) or (H, W, C).
         operations: list of typed ``Meta`` records (one per preprocessing step), batch size 1.
+        interpolation: resize-revert mode. Use ``"nearest"`` for binary/label masks
+            (bilinear erodes them on upscale); ``"bilinear"`` for continuous-tone images.
 
     Returns:
         Mask reverted to original-image space, same type as input.
     """
-    _validate_history(operations)
-    is_numpy = isinstance(mask, np.ndarray)
-    if is_numpy:
-        mask = torch.from_numpy(mask)
-
-    one_channel = mask.ndim == 2
-    if one_channel:
-        mask = mask.unsqueeze(-1)
-
-    for entry in reversed(operations):
-        op = _get_op_for_meta(entry)
-        mask = op.revert_images([mask], _single_image_meta(entry))[0]
-
-    if one_channel:
-        mask = mask.squeeze(-1)
-    return mask.numpy() if is_numpy else mask
+    return _reconstructor(interpolation).reconstruct_images([mask], operations)[0]
 
 
 @torch.inference_mode()
-def revert_masks_to_origin(masks, operations: list):
+def revert_masks_to_origin(masks, operations: list, interpolation: str = "bilinear"):
     """
-    Revert a stack of instance masks (N, H, W) to original-image space.
+    Revert a stack of mask images (N, H, W) to original-image space.
 
-    Treats the stack as instance masks bound to a single source image — applies
-    each op's coord-space mask transform, not the image-space ``revert_images``
-    used by :func:`revert_mask_to_origin`. Routes through the Operation registry
-    so resize/pad/crop all do the right thing for instance masks.
+    Batched form of :func:`revert_mask_to_origin`. Pass ``interpolation="nearest"`` for
+    binary/label instance masks.
     """
-    _validate_history(operations)
     if len(masks) == 0:
         return []
     is_tensor = isinstance(masks[0], torch.Tensor)
     is_numpy = isinstance(masks, np.ndarray)
 
-    masks_t = masks if isinstance(masks, torch.Tensor) else torch.as_tensor(np.array(masks) if is_numpy else masks)
-    per_image = [{"masks": masks_t}]
-    for entry in reversed(operations):
-        op = _get_op_for_meta(entry)
-        per_image = op.revert_coords(per_image, _single_image_meta(entry))
-    out = per_image[0]["masks"]
-
+    results = [revert_mask_to_origin(m, operations, interpolation=interpolation) for m in masks]
     if is_tensor:
-        return out
-    return out.cpu().numpy() if is_numpy else list(out)
+        return torch.stack(results)
+    return np.stack(results) if is_numpy else results
 
 
-@torch.inference_mode()
-def revert_to_origin(pts, operations: list, **kwargs):
-    """
-    Revert Nx2 points or Nx4 xyxy boxes to original-image space.
-
-    Args:
-        pts: torch.Tensor / np.ndarray / list of shape (N, 2) or (N, 4).
-        operations: list of typed ``Meta`` records (one per preprocessing step).
-
-    kwargs:
-        round (bool): round and clamp output to non-negative integers. Default True.
-        verbose (bool): log intermediate values after each op. Default False.
-
-    Returns:
-        Same shape and type as input.
-    """
-    _validate_history(operations)
+def _transform_pts(pts, operations: list, *, reverse: bool, to_round: bool):
+    """Route Nx2 points / Nx4 xyxy boxes through the Reconstructor's coord transform."""
     if not len(pts):
         return pts
 
@@ -558,55 +496,46 @@ def revert_to_origin(pts, operations: list, **kwargs):
     if pts.ndim != 2 or pts.shape[1] not in (2, 4):
         raise Exception(f"pts should be Nx2 or Nx4, got shape: {pts.shape}")
 
-    verbose = kwargs.get("verbose", False)
-    field = "boxes" if pts.shape[1] == 4 else "segments"
-    wrapped = pts if field == "boxes" else [pts]
-    per_image = [{field: wrapped}]
-    for entry in reversed(operations):
-        op = _get_op_for_meta(entry)
-        per_image = op.revert_coords(per_image, _single_image_meta(entry))
-        if verbose:
-            logger.info(f"after {type(entry).__name__}, result: {per_image}")
+    recon = _reconstructor()
+    transform = recon.reconstruct_coordinates if reverse else recon.apply_coordinates
+    if pts.shape[1] == 4:
+        out = transform({"boxes": [pts]}, operations)["boxes"][0]
+    else:
+        out = transform({"segments": [[pts]]}, operations)["segments"][0][0]
 
-    out = per_image[0]["boxes"] if field == "boxes" else per_image[0]["segments"][0]
-
-    if kwargs.get("round", True):
+    if to_round:
         out = out.round().clamp(min=0)
     if is_tensor:
         return out
     return out.cpu().numpy() if is_numpy else out.tolist()
 
 
-def apply_operations(pts, operations: list):
+@torch.inference_mode()
+def revert_to_origin(pts, operations: list, round: bool = True, **kwargs):
+    """
+    Revert Nx2 points or Nx4 xyxy boxes to original-image space.
+
+    Args:
+        pts: torch.Tensor / np.ndarray / list of shape (N, 2) or (N, 4).
+        operations: list of typed ``Meta`` records (one per preprocessing step), batch size 1.
+
+    kwargs:
+        round (bool): round and clamp output to non-negative integers. Default True.
+
+    Returns:
+        Same shape and type as input.
+    """
+    return _transform_pts(pts, operations, reverse=True, to_round=round)
+
+
+@torch.inference_mode()
+def apply_operations(pts, operations: list, round: bool = True):
     """
     Forward-apply preprocessing ops to original-space Nx2 points or Nx4 boxes.
 
     Inverse of :func:`revert_to_origin`. Dispatches to each op's ``apply_coords``.
     """
-    _validate_history(operations)
-    if not len(pts):
-        return pts
-
-    is_tensor = isinstance(pts, torch.Tensor)
-    is_numpy = isinstance(pts, np.ndarray)
-    if not is_tensor:
-        pts = torch.from_numpy(pts) if is_numpy else torch.as_tensor(pts)
-
-    if pts.ndim != 2 or pts.shape[1] not in (2, 4):
-        raise Exception(f"pts should be Nx2 or Nx4, got shape: {pts.shape}")
-
-    field = "boxes" if pts.shape[1] == 4 else "segments"
-    wrapped = pts if field == "boxes" else [pts]
-    per_image = [{field: wrapped}]
-    for entry in operations:
-        op = _get_op_for_meta(entry)
-        per_image = op.apply_coords(per_image, _single_image_meta(entry))
-
-    out = per_image[0]["boxes"] if field == "boxes" else per_image[0]["segments"][0]
-    out = out.round().clamp(min=0)
-    if is_tensor:
-        return out
-    return out.cpu().numpy() if is_numpy else out.tolist()
+    return _transform_pts(pts, operations, reverse=False, to_round=round)
 
 
 def convert_key_to_int(dt):

--- a/lmi_utils/image_utils/img_resize.py
+++ b/lmi_utils/image_utils/img_resize.py
@@ -23,12 +23,32 @@ def is_cuda_cv():  # 1 == using cuda, 0 = not using cuda
 
 
 def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwargs):
+    """Resize a single image (and optionally letterbox-pad it) to a target size.
+
+    Args:
+        image: HW or HWC image (numpy array or torch tensor).
+        width (int, optional): target width. Defaults to current width.
+        height (int, optional): target height. Defaults to current height.
+        preserve_aspect (bool): if True, scale to fit preserving aspect ratio and pad to (width, height).
+
+    kwargs:
+        mode (str): interpolation mode. Default "bilinear".
+        return_operators (bool): if True, also return a history list (new schema).
+        operators (list): seed history list. ``return_operators=True`` returns
+            ``seed + new_entries``. Each entry is::
+
+                {"type": "resize", "metadata": [{"src_size": [w, h], "dst_size": [w, h], "pad"?: [L, R, T, B]}]}
+                {"type": "pad",    "metadata": [{"pad": [L, R, T, B]}]}
+
+    Returns:
+        Image (always), and history list when ``return_operators=True``.
+    """
     h0, w0 = image.shape[:2]
-    # Default target dimensions to current if not provided
     tw = width if width is not None else w0
     th = height if height is not None else h0
-    operators = kwargs.get("operators", [])[:]
-    # Check if resize is needed
+    operators = list(kwargs.get("operators", []))
+    mode = kwargs.get("mode", "bilinear")
+
     if tw == w0 and th == h0:
         im_out = image
     else:
@@ -36,16 +56,16 @@ def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwar
             scale = min(th / h0, tw / w0)
             w1 = int(scale * w0)
             h1 = int(scale * h0)
-            im_out = resize_image(image, W=w1, H=h1, mode=kwargs.get("mode", "bilinear"))
-            operators.append({"resize": [w1, h1, w0, h0]})
-
+            im_out = resize_image(image, W=w1, H=h1, mode=mode)
+            entry = {"type": "resize", "metadata": [{"src_size": [w0, h0], "dst_size": [w1, h1]}]}
             if w1 != tw or h1 != th:
                 im_out, pad_l, pad_r, pad_t, pad_b = fit_im_to_size(im_out, tw, th)
-                operators.append({"pad": [pad_l, pad_r, pad_t, pad_b]})
+                entry["metadata"][0]["pad"] = [pad_l, pad_r, pad_t, pad_b]
+            operators.append(entry)
         else:
-            # Direct Resize (Stretch)
-            im_out = resize_image(image, W=tw, H=th, mode=kwargs.get("mode", "bilinear"))
-            operators.append({"resize": [tw, th, w0, h0]})
+            im_out = resize_image(image, W=tw, H=th, mode=mode)
+            operators.append({"type": "resize", "metadata": [{"src_size": [w0, h0], "dst_size": [tw, th]}]})
+
     if kwargs.get("return_operators", False) is True:
         return im_out, operators
     return im_out

--- a/lmi_utils/pipeline_base/core/schemas/schema_3.py
+++ b/lmi_utils/pipeline_base/core/schemas/schema_3.py
@@ -16,6 +16,7 @@ class PreprocessStep(BaseModel):
 
     type: str
     configuration: Dict[str, Any]
+    # Optional informational tag. GoFactory supplies it; local/static manifests may omit it.
     id: Optional[str] = None
 
 
@@ -46,6 +47,12 @@ class ADConfigs(BaseModel):
 
     min_threshold: float
     max_threshold: float
+
+
+class ClassificationConfigs(BaseModel):
+    """Configs for Classification."""
+
+    model_config = ConfigDict(extra="ignore")
 
 
 class _ModelBase(BaseModel):
@@ -79,8 +86,14 @@ class ADModel(_ModelBase):
     configs: ADConfigs
 
 
+class ClassificationModel(_ModelBase):
+    # only used for static models
+    model_type: Literal["Classification"]
+    configs: ClassificationConfigs
+
+
 Model = Annotated[
-    Union[ODModel, ADModel],
+    Union[ODModel, ADModel, ClassificationModel],
     Field(discriminator="model_type"),
 ]
 
@@ -101,28 +114,34 @@ class ModelCollectionV3(BaseModel):
 
     def get_global_preprocessing(self) -> Dict[str, List[Dict[str, Any]]]:
         supported = {"resize", "tile"}
+        ignored = {"crop-to-label"}
         tiling_keys = {"height", "width", "x_stride", "y_stride"}
 
         out: Dict[str, List[Dict[str, Any]]] = {}
         for role, model in self.models.items():
             ops: List[Dict[str, Any]] = []
             for step in model.details.preprocessing:
+                if step.type in ignored:
+                    continue
                 if step.type not in supported:
                     raise ValueError(f"Unsupported type '{step.type}'.")
                 if step.type == "tile":
                     if not tiling_keys.issubset(step.configuration.keys()):
                         raise ValueError(f"Tiling configuration must contain keys: {tiling_keys}.")
                     cfg = step.configuration
-                    ops.append(
-                        {
-                            "type": "tile",
-                            "configuration": {
-                                "tile_size": [cfg["height"], cfg["width"]],
-                                "stride": [cfg["y_stride"], cfg["x_stride"]],
-                            },
-                        }
-                    )
+                    entry: Dict[str, Any] = {
+                        "type": "tile",
+                        "configuration": {
+                            "tile_size": [cfg["height"], cfg["width"]],
+                            "stride": [cfg["y_stride"], cfg["x_stride"]],
+                        },
+                    }
                 else:
-                    ops.append(step.model_dump(exclude_none=True))
+                    entry = step.model_dump(exclude={"id"}, exclude_none=True)
+
+                if step.id is not None:
+                    entry["id"] = step.id
+                ops.append(entry)
+
             out[role] = ops
         return out

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -21,6 +21,8 @@ from lmi_utils.dataset_utils.representations import (
 
 # LMI AIS repo's modules
 from lmi_utils.image_utils.types import ImageBatch, ImageLike
+from lmi_utils.preprocess_utils import parse_steps, steps
+from lmi_utils.preprocess_utils.operation import Meta
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 from object_detectors.od_core.object_detector import ObjectDetector
@@ -202,20 +204,32 @@ class PipelineBase(metaclass=ABCMeta):
             self.logger.info(f"Successfully loaded {model_source} model: {model_key}\n")
         self.logger.info(f"Final loaded models: {list(self.models.keys())}\n")
 
-    def preprocess(self, model_role: str, images: ImageBatch) -> Tuple[List[ImageLike], List[Dict[str, Any]]]:
+    def preprocess(
+        self,
+        model_role: str,
+        images: ImageBatch,
+    ) -> Tuple[List[ImageLike], List[Meta]]:
         """preprocess the image(s) based on the preprocessing steps in model_role.
+        Note: the ``crop-to-label`` preprocess is intentionally ignored.
 
         Pairs with revert_preprocess() as its inverse.
 
+        For manual preprocessing, call``self.preprocessor.preprocess(images, configs)`` directly,
+        where ``configs`` are typed Config objects, e.g.:
+
+            from lmi_utils.preprocess_utils import steps
+            configs = [
+                steps.resize(width=224, height=224, preserve_aspect=True),
+                steps.flip(lr=True),
+            ]
+
         Args:
-            model_role (str): the model role to be used for preprocessing.
-            images (ImageBatch): the image(s) to be preprocessed.
+            model_role: the model role to be used for preprocessing.
+            images: the image(s) to be preprocessed.
 
         Returns:
             list[ImageLike]: the preprocessed image(s).
-            list[dict]: the preprocessing steps, each with keys:
-                - "type" (str): the type of the preprocessing operation.
-                - "metadata" (list): the metadata returned by the preprocessing operation, used for reconstruction.
+            list[Meta]: typed per-step metadata for reconstruction.
         """
         if model_role not in self._preprocessing:
             raise ValueError(f"Not found global preprocessing steps for model role: {model_role}")
@@ -263,11 +277,11 @@ class PipelineBase(metaclass=ABCMeta):
             f"[{model_role}] preprocessed size {(h, w)} != model input {(th, tw)}; injecting a resize. "
             "Configure a matching resize step in global preprocessing to remove this."
         )
-        resize_step = [{"type": "resize", "configuration": {"width": tw, "height": th, "preserve_aspect": preserve}}]
+        resize_step = [steps.resize(width=tw, height=th, preserve_aspect=preserve)]
         processed, extra = self.preprocessor.preprocess(processed, resize_step)
         return processed, history + extra
 
-    def revert_preprocess(self, data, ops: List[Dict[str, Any]]):
+    def revert_preprocess(self, data, ops: List[Meta]):
         """Invert preprocessing transforms on either image data (AD) or detection coordinates (OD).
 
         Dispatches based on the type of ``data``:
@@ -276,10 +290,20 @@ class PipelineBase(metaclass=ABCMeta):
 
         Pairs with ``preprocess()`` as its inverse.
 
+        For manual reverting, build ``ops`` as typed Meta objects, e.g.:
+
+            from lmi_utils.preprocess_utils import steps
+            ops = [
+                steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...),
+                steps.revert_crop(boxes=..., orig_sizes=...),
+            ]
+
+        in the same order they were applied during preprocessing.
+
         Args:
             data: Either a list of images (AD) or a batch results dict with keys
                   boxes, scores, classes, masks, segments, points (OD).
-            ops (list[dict]): Preprocessing history returned by preprocess().
+            ops (list[Meta]): Preprocessing history returned by preprocess().
 
         Returns:
             list[ImageLike] for the AD path (reconstructed images), or

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -234,6 +234,7 @@ class PipelineBase(metaclass=ABCMeta):
         if model_role not in self._preprocessing:
             raise ValueError(f"Not found global preprocessing steps for model role: {model_role}")
 
+        images = self.preprocessor.as_image_list(images)
         processed, history = self.preprocessor.preprocess(images, self._preprocessing[model_role])
         return self._ensure_od_input_size(model_role, images, processed, history)
 

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -193,7 +193,7 @@ class PipelineBase(metaclass=ABCMeta):
             self._load_model(model_key, config_to_use, **kwargs)
 
             if model_key in global_preprocessing:
-                self._preprocessing[model_key] = global_preprocessing[model_key]
+                self._preprocessing[model_key] = parse_steps(global_preprocessing[model_key])
                 self.logger.info(f"Loaded global preprocessing for '{model_key}'")
             else:
                 raise ValueError(

--- a/lmi_utils/preprocess_utils/__init__.py
+++ b/lmi_utils/preprocess_utils/__init__.py
@@ -1,0 +1,6 @@
+from . import steps
+from ._parser import parse_steps
+from .preprocessor import Preprocessor
+from .reconstructor import Reconstructor
+
+__all__ = ["Preprocessor", "Reconstructor", "steps", "parse_steps"]

--- a/lmi_utils/preprocess_utils/_parser.py
+++ b/lmi_utils/preprocess_utils/_parser.py
@@ -1,0 +1,51 @@
+"""Bridge between JSON manifests (legacy dict-shape) and typed Configs.
+
+External callers that load preprocessing manifests from JSON pass the resulting
+list of dicts through ``parse_steps`` to get a ``List[Config]`` suitable for
+``Preprocessor.preprocess``. In-process callers should construct Configs directly
+(via ``lmi_utils.preprocess_utils.steps``) and skip this layer.
+"""
+
+from typing import Any, Dict, List, Type
+
+from .operation import Config
+from .ops import (
+    CropConfig,
+    FlipConfig,
+    PadConfig,
+    ResizeConfig,
+    TileConfig,
+)
+
+# Manifest "type" string -> Config dataclass.
+STEP_TYPES: Dict[str, Type[Config]] = {
+    "crop": CropConfig,
+    "flip": FlipConfig,
+    "pad": PadConfig,
+    "resize": ResizeConfig,
+    "tile": TileConfig,
+}
+
+
+def parse_steps(steps: List[Dict[str, Any]]) -> List[Config]:
+    """Convert a list of manifest dicts into typed Configs.
+
+    Each entry must have ``type`` and ``configuration`` keys; optional ``id`` is
+    forwarded as the Config's ``id`` field.
+    """
+    if not isinstance(steps, list):
+        raise TypeError(f"steps must be a list, got {type(steps)}")
+    out: List[Config] = []
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            raise TypeError(f"steps[{i}] must be a dict, got {type(step)}")
+        if "type" not in step or "configuration" not in step:
+            raise ValueError(f"steps[{i}] must contain keys 'type' and 'configuration', got {step!r}")
+        cfg_cls = STEP_TYPES.get(step["type"])
+        if cfg_cls is None:
+            raise ValueError(f"steps[{i}]: unknown type {step['type']!r}. Known: {sorted(STEP_TYPES)}")
+        kwargs = dict(step.get("configuration") or {})
+        if step.get("id") is not None:
+            kwargs["id"] = step["id"]
+        out.append(cfg_cls(**kwargs))
+    return out

--- a/lmi_utils/preprocess_utils/base.py
+++ b/lmi_utils/preprocess_utils/base.py
@@ -7,50 +7,35 @@ from lmi_utils.image_utils.types import ImageLike
 
 
 class BaseProcessor:
-    _STEP_REQUIRED_KEYS = {"type", "configuration"}
-    _HISTORY_REQUIRED_KEYS = {"type", "metadata"}
     _COORD_FIELDS = frozenset({"boxes", "segments", "points", "masks"})
     # Subset of _COORD_FIELDS whose value is a list-of-tensors instead of a single tensor.
     _COORD_LIST_FIELDS = frozenset({"segments"})
 
     def to_tensor_list(self, images: List[ImageLike]) -> Tuple[List[torch.Tensor], bool]:
-        """
-        Convert image list to tensors if needed.
-
-        Returns:
-            (tensor_list, is_numpy): List of tensors and flag indicating if input was numpy
-        """
+        """Convert image list to tensors if needed; make contiguous."""
         is_numpy = isinstance(images[0], np.ndarray)
         if is_numpy:
-            return [torch.from_numpy(img) for img in images], True
-        return images, False
+            return [torch.from_numpy(np.ascontiguousarray(img)) for img in images], True
+        return [img.contiguous() for img in images], False
 
     def from_tensor_list(self, images: List[torch.Tensor], to_numpy: bool) -> List[ImageLike]:
-        """Convert tensor list back to numpy if needed."""
+        images = [img.contiguous() for img in images]
         if to_numpy:
             return [img.cpu().numpy() for img in images]
         return images
 
     def to_tensor_results(self, per_image: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], bool]:
-        """
-        Convert coordinate fields in result dicts to float32 tensors.
-
-        Converts boxes, segments, points, masks. Leaves classes and scores untouched.
-        Returns (converted_results, is_numpy).
-        """
         is_numpy = self._detect_results_numpy(per_image)
         if not is_numpy:
             return per_image, False
         return [self._result_to_tensor(r) for r in per_image], True
 
     def from_tensor_results(self, per_image: List[Dict[str, Any]], to_numpy: bool) -> List[Dict[str, Any]]:
-        """Convert coordinate fields back to numpy if to_numpy is True."""
         if not to_numpy:
             return per_image
         return [self._result_from_tensor(r) for r in per_image]
 
     def _detect_results_numpy(self, per_image: List[Dict[str, Any]]) -> bool:
-        """Return True if coordinate fields are numpy arrays. Raises if types are mixed."""
         first_type = None
         for r in per_image:
             for field in self._COORD_FIELDS:
@@ -94,13 +79,10 @@ class BaseProcessor:
         return out
 
     def validate_image_list(self, images: List[ImageLike], stage: str = "processing") -> None:
-        """Validate that images is a proper list of tensors or arrays."""
         if not isinstance(images, list):
             raise TypeError("Images must be a list.")
-
         if not images:
             raise ValueError(f"No input images provided for {stage}.")
-
         first_type = type(images[0])
         if first_type not in (torch.Tensor, np.ndarray):
             raise TypeError("Images must be torch.Tensors or np.ndarrays")
@@ -111,36 +93,26 @@ class BaseProcessor:
                 raise ValueError(f"Expected 2D (HW) or 3D (HWC) image, got {img.ndim}D array with shape {img.shape}")
 
     def validate_image_handler_output(self, output: Any, handler_name: str, expected_type: str = "handler") -> None:
-        """Validate handler output format."""
         if not isinstance(output, list):
             raise TypeError(f"{expected_type.capitalize()} '{handler_name}' must return a list of images, got {type(output)}")
         if not all(isinstance(img, torch.Tensor) for img in output):
             raise TypeError(f"{expected_type.capitalize()} '{handler_name}' returned non-tensor images")
 
-    def validate_coord_handler_output(self, output: Any, handler_name: str, input_populated: set = None) -> None:
-        """
-        Validate coord handler output:
-          - is a list of dicts.
-          - preserves every coord field that was non-empty in the input.
-
-        `input_populated` is the set of coord field names that had at least one
-        non-empty value across the input batch. The output must also have at
-        least one non-empty value in each of those fields.
-        """
+    def validate_coord_handler_output(self, output: Any, handler_name: str, input_populated: set = None) -> set:
+        """Validate a coord handler's output and return its populated coord fields."""
         if not isinstance(output, list) or not all(isinstance(d, dict) for d in output):
             raise TypeError(f"Revert coordinate handler '{handler_name}' must return a list of dicts, got {type(output)}")
-        if not input_populated:
-            return
         output_populated = self._populated_coord_fields(output)
-        dropped = input_populated - output_populated
-        if dropped:
-            raise KeyError(
-                f"Revert coordinate handler '{handler_name}' dropped non-empty coord field(s): {sorted(dropped)}. "
-                f"Input had {sorted(input_populated)}, output has {sorted(output_populated)}."
-            )
+        if input_populated:
+            dropped = input_populated - output_populated
+            if dropped:
+                raise KeyError(
+                    f"Revert coordinate handler '{handler_name}' dropped non-empty coord field(s): {sorted(dropped)}. "
+                    f"Input had {sorted(input_populated)}, output has {sorted(output_populated)}."
+                )
+        return output_populated
 
     def _populated_coord_fields(self, per_image: List[Dict[str, Any]]) -> set:
-        """Return the set of _COORD_FIELDS that have at least one non-empty value across the batch."""
         populated = set()
         for r in per_image:
             for field in self._COORD_FIELDS:
@@ -155,23 +127,3 @@ class BaseProcessor:
                 elif len(val):
                     populated.add(field)
         return populated
-
-    def validate_handler_metadata(self, metadata: Any, handler_name: str) -> None:
-        """Validate that handler metadata is a list (one entry per input image)."""
-        if not isinstance(metadata, list):
-            raise TypeError(f"Handler '{handler_name}' must return metadata as list, got {type(metadata)}")
-
-    def _validate_steps(self, steps: List[Dict[str, Any]], required_keys: set) -> None:
-        if not isinstance(steps, list):
-            raise TypeError("Steps must be a list.")
-        if not all(isinstance(step, dict) for step in steps):
-            raise TypeError("All steps must be dictionaries.")
-        for step in steps:
-            if not required_keys.issubset(step.keys()):
-                raise ValueError(f"Each step must contain keys: {required_keys}")
-
-    def validate_steps(self, steps: List[Dict[str, Any]]) -> None:
-        self._validate_steps(steps, self._STEP_REQUIRED_KEYS)
-
-    def validate_history_steps(self, steps: List[Dict[str, Any]]) -> None:
-        self._validate_steps(steps, self._HISTORY_REQUIRED_KEYS)

--- a/lmi_utils/preprocess_utils/base.py
+++ b/lmi_utils/preprocess_utils/base.py
@@ -11,6 +11,18 @@ class BaseProcessor:
     # Subset of _COORD_FIELDS whose value is a list-of-tensors instead of a single tensor.
     _COORD_LIST_FIELDS = frozenset({"segments"})
 
+    @staticmethod
+    def as_image_list(images: Any) -> List[ImageLike]:
+        """Normalize input into a flat list of HW(C) images.
+
+        Accepts a single HW/HWC image, a BHWC batch (4D), or an existing list and always returns a list.
+        """
+        if isinstance(images, list):
+            return images
+        if hasattr(images, "ndim") and images.ndim == 4:
+            return list(images)
+        return [images]
+
     def to_tensor_list(self, images: List[ImageLike]) -> Tuple[List[torch.Tensor], bool]:
         """Convert image list to tensors if needed; make contiguous."""
         is_numpy = isinstance(images[0], np.ndarray)

--- a/lmi_utils/preprocess_utils/operation.py
+++ b/lmi_utils/preprocess_utils/operation.py
@@ -1,46 +1,52 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar
 
 import torch
 
 
-class Operation(ABC):
-    """
-    Bundles the forward + revert-images + revert-coords for one preprocessing op.
+@dataclass
+class Config:
+    """Base for all forward-step configs. Subclass + @dataclass per op."""
 
-    Pair this with `Preprocessor.register(op)` and `Reconstructor.register(op)` so
-    a single object owns all three sides of the contract — no more chance of
-    forgetting to register a revert handler under a matching name.
+    id: Optional[str] = None
 
-    Subclasses must set `name` (the key used in processing_steps and history)
-    and implement `forward`. `revert_images` and `revert_coords` default to
-    no-ops, which is the right behavior for image-space-only ops (normalize,
-    clahe, denoise, ...).
+
+@dataclass
+class Meta:
+    """Base for all per-step metadata. Fields are batched (struct-of-arrays)."""
+
+
+CfgT = TypeVar("CfgT", bound=Config)
+MetaT = TypeVar("MetaT", bound=Meta)
+
+
+class Operation(ABC, Generic[CfgT, MetaT]):
+    """Forward + revert-images + revert-coords + apply-coords for one op.
+
+    Subclasses declare ``config_cls`` and ``meta_cls`` and implement ``forward``.
+    The three revert handlers default to identity (correct for image-space-only ops).
 
     Device contract:
-        Implementations MUST preserve the input device — output tensors live
-        on the same device as inputs. When allocating constants or scratch
-        tensors, always pass `device=<input>.device` (never default to CPU
-        and `.to(...)` later — that's a per-call H2D transfer).
+        Output tensors live on the same device as the input tensors. Always
+        allocate scratch with ``device=<input>.device``.
     """
 
-    name: str = ""
+    config_cls: ClassVar[Type[Config]]
+    meta_cls: ClassVar[Type[Meta]]
 
     @abstractmethod
-    def forward(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], List[Any]]:
-        """
-        Run the op.
+    def forward(self, images: List[torch.Tensor], config: CfgT) -> Tuple[List[torch.Tensor], MetaT]:
+        """Run the op. Returns (processed_images, batched_meta)."""
 
-        Returns:
-            (images, metadata_list): processed images and a per-source-image
-            metadata list. The metadata is fed back unchanged to revert_images
-            and revert_coords.
-        """
-
-    def revert_images(self, images: List[torch.Tensor], metadata: List[Any]) -> List[torch.Tensor]:
-        """Default: identity. Override for ops that change image geometry."""
+    def revert_images(self, images: List[torch.Tensor], meta: MetaT) -> List[torch.Tensor]:
+        """Default identity. Override for ops that change image geometry."""
         return images
 
-    def revert_coords(self, results: List[Dict[str, Any]], metadata: List[Any]) -> List[Dict[str, Any]]:
-        """Default: identity. Override for ops that change coordinate space."""
+    def revert_coords(self, results: List[Dict[str, Any]], meta: MetaT) -> List[Dict[str, Any]]:
+        """Default identity. Override for ops that change coordinate space."""
+        return results
+
+    def apply_coords(self, results: List[Dict[str, Any]], meta: MetaT) -> List[Dict[str, Any]]:
+        """Forward complement of ``revert_coords``. Default identity."""
         return results

--- a/lmi_utils/preprocess_utils/ops/__init__.py
+++ b/lmi_utils/preprocess_utils/ops/__init__.py
@@ -1,4 +1,23 @@
-from .resize import ResizeOperation
-from .tile import TileOperation
+from .crop import CropConfig, CropMeta, CropOperation
+from .flip import FlipConfig, FlipMeta, FlipOperation
+from .pad import PadConfig, PadMeta, PadOperation
+from .resize import ResizeConfig, ResizeMeta, ResizeOperation
+from .tile import TileConfig, TileMeta, TileOperation
 
-__all__ = ["ResizeOperation", "TileOperation"]
+__all__ = [
+    "CropConfig",
+    "CropMeta",
+    "CropOperation",
+    "FlipConfig",
+    "FlipMeta",
+    "FlipOperation",
+    "PadConfig",
+    "PadMeta",
+    "PadOperation",
+    "ResizeConfig",
+    "ResizeMeta",
+    "ResizeOperation",
+    "TileConfig",
+    "TileMeta",
+    "TileOperation",
+]

--- a/lmi_utils/preprocess_utils/ops/crop.py
+++ b/lmi_utils/preprocess_utils/ops/crop.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from .._coords import apply_coord_transform
+from ..operation import Config, Meta, Operation
+
+
+@dataclass
+class CropConfig(Config):
+    """Crop each image to a per-image box.
+
+    boxes: list of [x1, y1, x2, y2], one per input image.
+    """
+
+    boxes: List[List[int]] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not isinstance(self.boxes, list) or not self.boxes:
+            raise ValueError(f"CropConfig: 'boxes' must be a non-empty list, got {self.boxes!r}")
+        for i, box in enumerate(self.boxes):
+            if len(box) != 4:
+                raise ValueError(f"CropConfig: boxes[{i}] must have 4 elements [x1,y1,x2,y2], got {box!r}")
+
+
+@dataclass
+class CropMeta(Meta):
+    """Batched crop metadata.
+
+    boxes: clamped [x1, y1, x2, y2] actually used per image.
+    orig_sizes: [W, H] per image, used to restore the canvas on revert.
+    """
+
+    boxes: List[List[int]] = field(default_factory=list)
+    orig_sizes: List[List[int]] = field(default_factory=list)
+
+    def __post_init__(self):
+        if len(self.boxes) != len(self.orig_sizes):
+            raise ValueError(f"CropMeta: boxes ({len(self.boxes)}) and orig_sizes ({len(self.orig_sizes)}) lengths must match")
+
+
+class CropOperation(Operation[CropConfig, CropMeta]):
+    config_cls = CropConfig
+    meta_cls = CropMeta
+
+    @torch.inference_mode()
+    def forward(self, images: List[torch.Tensor], config: CropConfig) -> Tuple[List[torch.Tensor], CropMeta]:
+        if len(config.boxes) != len(images):
+            raise ValueError(f"crop: boxes length ({len(config.boxes)}) != image count ({len(images)})")
+
+        out_images: List[torch.Tensor] = []
+        out_boxes: List[List[int]] = []
+        out_sizes: List[List[int]] = []
+        for img, box in zip(images, config.boxes):
+            H, W = img.shape[0], img.shape[1]
+            x1 = max(0, min(W, int(round(float(box[0])))))
+            y1 = max(0, min(H, int(round(float(box[1])))))
+            x2 = max(x1, min(W, int(round(float(box[2])))))
+            y2 = max(y1, min(H, int(round(float(box[3])))))
+            out_images.append(img[y1:y2, x1:x2])
+            out_boxes.append([x1, y1, x2, y2])
+            out_sizes.append([W, H])
+
+        return out_images, CropMeta(boxes=out_boxes, orig_sizes=out_sizes)
+
+    @torch.inference_mode()
+    def revert_images(self, images: List[torch.Tensor], meta: CropMeta) -> List[torch.Tensor]:
+        if len(images) != len(meta.boxes):
+            raise ValueError(f"crop: image count ({len(images)}) != meta count ({len(meta.boxes)})")
+        restored = []
+        for img, box, size in zip(images, meta.boxes, meta.orig_sizes):
+            x1, y1, _, _ = box
+            W, H = size
+            ch, cw = img.shape[0], img.shape[1]
+            if img.dim() == 2:
+                canvas = torch.zeros((H, W), dtype=img.dtype, device=img.device)
+                canvas[y1 : y1 + ch, x1 : x1 + cw] = img
+            else:
+                C = img.shape[2]
+                canvas = torch.zeros((H, W, C), dtype=img.dtype, device=img.device)
+                canvas[y1 : y1 + ch, x1 : x1 + cw, :] = img
+            restored.append(canvas)
+        return restored
+
+    @torch.inference_mode()
+    def revert_coords(self, results: List[Dict[str, Any]], meta: CropMeta) -> List[Dict[str, Any]]:
+        if len(results) != len(meta.boxes):
+            raise ValueError(f"crop: results count ({len(results)}) != meta count ({len(meta.boxes)})")
+        return [self._apply_single(r, b, s, forward=False) for r, b, s in zip(results, meta.boxes, meta.orig_sizes)]
+
+    @torch.inference_mode()
+    def apply_coords(self, results: List[Dict[str, Any]], meta: CropMeta) -> List[Dict[str, Any]]:
+        if len(results) != len(meta.boxes):
+            raise ValueError(f"crop: results count ({len(results)}) != meta count ({len(meta.boxes)})")
+        return [self._apply_single(r, b, s, forward=True) for r, b, s in zip(results, meta.boxes, meta.orig_sizes)]
+
+    @staticmethod
+    def _apply_single(result: Dict[str, Any], box: List[int], size: List[int], *, forward: bool) -> Dict[str, Any]:
+        x1, y1, x2, y2 = box
+        W, H = size
+
+        def xy_fn(xy: torch.Tensor) -> torch.Tensor:
+            off = torch.tensor([x1, y1], dtype=torch.float32, device=xy.device)
+            xy = xy.float()
+            return xy - off if forward else xy + off
+
+        def mask_fn(masks: torch.Tensor) -> torch.Tensor:
+            if forward:
+                # crop full-image masks down to the box region
+                return masks[:, y1:y2, x1:x2]
+            n, mh, mw = masks.shape[0], masks.shape[1], masks.shape[2]
+            canvas = torch.zeros((n, H, W), dtype=masks.dtype, device=masks.device)
+            canvas[:, y1 : y1 + mh, x1 : x1 + mw] = masks
+            return canvas
+
+        return apply_coord_transform(result, xy_fn=xy_fn, mask_fn=mask_fn)

--- a/lmi_utils/preprocess_utils/ops/flip.py
+++ b/lmi_utils/preprocess_utils/ops/flip.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from .._coords import apply_coord_transform
+from ..operation import Config, Meta, Operation
+
+
+@dataclass
+class FlipConfig(Config):
+    """Flip each image horizontally and/or vertically."""
+
+    lr: bool = False
+    ud: bool = False
+
+
+@dataclass
+class FlipMeta(Meta):
+    """Batched flip metadata.
+
+    lr/ud: per-image flags (same for all entries in a single forward call,
+    repeated to preserve the per-image-list invariant).
+    sizes: per-image [W, H] of the flipped image.
+    """
+
+    lr: List[bool] = field(default_factory=list)
+    ud: List[bool] = field(default_factory=list)
+    sizes: List[List[int]] = field(default_factory=list)
+
+    def __post_init__(self):
+        n = len(self.sizes)
+        if not (len(self.lr) == n and len(self.ud) == n):
+            raise ValueError("FlipMeta: field lengths must match")
+
+
+class FlipOperation(Operation[FlipConfig, FlipMeta]):
+    config_cls = FlipConfig
+    meta_cls = FlipMeta
+
+    @torch.inference_mode()
+    def forward(self, images: List[torch.Tensor], config: FlipConfig) -> Tuple[List[torch.Tensor], FlipMeta]:
+        lr = bool(config.lr)
+        ud = bool(config.ud)
+
+        out_images: List[torch.Tensor] = []
+        lrs: List[bool] = []
+        uds: List[bool] = []
+        sizes: List[List[int]] = []
+        for img in images:
+            h, w = img.shape[:2]
+            out_images.append(_flip(img, lr, ud))
+            lrs.append(lr)
+            uds.append(ud)
+            sizes.append([w, h])
+        return out_images, FlipMeta(lr=lrs, ud=uds, sizes=sizes)
+
+    @torch.inference_mode()
+    def revert_images(self, images: List[torch.Tensor], meta: FlipMeta) -> List[torch.Tensor]:
+        return [_flip(img, lr, ud) for img, lr, ud in zip(images, meta.lr, meta.ud)]
+
+    @torch.inference_mode()
+    def revert_coords(self, results: List[Dict[str, Any]], meta: FlipMeta) -> List[Dict[str, Any]]:
+        return [_apply_flip(r, lr, ud, s) for r, lr, ud, s in zip(results, meta.lr, meta.ud, meta.sizes)]
+
+    @torch.inference_mode()
+    def apply_coords(self, results: List[Dict[str, Any]], meta: FlipMeta) -> List[Dict[str, Any]]:
+        return [_apply_flip(r, lr, ud, s) for r, lr, ud, s in zip(results, meta.lr, meta.ud, meta.sizes)]
+
+
+def _flip(img: torch.Tensor, lr: bool, ud: bool) -> torch.Tensor:
+    out = img
+    if lr:
+        out = torch.flip(out, dims=[1])
+    if ud:
+        out = torch.flip(out, dims=[0])
+    return out
+
+
+def _apply_flip(result: Dict[str, Any], lr: bool, ud: bool, size: List[int]) -> Dict[str, Any]:
+    w, h = size
+
+    def xy_fn(xy: torch.Tensor) -> torch.Tensor:
+        xy = xy.float().clone()
+        if lr:
+            xy[..., 0] = w - xy[..., 0]
+        if ud:
+            xy[..., 1] = h - xy[..., 1]
+        return xy
+
+    def box_fn(boxes: torch.Tensor) -> torch.Tensor:
+        if boxes.ndim == 3:  # OBB
+            n = boxes.shape[0]
+            return xy_fn(boxes.reshape(-1, 2)).reshape(n, 4, 2)
+        # xyxy: flip then swap corner pairs so x1<x2, y1<y2 is preserved
+        out = boxes.float().clone()
+        if lr:
+            x1 = w - out[:, 0]
+            x2 = w - out[:, 2]
+            out[:, 0] = torch.minimum(x1, x2)
+            out[:, 2] = torch.maximum(x1, x2)
+        if ud:
+            y1 = h - out[:, 1]
+            y2 = h - out[:, 3]
+            out[:, 1] = torch.minimum(y1, y2)
+            out[:, 3] = torch.maximum(y1, y2)
+        return out
+
+    def mask_fn(masks: torch.Tensor) -> torch.Tensor:
+        out = masks
+        if lr:
+            out = torch.flip(out, dims=[-1])
+        if ud:
+            out = torch.flip(out, dims=[-2])
+        return out
+
+    return apply_coord_transform(result, xy_fn=xy_fn, box_fn=box_fn, mask_fn=mask_fn)

--- a/lmi_utils/preprocess_utils/ops/pad.py
+++ b/lmi_utils/preprocess_utils/ops/pad.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from lmi_utils.gadget_utils.pipeline_utils import fit_im, fit_im_to_size
+
+from .._coords import apply_coord_transform
+from ..operation import Config, Meta, Operation
+
+
+@dataclass
+class PadConfig(Config):
+    """Pad or crop each image to a target size.
+
+    Either ``pad`` is supplied directly as [L, R, T, B] (positive => pad, negative => crop),
+    or ``width`` / ``height`` are used to compute it (``fit_im_to_size`` semantics:
+    target smaller than input center-crops on that axis).
+    """
+
+    width: Optional[int] = None
+    height: Optional[int] = None
+    pad: Optional[List[int]] = None
+    value: int = 0
+
+    def __post_init__(self):
+        if self.pad is not None and len(self.pad) != 4:
+            raise ValueError(f"pad: 'pad' must be [L, R, T, B], got {self.pad!r}")
+
+
+@dataclass
+class PadMeta(Meta):
+    """Batched pad metadata.
+
+    pads: per-image [L, R, T, B] actually applied.
+    """
+
+    pads: List[List[int]] = field(default_factory=list)
+
+
+class PadOperation(Operation[PadConfig, PadMeta]):
+    config_cls = PadConfig
+    meta_cls = PadMeta
+
+    @torch.inference_mode()
+    def forward(self, images: List[torch.Tensor], config: PadConfig) -> Tuple[List[torch.Tensor], PadMeta]:
+        out_images: List[torch.Tensor] = []
+        pads: List[List[int]] = []
+        for img in images:
+            if config.pad is not None:
+                out_images.append(fit_im(img, config.pad, value=config.value))
+                pads.append(list(config.pad))
+            else:
+                padded, pL, pR, pT, pB = fit_im_to_size(img, W=config.width, H=config.height, value=config.value)
+                out_images.append(padded)
+                pads.append([pL, pR, pT, pB])
+        return out_images, PadMeta(pads=pads)
+
+    @torch.inference_mode()
+    def revert_images(self, images: List[torch.Tensor], meta: PadMeta) -> List[torch.Tensor]:
+        if len(images) != len(meta.pads):
+            raise ValueError(f"pad: image count ({len(images)}) != meta count ({len(meta.pads)})")
+        return [fit_im(img, [-p[0], -p[1], -p[2], -p[3]]) for img, p in zip(images, meta.pads)]
+
+    @torch.inference_mode()
+    def revert_coords(self, results: List[Dict[str, Any]], meta: PadMeta) -> List[Dict[str, Any]]:
+        return [_apply_pad(r, p, forward=False) for r, p in zip(results, meta.pads)]
+
+    @torch.inference_mode()
+    def apply_coords(self, results: List[Dict[str, Any]], meta: PadMeta) -> List[Dict[str, Any]]:
+        return [_apply_pad(r, p, forward=True) for r, p in zip(results, meta.pads)]
+
+
+def _apply_pad(result: Dict[str, Any], pad: List[int], *, forward: bool) -> Dict[str, Any]:
+    pad_L, pad_R, pad_T, pad_B = pad
+
+    def xy_fn(xy: torch.Tensor) -> torch.Tensor:
+        offset = torch.tensor([pad_L, pad_T], dtype=torch.float32, device=xy.device)
+        xy = xy.float()
+        return xy + offset if forward else xy - offset
+
+    def mask_fn(masks: torch.Tensor) -> torch.Tensor:
+        pads = (pad_L, pad_R, pad_T, pad_B) if forward else (-pad_L, -pad_R, -pad_T, -pad_B)
+        return F.pad(masks, pads)
+
+    return apply_coord_transform(result, xy_fn=xy_fn, mask_fn=mask_fn)

--- a/lmi_utils/preprocess_utils/ops/resize.py
+++ b/lmi_utils/preprocess_utils/ops/resize.py
@@ -50,6 +50,10 @@ class ResizeOperation(Operation[ResizeConfig, ResizeMeta]):
     config_cls = ResizeConfig
     meta_cls = ResizeMeta
 
+    def __init__(self, image_mode: str = "bilinear"):
+        """image_mode: ``revert_images`` interpolation. ``"nearest"`` for binary/label masks."""
+        self.image_mode = image_mode
+
     @torch.inference_mode()
     def forward(self, images: List[torch.Tensor], config: ResizeConfig) -> Tuple[List[torch.Tensor], ResizeMeta]:
         out_images: List[torch.Tensor] = []
@@ -95,7 +99,10 @@ class ResizeOperation(Operation[ResizeConfig, ResizeMeta]):
     @torch.inference_mode()
     def revert_images(self, images: List[torch.Tensor], meta: ResizeMeta) -> List[torch.Tensor]:
         _check_len(images, meta.src_sizes, "resize")
-        return [_revert_image_single(img, src, dst, pad) for img, src, dst, pad in zip(images, meta.src_sizes, meta.dst_sizes, meta.pads)]
+        return [
+            _revert_image_single(img, src, dst, pad, mode=self.image_mode)
+            for img, src, dst, pad in zip(images, meta.src_sizes, meta.dst_sizes, meta.pads)
+        ]
 
     @torch.inference_mode()
     def revert_coords(self, results: List[Dict[str, Any]], meta: ResizeMeta) -> List[Dict[str, Any]]:
@@ -117,7 +124,7 @@ def _check_len(items, sizes, name: str) -> None:
         raise ValueError(f"{name}: input length ({len(items)}) != metadata length ({len(sizes)})")
 
 
-def _revert_image_single(img: torch.Tensor, src: List[int], dst: List[int], pad: List[int]) -> torch.Tensor:
+def _revert_image_single(img: torch.Tensor, src: List[int], dst: List[int], pad: List[int], mode: str = "bilinear") -> torch.Tensor:
     pL, pR, pT, pB = pad
     if pL or pR or pT or pB:
         from lmi_utils.gadget_utils.pipeline_utils import fit_im
@@ -127,7 +134,7 @@ def _revert_image_single(img: torch.Tensor, src: List[int], dst: List[int], pad:
     dst_w, dst_h = dst
     if (src_w, src_h) == (dst_w, dst_h):
         return img
-    return resize_image(img, W=src_w, H=src_h)
+    return resize_image(img, W=src_w, H=src_h, mode=mode)
 
 
 def _apply_resize(result: Dict[str, Any], src: List[int], dst: List[int], pad: List[int], *, forward: bool) -> Dict[str, Any]:

--- a/lmi_utils/preprocess_utils/ops/resize.py
+++ b/lmi_utils/preprocess_utils/ops/resize.py
@@ -1,64 +1,182 @@
-from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
-from lmi_utils.gadget_utils.pipeline_utils import revert_mask_to_origin, revert_masks_to_origin, revert_to_origin
-from lmi_utils.image_utils.img_resize import resize_and_pad
+from lmi_utils.gadget_utils.pipeline_utils import fit_im_to_size, resize_image
 
 from .._coords import apply_coord_transform
-from ..operation import Operation
+from ..operation import Config, Meta, Operation
 
 
-class ResizeOperation(Operation):
-    """Resize-and-pad each image; remember per-image ops for inversion."""
+@dataclass
+class ResizeConfig(Config):
+    """Resize each image to a target size.
 
-    name = "resize"
+    width: target width. Defaults to current width.
+    height: target height. Defaults to current height.
+    preserve_aspect: scale-to-fit preserving aspect ratio then pad (letterbox).
+    mode: interpolation mode passed to ``resize_image``.
+    """
+
+    width: Optional[int] = None
+    height: Optional[int] = None
+    preserve_aspect: bool = False
+    mode: str = "bilinear"
+
+
+@dataclass
+class ResizeMeta(Meta):
+    """Batched resize metadata.
+
+    src_sizes / dst_sizes: [W, H] per image; dst_size is the post-scale, pre-pad size.
+    pads: per-image [L, R, T, B] (zeros when no padding was applied).
+    """
+
+    src_sizes: List[List[int]] = field(default_factory=list)
+    dst_sizes: List[List[int]] = field(default_factory=list)
+    pads: List[List[int]] = field(default_factory=list)
+
+    def __post_init__(self):
+        n = len(self.src_sizes)
+        if not (len(self.dst_sizes) == n and len(self.pads) == n):
+            raise ValueError(
+                f"ResizeMeta: field lengths must match — "
+                f"src_sizes={len(self.src_sizes)} dst_sizes={len(self.dst_sizes)} pads={len(self.pads)}"
+            )
+
+
+class ResizeOperation(Operation[ResizeConfig, ResizeMeta]):
+    config_cls = ResizeConfig
+    meta_cls = ResizeMeta
 
     @torch.inference_mode()
-    def forward(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], List[Any]]:
-        resize_kwargs = {
-            "width": config.get("width"),
-            "height": config.get("height"),
-            "preserve_aspect": config.get("preserve_aspect", False),
-            "mode": config.get("mode", "bilinear"),
-        }
+    def forward(self, images: List[torch.Tensor], config: ResizeConfig) -> Tuple[List[torch.Tensor], ResizeMeta]:
+        out_images: List[torch.Tensor] = []
+        src_sizes: List[List[int]] = []
+        dst_sizes: List[List[int]] = []
+        pads: List[List[int]] = []
 
-        output_images = []
-        image_ops_list = []
         for img in images:
-            processed, ops = resize_and_pad(img, return_operators=True, **resize_kwargs)
-            output_images.append(processed)
-            image_ops_list.append(ops)
+            h0, w0 = img.shape[:2]
+            tw = config.width if config.width is not None else w0
+            th = config.height if config.height is not None else h0
 
-        return output_images, image_ops_list
+            if tw == w0 and th == h0:
+                out_images.append(img)
+                src_sizes.append([w0, h0])
+                dst_sizes.append([w0, h0])
+                pads.append([0, 0, 0, 0])
+                continue
+
+            if config.preserve_aspect:
+                scale = min(th / h0, tw / w0)
+                w1 = int(scale * w0)
+                h1 = int(scale * h0)
+                scaled = resize_image(img, W=w1, H=h1, mode=config.mode)
+                src_sizes.append([w0, h0])
+                dst_sizes.append([w1, h1])
+                if w1 != tw or h1 != th:
+                    padded, pL, pR, pT, pB = fit_im_to_size(scaled, W=tw, H=th)
+                    pads.append([pL, pR, pT, pB])
+                    out_images.append(padded)
+                else:
+                    pads.append([0, 0, 0, 0])
+                    out_images.append(scaled)
+            else:
+                scaled = resize_image(img, W=tw, H=th, mode=config.mode)
+                out_images.append(scaled)
+                src_sizes.append([w0, h0])
+                dst_sizes.append([tw, th])
+                pads.append([0, 0, 0, 0])
+
+        return out_images, ResizeMeta(src_sizes=src_sizes, dst_sizes=dst_sizes, pads=pads)
 
     @torch.inference_mode()
-    def revert_images(self, images: List[torch.Tensor], metadata: List[Any]) -> List[torch.Tensor]:
-        if len(images) != len(metadata):
-            raise ValueError(f"Image count ({len(images)}) doesn't match ops count ({len(metadata)})")
-        return [revert_mask_to_origin(image, ops) for image, ops in zip(images, metadata)]
+    def revert_images(self, images: List[torch.Tensor], meta: ResizeMeta) -> List[torch.Tensor]:
+        _check_len(images, meta.src_sizes, "resize")
+        return [_revert_image_single(img, src, dst, pad) for img, src, dst, pad in zip(images, meta.src_sizes, meta.dst_sizes, meta.pads)]
 
     @torch.inference_mode()
-    def revert_coords(self, results: List[Dict[str, Any]], metadata: List[Any]) -> List[Dict[str, Any]]:
-        if len(results) != len(metadata):
-            raise ValueError(f"Result count ({len(results)}) doesn't match ops count ({len(metadata)})")
-        return [self._revert_coords_single(r, ops) for r, ops in zip(results, metadata)]
+    def revert_coords(self, results: List[Dict[str, Any]], meta: ResizeMeta) -> List[Dict[str, Any]]:
+        _check_len(results, meta.src_sizes, "resize")
+        return [
+            _apply_resize(r, src, dst, pad, forward=False) for r, src, dst, pad in zip(results, meta.src_sizes, meta.dst_sizes, meta.pads)
+        ]
 
-    @staticmethod
-    def _revert_coords_single(result: Dict[str, Any], ops: list) -> Dict[str, Any]:
-        if not ops:
-            return result
+    @torch.inference_mode()
+    def apply_coords(self, results: List[Dict[str, Any]], meta: ResizeMeta) -> List[Dict[str, Any]]:
+        _check_len(results, meta.src_sizes, "resize")
+        return [
+            _apply_resize(r, src, dst, pad, forward=True) for r, src, dst, pad in zip(results, meta.src_sizes, meta.dst_sizes, meta.pads)
+        ]
 
-        def box_fn(boxes: torch.Tensor) -> torch.Tensor:
-            # OBB: per-box stack (each (4, 2) is a valid (N, 2) input).
-            # xyxy: pass (N, 4) natively so flip's corner-swap is correct.
-            if boxes.ndim == 3:
-                return torch.stack([revert_to_origin(box, ops) for box in boxes])
-            return revert_to_origin(boxes, ops)
 
-        return apply_coord_transform(
-            result,
-            xy_fn=lambda xy: revert_to_origin(xy, ops),
-            box_fn=box_fn,
-            mask_fn=lambda masks: revert_masks_to_origin(masks, ops),
-        )
+def _check_len(items, sizes, name: str) -> None:
+    if len(items) != len(sizes):
+        raise ValueError(f"{name}: input length ({len(items)}) != metadata length ({len(sizes)})")
+
+
+def _revert_image_single(img: torch.Tensor, src: List[int], dst: List[int], pad: List[int]) -> torch.Tensor:
+    pL, pR, pT, pB = pad
+    if pL or pR or pT or pB:
+        from lmi_utils.gadget_utils.pipeline_utils import fit_im
+
+        img = fit_im(img, [-pL, -pR, -pT, -pB])
+    src_w, src_h = src
+    dst_w, dst_h = dst
+    if (src_w, src_h) == (dst_w, dst_h):
+        return img
+    return resize_image(img, W=src_w, H=src_h)
+
+
+def _apply_resize(result: Dict[str, Any], src: List[int], dst: List[int], pad: List[int], *, forward: bool) -> Dict[str, Any]:
+    src_w, src_h = src
+    dst_w, dst_h = dst
+    pad_L, pad_R, pad_T, pad_B = pad
+
+    sx = dst_w / src_w
+    sy = dst_h / src_h
+
+    def xy_fn(xy: torch.Tensor) -> torch.Tensor:
+        device = xy.device
+        scale = torch.tensor([sx, sy], dtype=torch.float32, device=device)
+        offset = torch.tensor([pad_L, pad_T], dtype=torch.float32, device=device)
+        xy = xy.float()
+        if forward:
+            return xy * scale + offset
+        return (xy - offset) / scale
+
+    def mask_fn(masks: torch.Tensor) -> torch.Tensor:
+        return _resample_masks(masks, [src_w, src_h], [dst_w, dst_h], [pad_L, pad_R, pad_T, pad_B], pad_after=forward)
+
+    return apply_coord_transform(result, xy_fn=xy_fn, mask_fn=mask_fn)
+
+
+def _resample_masks(masks: torch.Tensor, src_size: List[int], dst_size: List[int], pad: List[int], *, pad_after: bool) -> torch.Tensor:
+    """Resample instance masks between original space (src) and preprocessed space (dst+pad).
+
+    pad_after=True: src -> dst -> pad (forward).
+    pad_after=False: strip pad -> dst -> src (revert).
+    """
+    import torch.nn.functional as F
+
+    src_w, src_h = src_size
+    dst_w, dst_h = dst_size
+    pad_L, pad_R, pad_T, pad_B = pad
+    if pad_after:
+        # forward: resize to (dst_h, dst_w), then pad to (dst_h + pT+pB, dst_w + pL+pR)
+        resized = F.interpolate(masks.float().unsqueeze(1), size=(dst_h, dst_w), mode="nearest").squeeze(1)
+        if pad_L or pad_R or pad_T or pad_B:
+            n = resized.shape[0]
+            canvas_h = dst_h + pad_T + pad_B
+            canvas_w = dst_w + pad_L + pad_R
+            canvas = torch.zeros((n, canvas_h, canvas_w), dtype=resized.dtype, device=resized.device)
+            canvas[:, pad_T : pad_T + dst_h, pad_L : pad_L + dst_w] = resized
+            return canvas
+        return resized
+    # revert: strip pad first (if any), then resize back to (src_h, src_w)
+    if pad_L or pad_T:
+        # mask shape: (N, H, W). Strip pad from a (dst_h+pT+pB, dst_w+pL+pR) canvas.
+        masks = masks[:, pad_T : pad_T + dst_h, pad_L : pad_L + dst_w]
+    return F.interpolate(masks.float().unsqueeze(1), size=(src_h, src_w), mode="nearest").squeeze(1)

--- a/lmi_utils/preprocess_utils/ops/tile.py
+++ b/lmi_utils/preprocess_utils/ops/tile.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -6,25 +7,92 @@ import torch
 from lmi_utils.image_utils.tiler import Tiler
 
 from .._coords import apply_coord_transform
-from ..operation import Operation
+from ..operation import Config, Meta, Operation
 
 
-class TileOperation(Operation):
-    """Tile each image into fixed-size patches; remember per-image grid for stitching."""
+@dataclass
+class TileConfig(Config):
+    """Tile each image into fixed-size patches; remember per-image grid for stitching.
 
-    name = "tile"
+    tile_size: int or [h, w] — patch size.
+    stride: int or [h, w] — step between tile origins.
+    scale_mode: how the image is fit to the tile grid before slicing ("padding" or "interpolation").
+    overlap_mode: how overlapping regions are merged on untile ("average", "max", ...).
+    """
+
+    tile_size: Union[int, List[int], None] = None
+    stride: Union[int, List[int], None] = None
+    scale_mode: str = "padding"
+    overlap_mode: str = "average"
+
+    def __post_init__(self):
+        if self.tile_size is None or self.stride is None:
+            raise ValueError("TileConfig: 'tile_size' and 'stride' are required")
+
+
+@dataclass
+class TileMeta(Meta):
+    """Batched tile metadata (one entry per *source* image; each source produces n_h*n_w tiles)."""
+
+    tile_sizes: List[List[int]] = field(default_factory=list)
+    strides: List[List[int]] = field(default_factory=list)
+    im_sizes: List[List[int]] = field(default_factory=list)
+    scale_sizes: List[List[int]] = field(default_factory=list)
+    n_tiles: List[List[int]] = field(default_factory=list)
+    batch_sizes: List[int] = field(default_factory=list)
+    num_channels: List[int] = field(default_factory=list)
+    scale_modes: List[str] = field(default_factory=list)
+    overlap_modes: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        n = len(self.n_tiles)
+        for name in (
+            "tile_sizes",
+            "strides",
+            "im_sizes",
+            "scale_sizes",
+            "batch_sizes",
+            "num_channels",
+            "scale_modes",
+            "overlap_modes",
+        ):
+            if len(getattr(self, name)) != n:
+                raise ValueError(f"TileMeta: field '{name}' length mismatch")
+
+    def per_image_dict(self, i: int) -> Dict[str, Any]:
+        """Reconstruct a single source image's dict suitable for Tiler.from_dict()."""
+        return {
+            "tile_size": list(self.tile_sizes[i]),
+            "stride": list(self.strides[i]),
+            "im_size": list(self.im_sizes[i]),
+            "scale_size": list(self.scale_sizes[i]),
+            "n_tiles": list(self.n_tiles[i]),
+            "batch_size": self.batch_sizes[i],
+            "num_channel": self.num_channels[i],
+            "scale_mode": self.scale_modes[i],
+            "overlap_mode": self.overlap_modes[i],
+        }
+
+
+class TileOperation(Operation[TileConfig, TileMeta]):
+    config_cls = TileConfig
+    meta_cls = TileMeta
 
     @torch.inference_mode()
-    def forward(self, images: List[torch.Tensor], config: Dict[str, Any]) -> Tuple[List[torch.Tensor], List[Any]]:
-        required_keys = {"tile_size", "stride"}
-        if not required_keys.issubset(config.keys()):
-            raise ValueError(f"Tiler configuration must contain keys: {required_keys}")
+    def forward(self, images: List[torch.Tensor], config: TileConfig) -> Tuple[List[torch.Tensor], TileMeta]:
+        scale_mode = config.scale_mode
+        overlap_mode = config.overlap_mode
 
-        scale_mode = config.get("scale_mode", "padding")
-        overlap_mode = config.get("overlap_mode", "average")
-
-        output_images = []
-        tiler_metadata = []
+        out_images: List[torch.Tensor] = []
+        tile_sizes: List[List[int]] = []
+        strides: List[List[int]] = []
+        im_sizes: List[List[int]] = []
+        scale_sizes: List[List[int]] = []
+        n_tiles_list: List[List[int]] = []
+        batch_sizes: List[int] = []
+        num_channels: List[int] = []
+        scale_modes: List[str] = []
+        overlap_modes: List[str] = []
 
         for img in images:
             ndim = img.dim()
@@ -33,7 +101,7 @@ class TileOperation(Operation):
                 add_channel = True
                 img = img.unsqueeze(-1)
 
-            tiler = Tiler(tile_size=config["tile_size"], stride=config["stride"])
+            tiler = Tiler(tile_size=config.tile_size, stride=config.stride)
             img_batch = img.permute(2, 0, 1).unsqueeze(0)  # [1, C, H, W]
             tiles_batch = tiler.tile(img_batch, mode=scale_mode)  # [N, C, H, W]
 
@@ -41,28 +109,43 @@ class TileOperation(Operation):
             tiles_list_hwc = [t.permute(1, 2, 0) for t in tiles_list_chw]
             if add_channel:
                 tiles_list_hwc = [t.squeeze(-1) for t in tiles_list_hwc]
+            out_images.extend(tiles_list_hwc)
 
-            output_images.extend(tiles_list_hwc)
+            d = tiler.to_dict()
+            tile_sizes.append(list(d["tile_size"]))
+            strides.append(list(d["stride"]))
+            im_sizes.append(list(d["im_size"]))
+            scale_sizes.append(list(d["scale_size"]))
+            n_tiles_list.append(list(d["n_tiles"]))
+            batch_sizes.append(int(d["batch_size"]))
+            num_channels.append(int(d["num_channel"]))
+            scale_modes.append(scale_mode)
+            overlap_modes.append(overlap_mode)
 
-            meta = tiler.to_dict()
-            meta["overlap_mode"] = overlap_mode
-            meta["scale_mode"] = scale_mode
-            tiler_metadata.append(meta)
-
-        return output_images, tiler_metadata
+        return out_images, TileMeta(
+            tile_sizes=tile_sizes,
+            strides=strides,
+            im_sizes=im_sizes,
+            scale_sizes=scale_sizes,
+            n_tiles=n_tiles_list,
+            batch_sizes=batch_sizes,
+            num_channels=num_channels,
+            scale_modes=scale_modes,
+            overlap_modes=overlap_modes,
+        )
 
     @torch.inference_mode()
-    def revert_images(self, images: List[torch.Tensor], metadata: List[Dict[str, Any]]) -> List[torch.Tensor]:
+    def revert_images(self, images: List[torch.Tensor], meta: TileMeta) -> List[torch.Tensor]:
         restored_images = []
         cursor = 0
 
-        for tiler_meta in metadata:
-            tiler = Tiler.from_dict(tiler_meta)
-            count = tiler_meta["n_tiles"][0] * tiler_meta["n_tiles"][1]
+        for i in range(len(meta.n_tiles)):
+            n_h, n_w = meta.n_tiles[i]
+            count = n_h * n_w
+            tiler = Tiler.from_dict(meta.per_image_dict(i))
 
             batch_slice_hwc = images[cursor : cursor + count]
             cursor += count
-
             if len(batch_slice_hwc) != count:
                 raise RuntimeError(f"Expected {count} tiles, found {len(batch_slice_hwc)}")
 
@@ -77,114 +160,105 @@ class TileOperation(Operation):
                 batch_hwc = batch_hwc.unsqueeze(-1)
             batch_chw = batch_hwc.permute(0, 3, 1, 2)  # [N, C, H, W]
 
-            scale_mode = tiler_meta.get("scale_mode", "padding")
-            overlap_mode = tiler_meta.get("overlap_mode", "average")
-            restored_batch = tiler.untile(batch_chw, scale_mode=scale_mode, overlap_mode=overlap_mode)
-
+            restored_batch = tiler.untile(batch_chw, scale_mode=meta.scale_modes[i], overlap_mode=meta.overlap_modes[i])
             restored_img = restored_batch.squeeze(0).permute(1, 2, 0)
             if add_channel:
                 restored_img = restored_img.squeeze(-1)
-
             restored_images.append(restored_img)
 
         if cursor != len(images):
             raise RuntimeError(f"Tile reconstruction mismatch: processed {cursor} images, but received {len(images)}")
-
         return restored_images
 
     @torch.inference_mode()
-    def revert_coords(self, results: List[Dict[str, Any]], metadata: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def revert_coords(self, results: List[Dict[str, Any]], meta: TileMeta) -> List[Dict[str, Any]]:
         output = []
         cursor = 0
-
-        for tiler_meta in metadata:
-            n_tiles_h, n_tiles_w = tiler_meta["n_tiles"]
-            count = n_tiles_h * n_tiles_w
+        for i in range(len(meta.n_tiles)):
+            n_h, n_w = meta.n_tiles[i]
+            count = n_h * n_w
             tile_results = results[cursor : cursor + count]
             cursor += count
-
             if len(tile_results) != count:
                 raise RuntimeError(f"Expected {count} tile results, found {len(tile_results)}")
-
-            output.append(self._merge_tile_coords(tile_results, tiler_meta))
+            output.append(_merge_tile_coords(tile_results, meta.per_image_dict(i)))
 
         if cursor != len(results):
             raise RuntimeError(f"Tile coord reconstruction mismatch: processed {cursor}, received {len(results)}")
-
         return output
 
-    @classmethod
-    def _merge_tile_coords(cls, tile_results: List[Dict[str, Any]], tiler_meta: Dict[str, Any]) -> Dict[str, Any]:
-        _, n_tiles_w = tiler_meta["n_tiles"]
-        stride_h, stride_w = tiler_meta["stride"]
-        im_h, im_w = tiler_meta["im_size"]
-        scale_h, scale_w = tiler_meta["scale_size"]
-        is_interp = tiler_meta.get("scale_mode", "padding") == "interpolation" and (scale_h != im_h or scale_w != im_w)
-        sx = im_w / scale_w if is_interp else 1.0
-        sy = im_h / scale_h if is_interp else 1.0
 
-        target_size = (im_h, im_w) if is_interp else (scale_h, scale_w)
+def _merge_tile_coords(tile_results: List[Dict[str, Any]], tiler_meta: Dict[str, Any]) -> Dict[str, Any]:
+    _, n_tiles_w = tiler_meta["n_tiles"]
+    stride_h, stride_w = tiler_meta["stride"]
+    im_h, im_w = tiler_meta["im_size"]
+    scale_h, scale_w = tiler_meta["scale_size"]
+    is_interp = tiler_meta.get("scale_mode", "padding") == "interpolation" and (scale_h != im_h or scale_w != im_w)
+    sx = im_w / scale_w if is_interp else 1.0
+    sy = im_h / scale_h if is_interp else 1.0
 
-        shifted = []
-        for idx, r in enumerate(tile_results):
-            row = idx // n_tiles_w
-            col = idx % n_tiles_w
-            shifted.append(cls._shift_tile_coords(r, col * stride_w, row * stride_h, sx, sy, target_size))
+    target_size = (im_h, im_w) if is_interp else (scale_h, scale_w)
 
-        return cls._concat_tile_results(shifted)
+    shifted = []
+    for idx, r in enumerate(tile_results):
+        row = idx // n_tiles_w
+        col = idx % n_tiles_w
+        shifted.append(_shift_tile_coords(r, col * stride_w, row * stride_h, sx, sy, target_size))
 
-    @staticmethod
-    def _shift_tile_coords(
-        result: Dict[str, Any], offset_x: int, offset_y: int, sx: float, sy: float, target_size: Tuple[int, int]
-    ) -> Dict[str, Any]:
-        scaled = sx != 1.0 or sy != 1.0
+    return _concat_tile_results(shifted)
 
-        def xy_fn(xy: torch.Tensor) -> torch.Tensor:
-            off = torch.tensor([offset_x, offset_y], dtype=torch.float32, device=xy.device)
-            shifted = xy.float() + off
-            if scaled:
-                scale = torch.tensor([sx, sy], dtype=torch.float32, device=xy.device)
-                shifted = shifted * scale
-            return shifted
 
-        def mask_fn(masks: torch.Tensor) -> torch.Tensor:
-            canvas_h, canvas_w = target_size
-            if scaled:
-                new_h = max(1, round(masks.shape[1] * sy))
-                new_w = max(1, round(masks.shape[2] * sx))
-                masks = torch.nn.functional.interpolate(masks.float().unsqueeze(1), size=(new_h, new_w), mode="nearest").squeeze(1)
-                paste_y = round(offset_y * sy)
-                paste_x = round(offset_x * sx)
-            else:
-                masks = masks.float()
-                paste_y, paste_x = offset_y, offset_x
-            canvas = torch.zeros(len(masks), canvas_h, canvas_w, dtype=masks.dtype, device=masks.device)
-            h_end = min(paste_y + masks.shape[1], canvas_h)
-            w_end = min(paste_x + masks.shape[2], canvas_w)
-            canvas[:, paste_y:h_end, paste_x:w_end] = masks[:, : h_end - paste_y, : w_end - paste_x]
-            return canvas
+def _shift_tile_coords(
+    result: Dict[str, Any], offset_x: int, offset_y: int, sx: float, sy: float, target_size: Tuple[int, int]
+) -> Dict[str, Any]:
+    scaled = sx != 1.0 or sy != 1.0
 
-        return apply_coord_transform(result, xy_fn=xy_fn, mask_fn=mask_fn)
+    def xy_fn(xy: torch.Tensor) -> torch.Tensor:
+        off = torch.tensor([offset_x, offset_y], dtype=torch.float32, device=xy.device)
+        shifted = xy.float() + off
+        if scaled:
+            scale = torch.tensor([sx, sy], dtype=torch.float32, device=xy.device)
+            shifted = shifted * scale
+        return shifted
 
-    @staticmethod
-    def _concat_tile_results(results: List[Dict[str, Any]]) -> Dict[str, Any]:
-        if not results:
-            return {}
+    def mask_fn(masks: torch.Tensor) -> torch.Tensor:
+        canvas_h, canvas_w = target_size
+        if scaled:
+            new_h = max(1, round(masks.shape[1] * sy))
+            new_w = max(1, round(masks.shape[2] * sx))
+            masks = torch.nn.functional.interpolate(masks.float().unsqueeze(1), size=(new_h, new_w), mode="nearest").squeeze(1)
+            paste_y = round(offset_y * sy)
+            paste_x = round(offset_x * sx)
+        else:
+            masks = masks.float()
+            paste_y, paste_x = offset_y, offset_x
+        canvas = torch.zeros(len(masks), canvas_h, canvas_w, dtype=masks.dtype, device=masks.device)
+        h_end = min(paste_y + masks.shape[1], canvas_h)
+        w_end = min(paste_x + masks.shape[2], canvas_w)
+        canvas[:, paste_y:h_end, paste_x:w_end] = masks[:, : h_end - paste_y, : w_end - paste_x]
+        return canvas
 
-        merged = {}
-        all_keys = {k for r in results for k in r}
+    return apply_coord_transform(result, xy_fn=xy_fn, mask_fn=mask_fn)
 
-        for key in all_keys:
-            vals = [r[key] for r in results if key in r and r[key] is not None]
-            if not vals:
-                continue
-            if key == "segments":
-                merged[key] = [seg for segs in vals for seg in segs]
-            elif key == "classes":
-                non_empty = [v for v in vals if len(v) > 0]
-                merged[key] = np.concatenate(non_empty) if non_empty else vals[0]
-            else:  # boxes, scores, points, masks
-                non_empty = [v for v in vals if len(v) > 0]
-                merged[key] = torch.cat(non_empty) if non_empty else vals[0]
 
-        return merged
+def _concat_tile_results(results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not results:
+        return {}
+
+    merged = {}
+    all_keys = {k for r in results for k in r}
+
+    for key in all_keys:
+        vals = [r[key] for r in results if key in r and r[key] is not None]
+        if not vals:
+            continue
+        if key == "segments":
+            merged[key] = [seg for segs in vals for seg in segs]
+        elif key == "classes":
+            non_empty = [v for v in vals if len(v) > 0]
+            merged[key] = np.concatenate(non_empty) if non_empty else vals[0]
+        else:  # boxes, scores, points, masks
+            non_empty = [v for v in vals if len(v) > 0]
+            merged[key] = torch.cat(non_empty) if non_empty else vals[0]
+
+    return merged

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -67,12 +67,7 @@ class Preprocessor(BaseProcessor):
         """
         self._validate_configs(configs)
 
-        if isinstance(images, list):
-            pass
-        elif hasattr(images, "ndim") and images.ndim == 4:
-            images = list(images)
-        else:
-            images = [images]
+        images = self.as_image_list(images)
         self.validate_image_list(images, stage="preprocessing")
 
         if not configs:

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -1,64 +1,72 @@
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple, Type
 
 from lmi_utils.image_utils.types import ImageBatch, ImageLike
 
 from .base import BaseProcessor
-from .operation import Operation
-from .ops import ResizeOperation, TileOperation
+from .operation import Config, Meta, Operation
+from .ops import (
+    CropOperation,
+    FlipOperation,
+    PadOperation,
+    ResizeOperation,
+    TileOperation,
+)
 
 
 class Preprocessor(BaseProcessor):
-    """
-    Runs a dynamic pipeline of preprocessing Operations on an image.
+    """Runs a typed pipeline of preprocessing Operations on an image.
 
-    Operations are registered as `Operation` instances and selected per-step
-    by name. Each step's metadata is recorded so a `Reconstructor` can later
-    invert the pipeline.
+    Operations are dispatched by Config type. Configs are constructed via
+    ``lmi_utils.preprocess_utils.steps`` (recommended) or directly as dataclasses.
+    JSON manifests should be converted via
+    ``lmi_utils.preprocess_utils._parser.parse_steps`` before being passed in.
 
     Device contract:
-        Output tensors live on the same device as the input tensors. Every
-        Operation must allocate any internal tensors with `device=<input>.device`
-        and avoid implicit `.cpu()` / `.cuda()` moves. Numpy inputs are bridged
-        through CPU tensors (numpy is CPU-only by definition).
+        Output tensors live on the same device as the input tensors.
     """
 
-    def __init__(self):
-        self._ops: Dict[str, Operation] = {}
-        self._register_defaults()
+    _DEFAULT_OPS: Tuple[Type[Operation], ...] = (
+        ResizeOperation,
+        PadOperation,
+        FlipOperation,
+        TileOperation,
+        CropOperation,
+    )
 
-    def _register_defaults(self) -> None:
-        self.register(ResizeOperation())
-        self.register(TileOperation())
+    @classmethod
+    def default_ops(cls) -> Dict[Type[Config], Type[Operation]]:
+        return {op_cls.config_cls: op_cls for op_cls in cls._DEFAULT_OPS}
+
+    def __init__(self):
+        self._ops: Dict[Type[Config], Operation] = {}
+        for op_cls in self._DEFAULT_OPS:
+            self.register(op_cls())
 
     def register(self, op: Operation) -> None:
-        """
-        Register an Operation. Pairs with `Reconstructor.register(op)`.
-
-        Args:
-            op: An `Operation` instance with a non-empty `name`.
-        """
+        """Register an Operation under its ``config_cls``."""
         if not isinstance(op, Operation):
             raise TypeError(f"Expected Operation, got {type(op)}")
-        if not op.name:
-            raise ValueError("Operation must define a non-empty `name`")
-        self._ops[op.name] = op
+        if not getattr(op, "config_cls", None):
+            raise ValueError("Operation must define `config_cls`")
+        self._ops[op.config_cls] = op
 
-    def preprocess(self, images: ImageBatch, processing_steps: List[Dict[str, Any]]) -> Tuple[List[ImageLike], List[Dict[str, Any]]]:
-        """
-        Runs the preprocessing pipeline.
+    def preprocess(
+        self,
+        images: ImageBatch,
+        configs: List[Config],
+    ) -> Tuple[List[ImageLike], List[Meta]]:
+        """Run the preprocessing pipeline.
 
         Args:
-            images: A single HW/HWC image, list of HW/HWC images, or a BHWC batch (numpy array or torch tensor). Any dtype is accepted.
-            processing_steps: List of step dicts, each with keys:
-                - "type" (str): Registered Operation name (e.g. "resize", "tile").
-                - "configuration" (dict): Op-specific config passed as-is.
+            images: HW/HWC image, list of HW/HWC images, or BHWC batch (numpy or torch).
+            configs: List of typed Config objects (one per step).
 
         Returns:
-            processed_imgs: List of (H, W, C) images, same type as input.
-            history: List of step records for reconstruction, each with keys:
-                - "type" (str): Operation name.
-                - "metadata" (list): Per-image metadata returned by the op.
+            (processed_images, history): the processed image list and a per-step
+            list of typed Meta objects suitable for Reconstructor.
         """
+        self._validate_configs(configs)
+
         if isinstance(images, list):
             pass
         elif hasattr(images, "ndim") and images.ndim == 4:
@@ -66,24 +74,31 @@ class Preprocessor(BaseProcessor):
         else:
             images = [images]
         self.validate_image_list(images, stage="preprocessing")
-        self.validate_steps(processing_steps)
+
+        if not configs:
+            return list(images), []
 
         processed_imgs, is_numpy = self.to_tensor_list(images)
 
-        history = []
-        for step in processing_steps:
-            op_name = step["type"]
-            config = step["configuration"]
-            if op_name not in self._ops:
-                raise ValueError(f"Operation '{op_name}' is not registered.")
+        history: List[Meta] = []
+        for cfg in configs:
+            op = self._ops.get(type(cfg))
+            if op is None:
+                raise ValueError(f"No Operation registered for {type(cfg).__name__}")
 
-            op = self._ops[op_name]
-            new_images, metadata = op.forward(processed_imgs, config)
-
-            self.validate_image_handler_output(new_images, op_name, expected_type="preprocess handler")
-            self.validate_handler_metadata(metadata, op_name)
-
-            history.append({"type": op_name, "metadata": metadata})
+            new_images, meta = op.forward(processed_imgs, cfg)
+            self.validate_image_handler_output(new_images, type(cfg).__name__, expected_type="preprocess handler")
+            if not isinstance(meta, Meta):
+                raise TypeError(f"{type(op).__name__}.forward returned {type(meta)}, expected Meta")
+            history.append(meta)
             processed_imgs = new_images
 
         return self.from_tensor_list(processed_imgs, is_numpy), history
+
+    @staticmethod
+    def _validate_configs(configs: List[Config]) -> None:
+        if not isinstance(configs, list):
+            raise TypeError(f"configs must be a list, got {type(configs)}")
+        for i, c in enumerate(configs):
+            if not isinstance(c, Config):
+                raise TypeError(f"configs[{i}] must be a Config, got {type(c)}")

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -1,60 +1,64 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Type
 
 from lmi_utils.image_utils.types import ImageLike
 
 from .base import BaseProcessor
-from .operation import Operation
-from .ops import ResizeOperation, TileOperation
+from .operation import Meta, Operation
+from .ops import (
+    CropOperation,
+    FlipOperation,
+    PadOperation,
+    ResizeOperation,
+    TileOperation,
+)
 
 
 class Reconstructor(BaseProcessor):
-    """
-    Reconstructs original images and coordinates from preprocessed data.
+    """Reconstructs original images and coordinates from preprocessed data.
 
-    Mirrors the `Preprocessor`: register the same `Operation` instance on
-    both, and image / coordinate reverts come from a single object.
+    Operations are dispatched by Meta type. The Reconstructor mirrors the
+    Preprocessor: register the same Operation classes on both.
 
     Device contract:
-        Output tensors live on the same device as the input tensors. Every
-        Operation must allocate any internal tensors with `device=<input>.device`
-        and avoid implicit `.cpu()` / `.cuda()` moves.
+        Output tensors live on the same device as the input tensors.
     """
 
-    def __init__(self):
-        self._ops: Dict[str, Operation] = {}
-        self._register_defaults()
+    _DEFAULT_OPS: Tuple[Type[Operation], ...] = (
+        ResizeOperation,
+        PadOperation,
+        FlipOperation,
+        TileOperation,
+        CropOperation,
+    )
 
-    def _register_defaults(self) -> None:
-        self.register(ResizeOperation())
-        self.register(TileOperation())
+    @classmethod
+    def default_ops(cls) -> Dict[Type[Meta], Type[Operation]]:
+        return {op_cls.meta_cls: op_cls for op_cls in cls._DEFAULT_OPS}
+
+    def __init__(self):
+        self._ops: Dict[Type[Meta], Operation] = {}
+        for op_cls in self._DEFAULT_OPS:
+            self.register(op_cls())
 
     def register(self, op: Operation) -> None:
-        """
-        Register an Operation. Pairs with `Preprocessor.register(op)`.
-
-        Image-space-only ops can rely on the default identity revert_coords;
-        config-only ops can rely on the default identity revert_images.
-        """
         if not isinstance(op, Operation):
             raise TypeError(f"Expected Operation, got {type(op)}")
-        if not op.name:
-            raise ValueError("Operation must define a non-empty `name`")
-        self._ops[op.name] = op
+        if not getattr(op, "meta_cls", None):
+            raise ValueError("Operation must define `meta_cls`")
+        self._ops[op.meta_cls] = op
 
-    def reconstruct_coordinates(self, results: Dict[str, Any], steps: List[Dict[str, Any]]) -> Dict[str, Any]:
-        """
-        Reverts predicted coordinates to the original pre-preprocessing space.
+    def reconstruct_coordinates(self, results: Dict[str, Any], history: List[Meta]) -> Dict[str, Any]:
+        """Revert predicted coordinates to original pre-preprocessing space."""
+        return self._transform_coordinates(results, history, reverse=True)
 
-        Args:
-            results: Batch results dict where each value is a per-image list.
-                     Keys: boxes, scores, classes, masks, segments, points.
-            steps: Preprocessing history returned by Preprocessor.preprocess.
+    def apply_coordinates(self, results: Dict[str, Any], history: List[Meta]) -> Dict[str, Any]:
+        """Forward-apply geometric ops to original-space coordinates."""
+        return self._transform_coordinates(results, history, reverse=False)
 
-        Returns:
-            Results dict with coordinates reverted to original image space.
-        """
-        self.validate_history_steps(steps)
-        if not results or not steps:
+    def _transform_coordinates(self, results: Dict[str, Any], history: List[Meta], *, reverse: bool) -> Dict[str, Any]:
+        """Run coord ops over ``history`` (reversed for revert, forward for apply)."""
+        self._validate_history(history)
+        if not results or not history:
             return results
 
         first_val = next(iter(results.values()))
@@ -62,40 +66,43 @@ class Reconstructor(BaseProcessor):
         per_image = [{k: v[i] for k, v in results.items()} for i in range(n)]
         per_image, is_numpy = self.to_tensor_results(per_image)
 
-        for step in reversed(steps):
-            op_name = step["type"]
-            if op_name not in self._ops:
-                raise ValueError(f"Revert coordinate handler for '{op_name}' is not registered.")
-            input_populated = self._populated_coord_fields(per_image)
-            per_image = self._ops[op_name].revert_coords(per_image, step["metadata"])
-            self.validate_coord_handler_output(per_image, op_name, input_populated=input_populated)
+        ordered = reversed(history) if reverse else history
+        input_populated = self._populated_coord_fields(per_image)
+        for meta in ordered:
+            op = self._ops.get(type(meta))
+            if op is None:
+                raise ValueError(f"No Operation registered for meta {type(meta).__name__}")
+            transform = op.revert_coords if reverse else op.apply_coords
+            per_image = transform(per_image, meta)
+            input_populated = self.validate_coord_handler_output(per_image, type(meta).__name__, input_populated=input_populated)
 
         per_image = self.from_tensor_results(per_image, is_numpy)
         keys = per_image[0].keys()
         return {k: [d[k] for d in per_image] for k in keys}
 
-    def reconstruct_images(self, images: List[ImageLike], steps: List[Dict[str, Any]]) -> List[ImageLike]:
-        """
-        Reconstructs the original image from images and history.
-
-        Args:
-            images: List of (H, W, C) tensors or numpy arrays.
-            steps: List of configuration dicts.
-
-        Returns:
-            List: The reconstructed image(s) (H, W, C).
-        """
+    def reconstruct_images(self, images: List[ImageLike], history: List[Meta]) -> List[ImageLike]:
+        """Reconstruct original images from preprocessed images and history."""
         self.validate_image_list(images, stage="reconstruction")
-        self.validate_history_steps(steps)
+        self._validate_history(history)
 
-        restored_images, is_numpy = self.to_tensor_list(images)
+        if not history:
+            return list(images)
 
-        for step in reversed(steps):
-            op_name = step["type"]
-            if op_name not in self._ops:
-                raise ValueError(f"Revert image handler for '{op_name}' is not registered.")
+        restored, is_numpy = self.to_tensor_list(images)
 
-            restored_images = self._ops[op_name].revert_images(restored_images, step["metadata"])
-            self.validate_image_handler_output(restored_images, op_name, expected_type="revert image handler")
+        for meta in reversed(history):
+            op = self._ops.get(type(meta))
+            if op is None:
+                raise ValueError(f"No Operation registered for meta {type(meta).__name__}")
+            restored = op.revert_images(restored, meta)
+            self.validate_image_handler_output(restored, type(meta).__name__, expected_type="revert image handler")
 
-        return self.from_tensor_list(restored_images, is_numpy)
+        return self.from_tensor_list(restored, is_numpy)
+
+    @staticmethod
+    def _validate_history(history: List[Meta]) -> None:
+        if not isinstance(history, list):
+            raise TypeError(f"history must be a list, got {type(history)}")
+        for i, m in enumerate(history):
+            if not isinstance(m, Meta):
+                raise TypeError(f"history[{i}] must be a Meta instance, got {type(m)}")

--- a/lmi_utils/preprocess_utils/steps.py
+++ b/lmi_utils/preprocess_utils/steps.py
@@ -1,0 +1,52 @@
+"""Public namespace for building preprocessing pipelines.
+
+Forward (used with self.preprocessor.preprocess in pipeline):
+    steps.crop(boxes=...)
+    steps.resize(width=..., height=..., preserve_aspect=...)
+    ...
+
+Inverse (used with self.revert_preprocess in pipeline):
+    steps.revert_crop(boxes=..., orig_sizes=...)
+    steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...)
+    ...
+"""
+
+from .ops import (
+    CropConfig,
+    CropMeta,
+    FlipConfig,
+    FlipMeta,
+    PadConfig,
+    PadMeta,
+    ResizeConfig,
+    ResizeMeta,
+    TileConfig,
+    TileMeta,
+)
+
+# forward
+crop = CropConfig
+resize = ResizeConfig
+pad = PadConfig
+flip = FlipConfig
+tile = TileConfig
+
+# inverse
+revert_crop = CropMeta
+revert_resize = ResizeMeta
+revert_pad = PadMeta
+revert_flip = FlipMeta
+revert_tile = TileMeta
+
+__all__ = [
+    "crop",
+    "resize",
+    "pad",
+    "flip",
+    "tile",
+    "revert_crop",
+    "revert_resize",
+    "revert_pad",
+    "revert_flip",
+    "revert_tile",
+]

--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -64,10 +64,12 @@ class ODBase(abc.ABC):
                 Accepts both numpy arrays and torch tensors. 2D (HW) images are
                 expanded to 3-channel RGB. All images in a batch must have the same dimensions.
             configs: Confidence threshold (float) or per-class thresholds (dict).
-            operators: Operators for coordinate reversion. Accepts:
+            operators: Unified preprocessing history for coordinate reversion. Accepts:
                 - None: no coordinate reversion.
-                - list[dict]: a single operator chain, applied to all images.
-                - list[list[dict]]: per-image operator chains (length must match batch size).
+                - List of history entries of shape
+                  ``{"type": str, "metadata": [<per_image_dict>, ...], "id"?: str}``,
+                  matching what ``Preprocessor.preprocess()`` returns. ``metadata`` length
+                  must be 1 (broadcast to all images) or equal to batch size (per-image).
         kwargs:
             batch_size (int): chunk size for dynamic mini-batch inference (default: None = all at once).
                 Ignored when self.fixed_batch_size is set.
@@ -317,38 +319,42 @@ class ODBase(abc.ABC):
 
     @staticmethod
     def _normalize_operators(operators, batch_size: int) -> list:
-        """Normalize operators to a per-image list of operator chains.
+        """Slice a typed preprocessing history into per-image chains.
 
-        Args:
-            operators: None, a single chain (list[dict]), or per-image chains (list[list[dict]]).
-            batch_size: Number of images in the batch.
+        The history is a list of typed ``Meta`` records (struct-of-arrays). Each
+        Meta's batched fields must have length 1 (broadcast) or ``batch_size``
+        (per-image).
 
         Returns:
-            List of operator chains, one per image.
+            List of length ``batch_size``, each element a per-image history list
+            of single-record Meta instances.
         """
+        from dataclasses import fields
+
+        from lmi_utils.preprocess_utils.operation import Meta
+
         if not operators:
             return [[] for _ in range(batch_size)]
-        if isinstance(operators[0], dict):
-            ODBase._reject_preprocessor_history(operators)
-            return [list(operators) for _ in range(batch_size)]
-        if len(operators) != batch_size:
-            raise ValueError(f"operators length ({len(operators)}) must match batch size ({batch_size})")
-        for chain in operators:
-            if chain and isinstance(chain[0], dict):
-                ODBase._reject_preprocessor_history(chain)
-        return operators
+        if not isinstance(operators, list) or not all(isinstance(e, Meta) for e in operators):
+            raise ValueError("operators must be a list of typed Meta records.")
 
-    @staticmethod
-    def _reject_preprocessor_history(chain: list) -> None:
-        # Preprocessor.preprocess() returns history dicts with keys {"type","metadata"};
-        # od_base expects legacy revert_to_origin dicts keyed by op name (resize/pad/stretch/flip).
-        # Passing the former silently corrupts coordinates, so fail fast with a redirect.
-        if any(isinstance(op, dict) and "type" in op and "metadata" in op for op in chain):
-            raise ValueError(
-                "Operators appears to be a Preprocessor history (dicts with 'type'/'metadata'). "
-                "Use self.revert_preprocess(results, ops_list) to invert a Preprocessor pipeline. "
-                "Or, pass legacy revert_to_origin list of dicts with 'resize'/'pad'/'stretch'/'flip' keys."
-            )
+        per_image: list = [[] for _ in range(batch_size)]
+        for entry in operators:
+            entry_fields = fields(entry)
+            list_field = next((f for f in entry_fields if isinstance(getattr(entry, f.name), list)), None)
+            n = len(getattr(entry, list_field.name)) if list_field else 1
+            if n not in (1, batch_size):
+                raise ValueError(f"history entry '{type(entry).__name__}' batch size {n} is not 1 (broadcast) or {batch_size} (per-image).")
+            for i in range(batch_size):
+                sliced = type(entry).__new__(type(entry))
+                for f in entry_fields:
+                    v = getattr(entry, f.name)
+                    if isinstance(v, list):
+                        object.__setattr__(sliced, f.name, [v[0] if n == 1 else v[i]])
+                    else:
+                        object.__setattr__(sliced, f.name, v)
+                per_image[i].append(sliced)
+        return per_image
 
     def _revert_coordinates(self, results: dict, operators: list, **kwargs) -> dict:
         """Revert prediction coordinates to the original pre-transform space.

--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -384,7 +384,8 @@ class ODBase(abc.ABC):
         # masks
         masks = results.get("masks")
         if masks is not None and len(masks):
-            results["masks"] = pipeline_utils.revert_masks_to_origin(masks, operators, **kwargs)
+            # binary instance masks: nearest preserves them (bilinear erodes on upscale)
+            results["masks"] = pipeline_utils.revert_masks_to_origin(masks, operators, interpolation="nearest")
 
         # segments
         segments = results.get("segments")

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -165,7 +165,8 @@ class RfdetrBase(ODBase):
             **kwargs:
                 images (list[np.ndarray]): Original images, used to determine target sizes.
                 configs: Confidence threshold (float) or per-class dict.
-                operators (list[list]): Per-image coordinate transform operators.
+                operators (list): per-image-sliced preprocessing history (one slice per image).
+                    Produced by ODBase._normalize_operators from the unified history.
                 return_segments (bool): Whether to convert masks to segments.
 
         Returns:

--- a/object_detectors/ultralytics_lmi/yolo/model.py
+++ b/object_detectors/ultralytics_lmi/yolo/model.py
@@ -133,7 +133,9 @@ class Yolo(YoloCore, ODBase):
             img (torch.Tensor): the preprocessed image(s)
             orig_imgs (list): list of original images. If this is a list of tensors, this function will return tensor results.
             conf (float | dict): float or dictionary of <class: confidence level>.
-            operators (list[list]): per-image operator chains.
+            operators (list[dict]): per-image preprocessing history slice for this image
+                (each entry's ``metadata`` is a single-image list). Built by od_base's
+                ``_normalize_operators`` from the unified history passed to ``predict()``.
         """
         ops_list = operators or [[] for _ in range(len(orig_imgs))]
         return [
@@ -157,7 +159,8 @@ class Yolo(YoloCore, ODBase):
                 preprocessed (torch.Tensor): the preprocessed image(s) (BCHW tensor).
                 images (list): list of original images.
                 configs (float | dict): confidence threshold(s).
-                operators (list[list]): per-image operator chains for coordinate reversion.
+                operators (list): per-image-sliced preprocessing history (one slice per
+                    image in the batch). Produced by ODBase._normalize_operators.
                 iou (float): IoU threshold for NMS. Default 0.45.
                 agnostic (bool): class-agnostic NMS. Default False.
                 max_det (int): max detections. Default 300.
@@ -216,7 +219,9 @@ class YoloSeg(Yolo):
             img (torch.Tensor): the preprocessed image
             orig_img (np.ndarray | torch.Tensor): Original image.
             conf (float | dict): Confidence threshold for filtering predictions.
-            operators (list): operator chain for coordinate reversion.
+            operators (list[dict]): preprocessing history slice for this single image
+                (each entry's ``metadata`` is a 1-element list). See the unified schema
+                in PRERELEASE §9.
             proto (torch.Tensor): The prototype tensor for the masks.
             return_segments (bool): If True, return the segments of the masks.
         """
@@ -248,7 +253,9 @@ class YoloSeg(Yolo):
             img (torch.Tensor): the preprocessed image(s)
             orig_imgs (list): A list of original images. If this is a list of tensors, this function will return tensor results.
             conf (float | dict): float or dictionary of <class: confidence level>.
-            operators (list[list]): per-image operator chains.
+            operators (list[dict]): per-image preprocessing history slice for this image
+                (each entry's ``metadata`` is a single-image list). Built by od_base's
+                ``_normalize_operators`` from the unified history passed to ``predict()``.
             protos (torch.Tensor): The prototype tensors for the masks.
             return_segments (bool): If True, return the segments of the masks.
         """
@@ -302,7 +309,9 @@ class YoloObb(Yolo):
             img (torch.Tensor): the preprocessed image
             orig_img (torch.Tensor): the original image
             confs (dict): per-class confidence thresholds, pre-parsed by postprocess.
-            operators (list): operator chain for coordinate reversion.
+            operators (list[dict]): preprocessing history slice for this single image
+                (each entry's ``metadata`` is a 1-element list). See the unified schema
+                in PRERELEASE §9.
 
         Returns:
             dict: the constructed result dictionary
@@ -344,7 +353,9 @@ class YoloPose(Yolo):
             img (torch.Tensor): the preprocessed image
             orig_img (np.ndarray | torch.Tensor): Original image.
             conf (float | dict): Confidence threshold for filtering predictions.
-            operators (list): operator chain for coordinate reversion.
+            operators (list[dict]): preprocessing history slice for this single image
+                (each entry's ``metadata`` is a 1-element list). See the unified schema
+                in PRERELEASE §9.
         """
         results, M = super().construct_result(pred, img, orig_img, conf)
         pred_kpts = pred[:, 6:].view(pred.shape[0], *self.model.kpt_shape)

--- a/object_detectors/ultralytics_lmi/yolo/run_model.py
+++ b/object_detectors/ultralytics_lmi/yolo/run_model.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
                     if masks is not None:
                         mask = masks[j]
                         if use_revert_to_origin:
-                            mask = revert_masks_to_origin(masks, operators)
+                            mask = revert_masks_to_origin(masks, operators, interpolation="nearest")
                         else:
                             mask = cv2.resize(mask, (im_out.shape[1], im_out.shape[0]))
                     box = boxes[j]

--- a/object_detectors/ultralytics_lmi/yolo/run_model.py
+++ b/object_detectors/ultralytics_lmi/yolo/run_model.py
@@ -146,11 +146,16 @@ if __name__ == "__main__":
                     W=args.resize[1] if args.resize[1] != 0 else None,
                 )
                 logger.warning(f"{im1.shape}, resizing")
-                operators.append({"resize": [im1.shape[1], im1.shape[0], im0.shape[1], im0.shape[0]]})
+                operators.append(
+                    {
+                        "type": "resize",
+                        "metadata": [{"src_size": [im0.shape[1], im0.shape[0]], "dst_size": [im1.shape[1], im1.shape[0]]}],
+                    }
+                )
 
             if args.pad:
                 im1, pad_L, pad_R, pad_T, pad_B = fit_im_to_size(im=im1, H=args.pad[0], W=args.pad[1])
-                operators.append({"pad": [pad_L, pad_R, pad_T, pad_B]})
+                operators.append({"type": "pad", "metadata": [{"pad": [pad_L, pad_R, pad_T, pad_B]}]})
                 logger.warning(f"{im1.shape}, padding")
 
             if args.sz[0] != im1.shape[0] or args.sz[1] != im1.shape[1]:

--- a/object_detectors/yolov5_lmi/model.py
+++ b/object_detectors/yolov5_lmi/model.py
@@ -285,7 +285,7 @@ class Yolov5(ODBase):
             segs = results["segments"][0]
             # convert mask to sensor space
             result_contours = [pipeline_utils.revert_to_origin(seg, operators) for seg in segs]
-            masks = pipeline_utils.revert_masks_to_origin(masks, operators)
+            masks = pipeline_utils.revert_masks_to_origin(masks, operators, interpolation="nearest")
             results_dict["segments"] = result_contours
             results_dict["masks"] = masks
 

--- a/object_detectors/yolov5_lmi/model.py
+++ b/object_detectors/yolov5_lmi/model.py
@@ -234,8 +234,9 @@ class Yolov5(ODBase):
         Args:
             image (np.ndarry): the input image
             configs (dict): a dictionary of the confidence thresholds for each class, e.g., {'classA':0.5, 'classB':0.6}
-            operators (list): a list of dictionaries of the image preprocess operators,
-                such as {'resize':[resized_w, resized_h, orig_w, orig_h]}, {'pad':[pad_left, pad_right, pad_top, pad_bot]}
+            operators (list): unified preprocessing history (single-image; the yolov5 wrapper
+                runs one image at a time). Entries are ``{"type", "metadata": [<per_image_dict>], "id"?}``.
+                See PRERELEASE §9 for the schema.
             iou (float): the iou threshold for non-maximum suppression. defaults to 0.4
             agnostic (bool): If True, the model is agnostic to the number of classes, and all classes will be considered as one.
             max_det (int): The maximum number of detections to return. defaults to 300.

--- a/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
+++ b/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import cv2
@@ -6,6 +7,7 @@ import pytest
 import torch
 
 import lmi_utils.gadget_utils.pipeline_utils as pipeline_utils
+from lmi_utils.preprocess_utils.ops import FlipMeta, PadMeta, ResizeMeta
 
 logger = logging.getLogger(__name__)
 
@@ -121,42 +123,68 @@ class Test_fit_im_to_size:
             assert l1 == l2 and r1 == r2 and t1 == t2 and b1 == b2
 
 
-class Test_revert_to_origin:
-    def np_func(self, pts: np.ndarray, operations: list, verbose=False):
-        def revert(x, y, operations):
-            nx, ny = x, y
-            for operator in reversed(operations):
-                if "resize" in operator:
-                    tw, th, orig_w, orig_h = operator["resize"]
-                    r = [tw / orig_w, th / orig_h]
-                    nx, ny = nx / r[0], ny / r[1]
-                if "pad" in operator:
-                    pad_L, pad_R, pad_T, pad_B = operator["pad"]
-                    nx, ny = nx - pad_L, ny - pad_T
-                if "stretch" in operator:
-                    s = operator["stretch"]
-                    nx, ny = nx / s[0], ny / s[1]
-                if verbose:
-                    logger.info(f"after {operator}, pt: {x:.2f},{y:.2f} -> {nx:.2f},{ny:.2f}")
-            nx = round(nx)
-            ny = round(ny)
-            return [max(nx, 0), max(ny, 0)]
+def _resize_entry(dst_w, dst_h, src_w, src_h, pad=None):
+    """Build a typed `ResizeMeta` history entry (B=1)."""
+    return ResizeMeta(
+        src_sizes=[[src_w, src_h]],
+        dst_sizes=[[dst_w, dst_h]],
+        pads=[list(pad) if pad is not None else [0, 0, 0, 0]],
+    )
 
-        pts2 = []
+
+def _pad_entry(L, R, T, B):
+    return PadMeta(pads=[[L, R, T, B]])
+
+
+def _flip_entry(lr, ud, w, h):
+    return FlipMeta(lr=[lr], ud=[ud], sizes=[[w, h]])
+
+
+class Test_revert_to_origin:
+    """Sanity-check the new unified-schema revert_to_origin against a hand-rolled reference.
+
+    The reference applies each atomic op's inverse (resize unscale, pad subtract, flip
+    mirror) in REVERSE history order, matching how the wrapper dispatches through the
+    Operation registry.
+    """
+
+    def np_func(self, pts, history, verbose=False):
         if isinstance(pts, list):
-            pts = np.array(pts)
-        for pt in pts:
-            if len(pt) == 0:
-                continue
-            if len(pt) == 2:
-                x, y = pt
-                pts2.append(revert(x, y, operations))
-            elif len(pt) == 4:
-                x1, y1, x2, y2 = pt
-                pts2.append(revert(x1, y1, operations) + revert(x2, y2, operations))
-            else:
-                raise Exception(f"does not support pts neither Nx2 nor Nx4. Got shape: {pt.shape} with val: {pt}")
-        return pts2
+            pts = np.array(pts, dtype=np.float64)
+        pts = pts.astype(np.float64).copy()
+        r, c = pts.shape
+        for entry in reversed(history):
+            if isinstance(entry, ResizeMeta):
+                src_w, src_h = entry.src_sizes[0]
+                dst_w, dst_h = entry.dst_sizes[0]
+                pL, _, pT, _ = entry.pads[0]
+                pts[:, 0] = (pts[:, 0] - pL) * (src_w / dst_w)
+                pts[:, 1] = (pts[:, 1] - pT) * (src_h / dst_h)
+                if c == 4:
+                    pts[:, 2] = (pts[:, 2] - pL) * (src_w / dst_w)
+                    pts[:, 3] = (pts[:, 3] - pT) * (src_h / dst_h)
+            elif isinstance(entry, PadMeta):
+                pL, _, pT, _ = entry.pads[0]
+                pts[:, 0] -= pL
+                pts[:, 1] -= pT
+                if c == 4:
+                    pts[:, 2] -= pL
+                    pts[:, 3] -= pT
+            elif isinstance(entry, FlipMeta):
+                lr, ud, (w, h) = entry.lr[0], entry.ud[0], entry.sizes[0]
+                if lr:
+                    pts[:, 0] = w - pts[:, 0]
+                    if c == 4:
+                        pts[:, 2] = w - pts[:, 2]
+                        pts[:, [0, 2]] = pts[:, [2, 0]]
+                if ud:
+                    pts[:, 1] = h - pts[:, 1]
+                    if c == 4:
+                        pts[:, 3] = h - pts[:, 3]
+                        pts[:, [1, 3]] = pts[:, [3, 1]]
+            if verbose:
+                logger.info(f"after {type(entry).__name__}, pts: {pts}")
+        return np.maximum(np.round(pts), 0).astype(np.float32)
 
     @pytest.mark.parametrize(
         "pts, operations",
@@ -164,25 +192,22 @@ class Test_revert_to_origin:
             (
                 [[10.1, 20.0], [30.2, 40.4], [50.5, 60.4], [70.2, 80.1]],
                 [
-                    {"resize": [100, 100, 200, 300]},
-                    {"pad": [8, 9, 10, 11]},
-                    {"stretch": [1.5, 2]},
+                    _resize_entry(100, 100, 200, 300),
+                    _pad_entry(8, 9, 10, 11),
                 ],
             ),
             (
                 np.array([[15.3, 25.8], [35.7, 45], [55.6, 65], [75, 85.3]]),
                 [
-                    {"resize": [200, 300, 100, 100]},
-                    {"pad": [-8, -9, 10, 11]},
-                    {"stretch": [1.3, 1.5]},
+                    _resize_entry(200, 300, 100, 100),
+                    _pad_entry(-8, -9, 10, 11),
                 ],
             ),
             (
                 [[15, 25, 35, 45], [55, 65, 75, 85]],
                 [
-                    {"resize": [200, 300, 100, 100]},
-                    {"pad": [8, 9, 10, 11]},
-                    {"stretch": [1.5, 2]},
+                    _resize_entry(200, 300, 100, 100),
+                    _pad_entry(8, 9, 10, 11),
                 ],
             ),
         ],
@@ -191,16 +216,15 @@ class Test_revert_to_origin:
         pts1 = self.np_func(pts, operations)
 
         pts2 = pipeline_utils.revert_to_origin(pts, operations)
-        assert np.array_equal(pts1, pts2)
+        assert np.array_equal(pts1, np.asarray(pts2, dtype=np.float32))
 
-        if not isinstance(pts, np.ndarray):
-            pts = np.array(pts)
-        pts2 = pipeline_utils.revert_to_origin(torch.from_numpy(pts), operations)
+        pts_np = pts if isinstance(pts, np.ndarray) else np.array(pts)
+        pts2 = pipeline_utils.revert_to_origin(torch.from_numpy(pts_np.astype(np.float32)), operations)
         assert np.array_equal(pts1, pts2.numpy())
 
         if torch.cuda.is_available():
-            pts = torch.tensor(pts).cuda()
-            pts2 = pipeline_utils.revert_to_origin(pts, operations)
+            cuda_pts = torch.tensor(pts_np, dtype=torch.float32).cuda()
+            pts2 = pipeline_utils.revert_to_origin(cuda_pts, operations)
             assert pts2.is_cuda
             assert np.array_equal(pts1, pts2.cpu().numpy())
 
@@ -361,42 +385,44 @@ class Test_pts_to_3d:
 
 
 class Test_apply_operations:
-    def np_func(self, pts: np.ndarray, operations: list):
-        pts = np.array(pts).astype(np.float32)
+    """Forward complement of revert_to_origin. Applies each op's coord transform in order."""
+
+    def np_func(self, pts, history):
+        pts = np.array(pts, dtype=np.float64).copy()
         r, c = pts.shape
-        if c not in [2, 4]:
+        if c not in (2, 4):
             raise Exception(f"pts should be Nx2 or Nx4, got shape: {pts.shape}")
-        for op in operations:
-            if "resize" in op:
-                tw, th, orig_w, orig_h = op["resize"]
-                r = np.array([tw / orig_w, th / orig_h])
-                pts[:, :2] = pts[:, :2] * r
+        for entry in history:
+            if isinstance(entry, ResizeMeta):
+                src_w, src_h = entry.src_sizes[0]
+                dst_w, dst_h = entry.dst_sizes[0]
+                pL, _, pT, _ = entry.pads[0]
+                sx, sy = dst_w / src_w, dst_h / src_h
+                pts[:, 0] = pts[:, 0] * sx + pL
+                pts[:, 1] = pts[:, 1] * sy + pT
                 if c == 4:
-                    pts[:, 2:] = pts[:, 2:] * r
-            elif "pad" in op:
-                pad_L, pad_R, pad_T, pad_B = op["pad"]
-                t = np.array([pad_L, pad_T])
-                pts[:, :2] = pts[:, :2] + t
+                    pts[:, 2] = pts[:, 2] * sx + pL
+                    pts[:, 3] = pts[:, 3] * sy + pT
+            elif isinstance(entry, PadMeta):
+                pL, _, pT, _ = entry.pads[0]
+                pts[:, 0] += pL
+                pts[:, 1] += pT
                 if c == 4:
-                    pts[:, 2:] = pts[:, 2:] + t
-            elif "stretch" in op:
-                s = np.array(op["stretch"])
-                pts[:, :2] = pts[:, :2] * s
-                if c == 4:
-                    pts[:, 2:] = pts[:, 2:] * s
-            elif "flip" in op:
-                lr, ud, im_w, im_h = op["flip"]
-                idx = [0, 2] if c == 4 else [0]
-                idy = [1, 3] if c == 4 else [1]
+                    pts[:, 2] += pL
+                    pts[:, 3] += pT
+            elif isinstance(entry, FlipMeta):
+                lr, ud, (w, h) = entry.lr[0], entry.ud[0], entry.sizes[0]
                 if lr:
-                    pts[:, idx] = im_w - pts[:, idx]
+                    pts[:, 0] = w - pts[:, 0]
                     if c == 4:
+                        pts[:, 2] = w - pts[:, 2]
                         pts[:, [0, 2]] = pts[:, [2, 0]]
                 if ud:
-                    pts[:, idy] = im_h - pts[:, idy]
+                    pts[:, 1] = h - pts[:, 1]
                     if c == 4:
+                        pts[:, 3] = h - pts[:, 3]
                         pts[:, [1, 3]] = pts[:, [3, 1]]
-        return pts.round().clip(min=0)
+        return np.maximum(np.round(pts), 0).astype(np.float32)
 
     @pytest.mark.parametrize(
         "pts, operations",
@@ -404,26 +430,24 @@ class Test_apply_operations:
             (
                 [[10, 20], [30, 40], [50, 60], [70, 80]],
                 [
-                    {"resize": [100, 100, 200, 300]},
-                    {"pad": [8, 9, 10, 11]},
-                    {"stretch": [1.5, 2]},
-                    {"flip": [True, False, 100, 100]},
+                    _resize_entry(100, 100, 200, 300),
+                    _pad_entry(8, 9, 10, 11),
+                    _flip_entry(True, False, 100, 100),
                 ],
             ),
             (
                 np.array([[15.0, 25.2], [35.1, 45.0], [55.0, 65], [75.5, 85]]),
                 [
-                    {"resize": [200, 300, 100, 100]},
-                    {"pad": [6, 7, 9, 10]},
-                    {"stretch": [1.0, 2]},
+                    _resize_entry(200, 300, 100, 100),
+                    _pad_entry(6, 7, 9, 10),
                 ],
             ),
             (
                 [[15, 25, 35, 45], [55, 65, 75, 85]],
                 [
-                    {"resize": [200, 300, 100, 100]},
-                    {"pad": [11, 9, -2, -3]},
-                    {"flip": [False, True, 200, 300]},
+                    _resize_entry(200, 300, 100, 100),
+                    _pad_entry(11, 9, -2, -3),
+                    _flip_entry(False, True, 200, 300),
                 ],
             ),
         ],
@@ -431,16 +455,15 @@ class Test_apply_operations:
     def test_cases(self, pts, operations):
         pts1 = self.np_func(pts, operations)
         pts2 = pipeline_utils.apply_operations(pts, operations)
-        assert np.array_equal(pts1, pts2)
+        assert np.array_equal(pts1, np.asarray(pts2, dtype=np.float32))
 
-        if not isinstance(pts, np.ndarray):
-            pts = np.array(pts)
-        pts2 = pipeline_utils.apply_operations(torch.from_numpy(pts), operations)
+        pts_np = pts if isinstance(pts, np.ndarray) else np.array(pts)
+        pts2 = pipeline_utils.apply_operations(torch.from_numpy(pts_np.astype(np.float32)), operations)
         assert np.array_equal(pts1, pts2.numpy())
 
         if torch.cuda.is_available():
-            pts = torch.tensor(pts).cuda()
-            pts2 = pipeline_utils.apply_operations(pts, operations)
+            cuda_pts = torch.tensor(pts_np, dtype=torch.float32).cuda()
+            pts2 = pipeline_utils.apply_operations(cuda_pts, operations)
             assert pts2.is_cuda
             assert np.array_equal(pts1, pts2.cpu().numpy())
 
@@ -450,13 +473,13 @@ class Test_revert_mask_to_origin:
         "mask, operations, expected_shape",
         [
             (
-                np.random.randint(0, 255, (100, 100, 3)),
-                [{"pad": [8, 9, 10, 11]}, {"flip": [True, False, 100, 100]}],
+                np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8),
+                [_pad_entry(8, 9, 10, 11), _flip_entry(True, False, 100, 100)],
                 (79, 83, 3),
             ),
             (
-                np.random.randint(0, 255, (90, 100)),
-                [{"flip": [True, False, 100, 90]}],
+                np.random.randint(0, 255, (90, 100), dtype=np.uint8),
+                [_flip_entry(True, False, 100, 90)],
                 (90, 100),
             ),
         ],
@@ -465,11 +488,67 @@ class Test_revert_mask_to_origin:
         mask2 = pipeline_utils.revert_mask_to_origin(mask, operations)
         assert mask2.shape == expected_shape
 
-        if "flip" in operations[0]:
-            lr, up, im_w, im_h = operations[0]["flip"]
+        first = operations[0]
+        if isinstance(first, FlipMeta):
             mask3 = mask.copy()
-            if lr:
+            if first.lr[0]:
                 mask3 = np.flip(mask3, axis=1)
-            if up:
+            if first.ud[0]:
                 mask3 = np.flip(mask3, axis=0)
             assert np.array_equal(mask2, mask3)
+
+
+class Test_static_manifest_validation:
+    def _write_manifest(self, tmp_path, models):
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(models))
+        return str(path)
+
+    def _model(self, role, preprocessing):
+        return {
+            "model_role": role,
+            "model_name": "m",
+            "model_version": "1",
+            "format": "trt",
+            "artifacts": {},
+            "model_type": "ObjectDetection",
+            "configs": {},
+            "details": {
+                "image_size": [640, 640],
+                "preprocessing": preprocessing,
+                "training_package": "",
+                "training_algorithm": "",
+            },
+        }
+
+    def test_missing_id_passes_through(self, tmp_path):
+        # The loader validates but does not fill ids; schema_3 fills them at from_dict time.
+        models = [self._model("det", [{"type": "resize", "configuration": {"width": 640, "height": 640}}])]
+        manifest_path = self._write_manifest(tmp_path, models)
+        result = pipeline_utils.get_models_from_static_manifest(manifest_path)
+        assert "id" not in result["det"]["details"]["preprocessing"][0]
+
+    def test_preserves_explicit_id(self, tmp_path):
+        models = [
+            self._model(
+                "det",
+                [{"type": "resize", "configuration": {"width": 640, "height": 640}, "id": "my-resize"}],
+            )
+        ]
+        manifest_path = self._write_manifest(tmp_path, models)
+        result = pipeline_utils.get_models_from_static_manifest(manifest_path)
+        assert result["det"]["details"]["preprocessing"][0]["id"] == "my-resize"
+
+    def test_crop_to_label_step_tolerated(self, tmp_path):
+        # Legacy manifests may still carry a removed `crop-to-label` step; the validator
+        # tolerates it (dropped later by get_global_preprocessing) instead of raising.
+        models = [self._model("det", [{"type": "crop-to-label", "configuration": {"label": "BOTTLE"}}])]
+        manifest_path = self._write_manifest(tmp_path, models)
+        result = pipeline_utils.get_models_from_static_manifest(manifest_path)
+        assert "det" in result
+
+    def test_unknown_op_type_raises(self, tmp_path):
+        models = [self._model("det", [{"type": "nonsense", "configuration": {}}])]
+        manifest_path = self._write_manifest(tmp_path, models)
+        with pytest.raises(ValueError, match="unknown type"):
+            pipeline_utils.get_models_from_static_manifest(manifest_path)

--- a/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
+++ b/tests/lmi_utils/gadget_utils/test_pipeline_utils.py
@@ -498,6 +498,49 @@ class Test_revert_mask_to_origin:
             assert np.array_equal(mask2, mask3)
 
 
+class Test_revert_mask_interpolation:
+    @staticmethod
+    def _block_mask():
+        # 4x4 with a centered 2x2 foreground block (binary uint8)
+        m = np.zeros((4, 4), dtype=np.uint8)
+        m[1:3, 1:3] = 1
+        return m
+
+    def test_nearest_preserves_binary_area(self):
+        mask = self._block_mask()
+        ops = [_resize_entry(4, 4, 8, 8)]  # revert upscales 4x4 -> 8x8
+
+        nearest = pipeline_utils.revert_mask_to_origin(mask, ops, interpolation="nearest")
+        bilinear = pipeline_utils.revert_mask_to_origin(mask, ops)  # default bilinear
+
+        assert nearest.shape == (8, 8)
+        # nearest doubles the 2x2 block -> 4x4 = 16 fg px and stays binary
+        assert set(np.unique(nearest)).issubset({0, 1})
+        assert int((nearest > 0).sum()) == 16
+        # bilinear + uint8 truncation erodes the block
+        assert int((bilinear > 0).sum()) < int((nearest > 0).sum())
+
+    def test_stack_equals_loop_over_singular(self):
+        masks = np.stack([self._block_mask(), self._block_mask()])  # (2,4,4)
+        ops = [_resize_entry(4, 4, 8, 8)]
+
+        stacked = pipeline_utils.revert_masks_to_origin(masks, ops, interpolation="nearest")
+        loop = np.stack([pipeline_utils.revert_mask_to_origin(m, ops, interpolation="nearest") for m in masks])
+        assert np.array_equal(stacked, loop)
+
+    def test_stack_preserves_tensor_type(self):
+        m = torch.from_numpy(self._block_mask())
+        masks = torch.stack([m, m])
+        ops = [_resize_entry(4, 4, 8, 8)]
+
+        out = pipeline_utils.revert_masks_to_origin(masks, ops, interpolation="nearest")
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (2, 8, 8)
+
+    def test_empty_stack(self):
+        assert pipeline_utils.revert_masks_to_origin([], [_resize_entry(4, 4, 8, 8)]) == []
+
+
 class Test_static_manifest_validation:
     def _write_manifest(self, tmp_path, models):
         path = tmp_path / "manifest.json"

--- a/tests/lmi_utils/image_utils/test_img_resize.py
+++ b/tests/lmi_utils/image_utils/test_img_resize.py
@@ -15,7 +15,7 @@ from lmi_utils.image_utils.img_resize import resize_and_pad
         ((10, 10, 3), 1000, 1000),
     ],
 )
-def test_resize_and_pad_stretch(input_shape, target_w, target_h):
+def test_resize_and_pad(input_shape, target_w, target_h):
     input_image = np.zeros(input_shape, dtype=np.uint8)
     h, w = input_shape[:2]
 
@@ -23,7 +23,11 @@ def test_resize_and_pad_stretch(input_shape, target_w, target_h):
 
     assert output.shape == (target_h, target_w, 3)
     assert len(ops) == 1
-    assert ops[0]["resize"] == [target_w, target_h, w, h]
+    assert ops[0]["type"] == "resize"
+    md = ops[0]["metadata"][0]
+    assert md["src_size"] == [w, h]
+    assert md["dst_size"] == [target_w, target_h]
+    assert "pad" not in md
 
 
 @pytest.mark.parametrize(
@@ -42,21 +46,21 @@ def test_resize_and_pad_preserve_aspect(input_shape, target_w, target_h, expecte
     output, ops = resize_and_pad(input_image, width=target_w, height=target_h, preserve_aspect=True, return_operators=True)
 
     assert output.shape == (target_h, target_w, 3)
+    assert len(ops) == 1
+    assert ops[0]["type"] == "resize"
 
-    # Verify Resize Logic
-    # Operator format: [new_w, new_h, old_w, old_h]
-    assert ops[0]["resize"] == [expected_resize[0], expected_resize[1], w, h]
+    md = ops[0]["metadata"][0]
+    assert md["src_size"] == [w, h]
+    assert md["dst_size"] == [expected_resize[0], expected_resize[1]]
 
-    # Verify Padding Logic
     exp_pad_w, exp_pad_h = expected_pad
-
     if exp_pad_w or exp_pad_h:
-        assert len(ops) == 2
-        pad_l, pad_r, pad_t, pad_b = ops[1]["pad"]
+        assert "pad" in md
+        pad_l, pad_r, pad_t, pad_b = md["pad"]
         assert pad_l + pad_r == exp_pad_w
         assert pad_t + pad_b == exp_pad_h
     else:
-        assert len(ops) == 1
+        assert "pad" not in md
 
 
 @pytest.mark.parametrize("input_type", ["numpy", "torch"])
@@ -70,7 +74,6 @@ def test_resize_and_pad_polymorphism(input_type):
 
     output, ops = resize_and_pad(input_image, width=target_w, height=target_h, preserve_aspect=True, return_operators=True)
 
-    # Verification
     if input_type == "numpy":
         assert isinstance(output, np.ndarray), "Input was Numpy, expected Numpy output"
     else:
@@ -78,10 +81,8 @@ def test_resize_and_pad_polymorphism(input_type):
 
     assert output.shape == (100, 100)
 
-    # Check operator integrity
-    resize_op = ops[0]["resize"]
-    assert isinstance(resize_op[0], (int, np.integer))
-    assert isinstance(resize_op[2], (int, np.integer))
-
-    # Verify the values
-    assert resize_op == [100, 100, 50, 50]
+    md = ops[0]["metadata"][0]
+    assert md["src_size"] == [50, 50]
+    assert md["dst_size"] == [100, 100]
+    # 50x50 → 100x100 preserve aspect: no padding (already square).
+    assert "pad" not in md

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -152,7 +152,8 @@ def test_pipeline_OD_injects_resize_on_size_mismatch(caplog):
 
     ops_list = results["ops_list"]
     # Configured resize + injected corrective resize, both recorded for reversion.
-    assert [op.get("type") for op in ops_list] == ["resize", "resize"], f"Unexpected history: {ops_list}"
+    actual_types = [type(op).__name__.removesuffix("Meta").lower() for op in ops_list]
+    assert actual_types == ["resize", "resize"], f"Unexpected history: {actual_types}"
     assert any("injecting a resize" in r.message for r in caplog.records), "Expected an injection warning"
 
 

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -96,7 +96,7 @@ def _build_od_model_roles(version, model_path, preprocessing_steps):
     "version, preprocessing_steps, expected_types",
     [
         ("2", [{"type": "resize", "configuration": {"height": 640, "width": 640}}], ["resize"]),
-        ("3", [{"type": "resize", "configuration": {"height": 640, "width": 640, "preserve_aspect": True}}], ["resize"]),
+        ("3", [{"type": "resize", "id": "r1", "configuration": {"height": 640, "width": 640, "preserve_aspect": True}}], ["resize"]),
     ],
 )
 def test_pipeline_OD(version, preprocessing_steps, expected_types):
@@ -121,7 +121,7 @@ def test_pipeline_OD(version, preprocessing_steps, expected_types):
     ops_list = results["ops_list"]
 
     # Verify operators
-    actual_types = [op.get("type") for op in ops_list]
+    actual_types = [type(op).__name__.removesuffix("Meta").lower() for op in ops_list]
     assert actual_types == expected_types, f"Operator mismatch: {actual_types} != {expected_types}"
 
     # write outputs for manual inspection
@@ -241,12 +241,12 @@ def _build_ad_model_roles(version, model_path, preprocessing_steps):
             ],
             ["resize", "tile"],
         ),
-        ("3", [{"type": "resize", "configuration": {"height": 224, "width": 224}}], ["resize"]),
+        ("3", [{"type": "resize", "id": "r1", "configuration": {"height": 224, "width": 224}}], ["resize"]),
         (
             "3",
             [
-                {"type": "resize", "configuration": {"height": 224, "width": 448}},
-                {"type": "tile", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
+                {"type": "resize", "id": "r1", "configuration": {"height": 224, "width": 448}},
+                {"type": "tile", "id": "t1", "configuration": {"height": 224, "width": 224, "y_stride": 112, "x_stride": 112}},
             ],
             ["resize", "tile"],
         ),
@@ -274,7 +274,7 @@ def test_pipeline_AD(version, preprocessing_steps, expected_types):
     ops_list = results["ops_list"]
 
     # Verify operators
-    actual_types = [op.get("type") for op in ops_list]
+    actual_types = [type(op).__name__.removesuffix("Meta").lower() for op in ops_list]
     assert actual_types == expected_types, f"Operator mismatch: {actual_types} != {expected_types}"
 
     # Verify shapes

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -145,12 +145,12 @@ def test_pipeline_OD_injects_resize_on_size_mismatch(caplog):
 
     image_files = [os.path.join(image_dir, f) for f in os.listdir(image_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
     assert len(image_files) > 0, "No images found in assets"
-    images = [cv2.cvtColor(cv2.imread(f), cv2.COLOR_BGR2RGB) for f in image_files]
+    image = cv2.cvtColor(cv2.imread(image_files[0]), cv2.COLOR_BGR2RGB)
 
     with caplog.at_level(logging.WARNING):
-        results = pipeline.predict({}, {"images": images})
+        processed, ops_list = pipeline.preprocess("mock-model", image)
 
-    ops_list = results["ops_list"]
+    assert len(processed) == 1, f"Expected a single processed image, got {len(processed)}"
     # Configured resize + injected corrective resize, both recorded for reversion.
     actual_types = [type(op).__name__.removesuffix("Meta").lower() for op in ops_list]
     assert actual_types == ["resize", "resize"], f"Unexpected history: {actual_types}"

--- a/tests/lmi_utils/pipeline_base/test_schema3.py
+++ b/tests/lmi_utils/pipeline_base/test_schema3.py
@@ -89,3 +89,29 @@ def test_none_entries_skipped(schema3):
     schema3["disabled_model"] = None
     mc = ModelCollectionV3.from_dict(schema3)
     assert "disabled_model" not in mc.models
+
+
+def test_crop_to_label_step_ignored(schema3):
+    # Legacy manifests may still carry a removed `crop-to-label` step; it is dropped
+    # from the resolved chain rather than raising, for backward compatibility.
+    steps = schema3["top_od_defect"]["details"]["preprocessing"]
+    steps.insert(0, {"type": "crop-to-label", "configuration": {"label": "BOTTLE-BBOX"}})
+
+    pre = ModelCollectionV3.from_dict(schema3).get_global_preprocessing()
+    types = [op["type"] for op in pre["top_od_defect"]]
+    assert "crop-to-label" not in types
+
+
+def test_preprocessing_step_missing_id_stays_none(schema3):
+    # Local manifests may omit `id`; it is not autofilled, and the resolved chain
+    # omits the key entirely rather than emitting a null id.
+    steps = schema3["top_od_defect"]["details"]["preprocessing"]
+    for step in steps:
+        step.pop("id", None)
+
+    mc = ModelCollectionV3.from_dict(schema3)
+    parsed = mc.models["top_od_defect"].details.preprocessing
+    assert all(step.id is None for step in parsed)
+
+    ops = mc.get_global_preprocessing()["top_od_defect"]
+    assert all("id" not in op for op in ops)

--- a/tests/lmi_utils/preprocess_utils/test_chain_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_chain_pipeline.py
@@ -1,0 +1,114 @@
+"""Cross-op chain tests covering flip/pad mixed with crop/resize/tile, plus forward
+apply_coords round-trips through full pipelines."""
+
+import numpy as np
+import pytest
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+
+def _hwc_image(h, w, c=3):
+    return torch.arange(h * w * c, dtype=torch.float32).reshape(h, w, c)
+
+
+def _make_results(boxes):
+    segs = [torch.stack([b[[0, 1]], b[[2, 1]], b[[2, 3]], b[[0, 3]]]) for b in boxes]
+    cx = (boxes[:, 0] + boxes[:, 2]) / 2
+    cy = (boxes[:, 1] + boxes[:, 3]) / 2
+    pts = torch.cat([torch.stack([cx, cy], dim=-1).unsqueeze(1), torch.ones(len(boxes), 1, 1)], dim=-1)
+    return {
+        "boxes": [boxes],
+        "scores": [torch.ones(len(boxes))],
+        "classes": [np.zeros(len(boxes), dtype=np.int32)],
+        "segments": [segs],
+        "points": [pts],
+    }
+
+
+@pytest.fixture
+def pipeline():
+    return Preprocessor(), Reconstructor()
+
+
+def test_pad_then_crop_image_round_trip(pipeline):
+    pre, rec = pipeline
+    img = torch.ones((10, 8, 3), dtype=torch.float32)
+    configs = [
+        steps.pad(pad=[2, 3, 4, 5]),
+        steps.crop(boxes=[[2, 4, 10, 14]]),
+    ]
+    out, history = pre.preprocess([img], configs)
+    assert out[0].shape == (10, 8, 3)
+    assert torch.equal(out[0], img)
+
+    restored = rec.reconstruct_images(out, history)
+    assert restored[0].shape == img.shape
+
+
+def test_flip_then_resize_coord_round_trip(pipeline):
+    pre, rec = pipeline
+    img = _hwc_image(100, 80, 3)
+    configs = [
+        steps.flip(lr=True),
+        steps.resize(width=40, height=50, preserve_aspect=False),
+    ]
+    _out, history = pre.preprocess([img], configs)
+
+    boxes = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    original = _make_results(boxes)
+    forward = rec.apply_coordinates(original, history)
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], boxes, atol=1e-4)
+    assert torch.allclose(round_trip["points"][0], original["points"][0], atol=1e-4)
+
+
+def test_full_pipeline_coord_round_trip(pipeline):
+    pre, rec = pipeline
+    img = _hwc_image(100, 80, 3)
+    configs = [
+        steps.pad(pad=[4, 4, 6, 6]),
+        steps.crop(boxes=[[8, 10, 80, 100]]),
+        steps.resize(width=64, height=64, preserve_aspect=False),
+        steps.flip(lr=True, ud=True),
+    ]
+    _out, history = pre.preprocess([img], configs)
+
+    boxes = torch.tensor([[5.0, 5.0, 25.0, 35.0], [40.0, 10.0, 60.0, 60.0]])
+    original = _make_results(boxes)
+
+    forward = rec.apply_coordinates(original, history)
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], boxes, atol=1e-3)
+    assert torch.allclose(round_trip["points"][0], original["points"][0], atol=1e-3)
+    for r, o in zip(round_trip["segments"][0], original["segments"][0]):
+        assert torch.allclose(r, o, atol=1e-3)
+
+
+def test_full_pipeline_image_reconstructs_to_padded_then_original_shape(pipeline):
+    pre, rec = pipeline
+    img = _hwc_image(100, 80, 3)
+    configs = [
+        steps.pad(pad=[4, 4, 6, 6]),
+        steps.crop(boxes=[[8, 10, 80, 100]]),
+        steps.resize(width=64, height=64, preserve_aspect=False),
+        steps.flip(lr=True, ud=True),
+    ]
+    out, history = pre.preprocess([img], configs)
+    restored = rec.reconstruct_images(out, history)
+    assert restored[0].shape == img.shape
+
+
+def test_tile_with_flip_lossless(pipeline):
+    pre, rec = pipeline
+    img = torch.randint(0, 256, (100, 100, 3), dtype=torch.uint8)
+    configs = [
+        steps.flip(lr=True),
+        steps.tile(tile_size=50, stride=50),
+    ]
+    out, history = pre.preprocess([img], configs)
+    assert len(out) == 4
+    restored = rec.reconstruct_images(out, history)
+    assert torch.equal(restored[0], img)

--- a/tests/lmi_utils/preprocess_utils/test_crop.py
+++ b/tests/lmi_utils/preprocess_utils/test_crop.py
@@ -1,0 +1,164 @@
+import numpy as np
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+
+def _hwc_image(h, w, c=3):
+    return torch.arange(h * w * c, dtype=torch.float32).reshape(h, w, c)
+
+
+def _empty_results(n=1, **overrides):
+    results = {
+        "boxes": [torch.zeros((0, 4)) for _ in range(n)],
+        "scores": [torch.zeros((0,)) for _ in range(n)],
+        "classes": [np.zeros((0,), dtype=np.int32) for _ in range(n)],
+        "segments": [[] for _ in range(n)],
+        "points": [torch.zeros((0, 1, 3)) for _ in range(n)],
+    }
+    results.update(overrides)
+    return results
+
+
+def test_crop_forward_basic():
+    pre = Preprocessor()
+    img = _hwc_image(100, 80, 3)
+    out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+
+    assert len(out) == 1
+    assert out[0].shape == (70, 50, 3)
+    assert history[0].boxes[0] == [10, 20, 60, 90]
+    assert history[0].orig_sizes[0] == [80, 100]
+
+
+def test_crop_clamps_out_of_bounds():
+    pre = Preprocessor()
+    img = _hwc_image(50, 50, 3)
+    out, history = pre.preprocess([img], [steps.crop(boxes=[[-5, -5, 100, 100]])])
+
+    assert out[0].shape == (50, 50, 3)
+    assert history[0].boxes[0] == [0, 0, 50, 50]
+
+
+def test_crop_revert_image_pastes_into_canvas():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = torch.ones((100, 80, 3), dtype=torch.float32)
+    out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+
+    restored = rec.reconstruct_images(out, history)
+    assert restored[0].shape == (100, 80, 3)
+    assert restored[0][20:90, 10:60].eq(1).all()
+    assert restored[0][:20].eq(0).all()
+    assert restored[0][90:].eq(0).all()
+    assert restored[0][:, :10].eq(0).all()
+    assert restored[0][:, 60:].eq(0).all()
+
+
+def test_crop_revert_coords_adds_offset_to_boxes():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+
+    results = _empty_results(boxes=[torch.tensor([[5.0, 5.0, 15.0, 15.0]])])
+    reverted = rec.reconstruct_coordinates(results, history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor([[15.0, 25.0, 25.0, 35.0]]))
+
+
+def test_crop_revert_coords_boxes_obb():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[5, 10, 55, 80]])])
+
+    obb = torch.tensor([[[0.0, 0.0], [10.0, 0.0], [10.0, 5.0], [0.0, 5.0]]])
+    results = _empty_results(boxes=[obb])
+    reverted = rec.reconstruct_coordinates(results, history)
+    expected = torch.tensor([[[5.0, 10.0], [15.0, 10.0], [15.0, 15.0], [5.0, 15.0]]])
+    assert reverted["boxes"][0].shape == (1, 4, 2)
+    assert torch.allclose(reverted["boxes"][0], expected)
+
+
+def test_crop_revert_coords_segments_variable_length():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[15, 20, 60, 90]])])
+
+    seg_a = torch.tensor([[0.0, 0.0], [5.0, 0.0], [5.0, 5.0]])
+    seg_b = torch.tensor([[1.0, 2.0], [3.0, 4.0], [7.0, 8.0], [9.0, 0.0]])
+    results = _empty_results(segments=[[seg_a, seg_b]])
+    reverted = rec.reconstruct_coordinates(results, history)
+    out_segs = reverted["segments"][0]
+    assert len(out_segs) == 2
+    assert torch.allclose(out_segs[0], seg_a + torch.tensor([15.0, 20.0]))
+    assert torch.allclose(out_segs[1], seg_b + torch.tensor([15.0, 20.0]))
+
+
+def test_crop_revert_coords_points_preserve_visibility():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[8, 15, 48, 95]])])
+
+    pts = torch.tensor([[[0.0, 0.0, 2.0], [20.0, 40.0, 1.0], [39.0, 79.0, 0.0]]])
+    results = _empty_results(points=[pts])
+    reverted = rec.reconstruct_coordinates(results, history)
+    expected = torch.tensor([[[8.0, 15.0, 2.0], [28.0, 55.0, 1.0], [47.0, 94.0, 0.0]]])
+    assert reverted["points"][0].shape == (1, 3, 3)
+    assert torch.allclose(reverted["points"][0], expected)
+
+
+def test_crop_revert_coords_masks_paste_into_full_canvas():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[12, 25, 72, 95]])])
+
+    mask = torch.ones((1, 70, 60), dtype=torch.float32)
+    results = _empty_results(masks=[mask])
+    reverted = rec.reconstruct_coordinates(results, history)
+    out_mask = reverted["masks"][0]
+    assert out_mask.shape == (1, 100, 80)
+    assert out_mask[0, 25:95, 12:72].eq(1).all()
+    assert out_mask[0, :25].eq(0).all()
+
+
+def test_crop_apply_coords_forward_inverse_of_revert():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[20, 30, 70, 90]])])
+
+    orig = _empty_results(
+        boxes=[torch.tensor([[25.0, 35.0, 65.0, 75.0]])],
+        segments=[[torch.tensor([[22.0, 32.0], [24.0, 36.0]])]],
+        points=[torch.tensor([[[40.0, 50.0, 2.0]]])],
+    )
+    applied = rec.apply_coordinates(orig, history)
+    assert torch.allclose(applied["boxes"][0], torch.tensor([[5.0, 5.0, 45.0, 45.0]]))
+    assert torch.allclose(applied["segments"][0][0], torch.tensor([[2.0, 2.0], [4.0, 6.0]]))
+    assert torch.allclose(applied["points"][0], torch.tensor([[[20.0, 20.0, 2.0]]]))
+
+    round_trip = rec.reconstruct_coordinates(applied, history)
+    assert torch.allclose(round_trip["boxes"][0], orig["boxes"][0])
+    assert torch.allclose(round_trip["segments"][0][0], orig["segments"][0][0])
+    assert torch.allclose(round_trip["points"][0], orig["points"][0])
+
+
+def test_crop_apply_coords_masks_crops_full_image_masks():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.crop(boxes=[[18, 22, 78, 92]])])
+
+    full = torch.zeros((1, 100, 80), dtype=torch.float32)
+    full[0, 22:92, 18:78] = 1.0
+    orig = _empty_results(masks=[full])
+    applied = rec.apply_coordinates(orig, history)
+    assert applied["masks"][0].shape == (1, 70, 60)
+    assert applied["masks"][0].eq(1).all()
+
+
+def test_crop_manual_revert_via_steps_namespace():
+    """Manual inverse without history — build a CropMeta directly via steps.revert_crop."""
+    rec = Reconstructor()
+    results = _empty_results(boxes=[torch.tensor([[5.0, 5.0, 15.0, 15.0]])])
+    history = [steps.revert_crop(boxes=[[10, 20, 60, 90]], orig_sizes=[[80, 100]])]
+    reverted = rec.reconstruct_coordinates(results, history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor([[15.0, 25.0, 25.0, 35.0]]))

--- a/tests/lmi_utils/preprocess_utils/test_device_contract.py
+++ b/tests/lmi_utils/preprocess_utils/test_device_contract.py
@@ -3,19 +3,19 @@
 import pytest
 import torch
 
+from lmi_utils.preprocess_utils import steps
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
 cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 
-STEPS = [
-    {"type": "resize", "configuration": {"width": 32, "height": 32, "preserve_aspect": True}},
-    {"type": "tile", "configuration": {"tile_size": [16, 16], "stride": [16, 16]}},
+CONFIGS = [
+    steps.resize(width=32, height=32, preserve_aspect=True),
+    steps.tile(tile_size=[16, 16], stride=[16, 16]),
 ]
 
 
 def _device_type(t):
-    """Compare device by type only ('cuda', 'cpu') — index is implementation detail."""
     return t.device.type if isinstance(t, torch.Tensor) else None
 
 
@@ -34,7 +34,7 @@ def test_preprocess_preserves_device(prep, device_str):
     device = torch.device(device_str)
     image = torch.zeros((40, 40, 3), dtype=torch.float32, device=device)
 
-    processed, _ = prep.preprocess(image, STEPS)
+    processed, _ = prep.preprocess(image, CONFIGS)
 
     assert all(_device_type(t) == device.type for t in processed), [_device_type(t) for t in processed]
 
@@ -44,7 +44,7 @@ def test_reconstruct_images_preserves_device(prep, recon, device_str):
     device = torch.device(device_str)
     image = torch.zeros((40, 40, 3), dtype=torch.float32, device=device)
 
-    processed, history = prep.preprocess(image, STEPS)
+    processed, history = prep.preprocess(image, CONFIGS)
     restored = recon.reconstruct_images(processed, history)
 
     assert all(_device_type(t) == device.type for t in restored), [_device_type(t) for t in restored]
@@ -55,11 +55,9 @@ def test_reconstruct_coordinates_preserves_device(prep, recon, device_str):
     device = torch.device(device_str)
     image = torch.zeros((40, 40, 3), dtype=torch.float32, device=device)
 
-    _, history = prep.preprocess(image, STEPS)
+    _, history = prep.preprocess(image, CONFIGS)
 
-    # Build a per-tile result batch on `device`. After tile->resize revert,
-    # coordinates should still be on `device`.
-    n_tiles = 2 * 2  # 32 / 16 = 2 along each axis
+    n_tiles = 2 * 2
     boxes_per_tile = torch.tensor([[1.0, 2.0, 5.0, 6.0]], device=device)
     masks_per_tile = torch.ones((1, 16, 16), device=device)
     segs_per_tile = [torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=device)]

--- a/tests/lmi_utils/preprocess_utils/test_error_handling.py
+++ b/tests/lmi_utils/preprocess_utils/test_error_handling.py
@@ -1,58 +1,67 @@
+# Lightweight test-only Config/Meta/Operation triples for stub handlers.
+from dataclasses import dataclass, field
+
 import numpy as np
 import pytest
 import torch
 
-from lmi_utils.preprocess_utils.operation import Operation
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.operation import Config, Meta, Operation
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
 
-def _make_op(name, forward=None, revert_images=None, revert_coords=None):
-    """Build a one-off Operation subclass with caller-provided behavior."""
-    fwd = forward if forward is not None else (lambda images, config: (images, []))
+@dataclass
+class _StubConfig(Config):
+    pass
+
+
+@dataclass
+class _StubMeta(Meta):
+    items: list = field(default_factory=list)
+
+
+def _make_op(*, config_cls=None, meta_cls=None, forward=None, revert_images=None, revert_coords=None):
+    if config_cls is None:
+        config_cls = type("_TestCfg", (Config,), {"__annotations__": {}})
+        config_cls = dataclass(config_cls)
+    if meta_cls is None:
+        meta_cls = type("_TestMeta", (Meta,), {"__annotations__": {}})
+        meta_cls = dataclass(meta_cls)
+    fwd = forward if forward is not None else (lambda self, images, config: (images, meta_cls()))
     attrs = {
-        "name": name,
-        "forward": lambda self, images, config: fwd(images, config),
+        "config_cls": config_cls,
+        "meta_cls": meta_cls,
+        "forward": fwd,
     }
     if revert_images is not None:
-        attrs["revert_images"] = lambda self, images, metadata: revert_images(images, metadata)
+        attrs["revert_images"] = revert_images
     if revert_coords is not None:
-        attrs["revert_coords"] = lambda self, results, metadata: revert_coords(results, metadata)
-    return type("_TestOp", (Operation,), attrs)()
+        attrs["revert_coords"] = revert_coords
+    cls = type("_TestOp", (Operation,), attrs)
+    return cls(), config_cls, meta_cls
 
 
 @pytest.fixture
 def prep():
-    """Returns a fresh Preprocessor instance for each test."""
     return Preprocessor()
 
 
 @pytest.fixture
 def recon():
-    """Returns a fresh Reconstructor instance for each test."""
     return Reconstructor()
-
-
-# ==========================================
-# Group 1: Input Validation
-# Tests related to data types and dimensions
-# ==========================================
 
 
 @pytest.mark.parametrize("invalid_input", [123, "string", None, 5.6, [None]])
 def test_preprocessor_invalid_inputs(prep, invalid_input):
-    """Test that both Preprocessor reject invalid image types."""
     with pytest.raises(TypeError, match="Images must be torch.Tensors or np.ndarrays"):
         prep.preprocess([invalid_input], [])
 
 
 def test_preprocessor_one_dim_image(prep):
-    """Test that preprocessor rejects one-dimensional images."""
     image = np.zeros((10,), dtype=np.uint8)
-    ops = [{"type": "tile", "configuration": {"tile_size": [8, 8], "stride": [8, 8]}}]
-
     with pytest.raises(ValueError, match="Expected 2D .HW. or 3D .HWC. image"):
-        prep.preprocess([image], ops)
+        prep.preprocess([image], [steps.tile(tile_size=[8, 8], stride=[8, 8])])
 
 
 @pytest.mark.parametrize(
@@ -65,112 +74,97 @@ def test_preprocessor_one_dim_image(prep):
     ],
 )
 def test_reconstructor_invalid_inputs(recon, bad_input, error_type, match_msg):
-    """Test that reconstructor validates input structure and consistency."""
     with pytest.raises(error_type, match=match_msg):
         recon.reconstruct_images(bad_input, [])
 
 
-# ==========================================
-# Group 2: Step Configuration
-# Tests related to step dict structure
-# ==========================================
-
-
-@pytest.mark.parametrize("invalid_step", [{"configuration": {}}, {"type": "resize"}])
-def test_invalid_step_keys(prep, recon, invalid_step):
-    """Test that both classes validate step structure (must have type and configuration)."""
+def test_configs_must_be_list(prep, recon):
     im = np.zeros((10, 10, 3), dtype=np.uint8)
-
-    with pytest.raises(TypeError, match="Steps must be a list"):
+    with pytest.raises(TypeError, match="configs must be a list"):
         prep.preprocess(im, "not_a_list")
-    with pytest.raises(TypeError, match="Steps must be a list"):
+    with pytest.raises(TypeError, match="history must be a list"):
         recon.reconstruct_images([im], "not_a_list")
 
-    with pytest.raises(TypeError, match="All steps must be dictionaries"):
-        prep.preprocess(im, ["not_a_dict"])
-    with pytest.raises(TypeError, match="All steps must be dictionaries"):
-        recon.reconstruct_images([im], ["not_a_dict"])
 
-    with pytest.raises(ValueError, match="Each step must contain keys"):
-        prep.preprocess(im, [invalid_step])
-    with pytest.raises(ValueError, match="Each step must contain keys"):
-        recon.reconstruct_images([im], [invalid_step])
+def test_config_must_be_typed(prep):
+    im = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(TypeError, match="configs\\[0\\] must be a Config"):
+        prep.preprocess(im, ["not_a_config"])
 
 
-# ==========================================
-# Group 3: Handler Registry
-# Tests related to registering/retrieving handlers
-# ==========================================
+def test_history_must_be_typed(recon):
+    im = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(TypeError, match="history\\[0\\] must be a Meta instance"):
+        recon.reconstruct_images([im], ["not_a_meta"])
 
 
-def test_unregistered_handler(prep, recon):
-    """Test that classes reject operations with unknown handlers."""
+def test_unregistered_config(prep):
+    @dataclass
+    class _UnregCfg(Config):
+        pass
+
     image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="No Operation registered"):
+        prep.preprocess(image, [_UnregCfg()])
 
-    with pytest.raises(ValueError, match="Operation 'unknown' is not registered"):
-        prep.preprocess(image, [{"type": "unknown", "configuration": {}}])
 
-    with pytest.raises(ValueError, match="Revert image handler for 'unknown' is not registered"):
-        recon.reconstruct_images([image], [{"type": "unknown", "metadata": []}])
+def test_unregistered_meta(recon):
+    @dataclass
+    class _UnregMeta(Meta):
+        pass
+
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="No Operation registered"):
+        recon.reconstruct_images([image], [_UnregMeta()])
 
 
 def test_register_non_operation(prep, recon):
-    """Test that only Operation instances can be registered."""
     with pytest.raises(TypeError, match="Expected Operation"):
         prep.register("not_an_op")
     with pytest.raises(TypeError, match="Expected Operation"):
         recon.register("not_an_op")
 
 
-# ==========================================
-# Group 4: Handler Compliance
-# Tests ensuring custom handlers return valid data
-# ==========================================
-
-
 def test_preprocessor_handler_returns(prep):
-    """Test that preprocessor ops return (list of tensors, dict)."""
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
-    prep.register(_make_op("bad1", forward=lambda images, config: (images[0], [])))
-    with pytest.raises(TypeError, match="Preprocess handler 'bad1' must return a list of images"):
-        prep.preprocess(image, [{"type": "bad1", "configuration": {}}])
+    op, cfg_cls, meta_cls = _make_op(forward=lambda self, images, config: (images[0], meta_cls()))
+    prep.register(op)
+    with pytest.raises(TypeError, match="must return a list of images"):
+        prep.preprocess(image, [cfg_cls()])
 
-    prep.register(_make_op("bad2", forward=lambda images, config: (images, "not_a_list")))
-    with pytest.raises(TypeError, match="Handler 'bad2' must return metadata as list"):
-        prep.preprocess(image, [{"type": "bad2", "configuration": {}}])
+    op2, cfg_cls2, meta_cls2 = _make_op(forward=lambda self, images, config: (images, "not_a_meta"))
+    prep.register(op2)
+    with pytest.raises(TypeError, match="expected Meta"):
+        prep.preprocess(image, [cfg_cls2()])
 
-    prep.register(_make_op("bad3", forward=lambda images, config: (images, {"wrapped": []})))
-    with pytest.raises(TypeError, match="Handler 'bad3' must return metadata as list"):
-        prep.preprocess(image, [{"type": "bad3", "configuration": {}}])
-
-    prep.register(_make_op("bad4", forward=lambda images, config: ([np.zeros((10, 10, 3))], [])))
-    with pytest.raises(TypeError, match="Preprocess handler 'bad4' returned non-tensor images"):
-        prep.preprocess(image, [{"type": "bad4", "configuration": {}}])
+    op3, cfg_cls3, meta_cls3 = _make_op(forward=lambda self, images, config: ([np.zeros((10, 10, 3))], meta_cls3()))
+    prep.register(op3)
+    with pytest.raises(TypeError, match="returned non-tensor images"):
+        prep.preprocess(image, [cfg_cls3()])
 
 
 def test_reconstructor_handler_returns(recon):
-    """Test that reconstructor revert ops return list of tensors."""
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
-    recon.register(_make_op("bad1", revert_images=lambda images, metadata: images[0]))
-    with pytest.raises(TypeError, match="Revert image handler 'bad1' must return a list of images"):
-        recon.reconstruct_images([image], [{"type": "bad1", "metadata": []}])
+    op, _cfg, meta_cls = _make_op(revert_images=lambda self, images, meta: images[0])
+    recon.register(op)
+    with pytest.raises(TypeError, match="must return a list of images"):
+        recon.reconstruct_images([image], [meta_cls()])
 
-    recon.register(_make_op("bad2", revert_images=lambda images, metadata: [np.zeros((10, 10, 3))]))
+    op2, _cfg2, meta_cls2 = _make_op(revert_images=lambda self, images, meta: [np.zeros((10, 10, 3))])
+    recon.register(op2)
     tensor_image = torch.zeros((10, 10, 3))
-    with pytest.raises(TypeError, match="Revert image handler 'bad2' returned non-tensor images"):
-        recon.reconstruct_images([tensor_image], [{"type": "bad2", "metadata": []}])
+    with pytest.raises(TypeError, match="returned non-tensor images"):
+        recon.reconstruct_images([tensor_image], [meta_cls2()])
 
 
 def test_revert_coords_drops_field(recon):
-    """A coord handler that silently drops a populated field must raise."""
-
-    def drop_masks(results, metadata):
-        # Strip 'masks' from every per-image dict — simulates a buggy handler.
+    def drop_masks(self, results, meta):
         return [{k: v for k, v in r.items() if k != "masks"} for r in results]
 
-    recon.register(_make_op("dropper", revert_coords=drop_masks))
+    op, _cfg, meta_cls = _make_op(revert_coords=drop_masks)
+    recon.register(op)
 
     results = {
         "boxes": [torch.tensor([[0.0, 0.0, 5.0, 5.0]])],
@@ -178,29 +172,25 @@ def test_revert_coords_drops_field(recon):
         "scores": [torch.tensor([0.9])],
         "classes": [np.array([0])],
     }
-    steps = [{"type": "dropper", "metadata": [None]}]
-
     with pytest.raises(KeyError, match="dropped non-empty coord field.*masks"):
-        recon.reconstruct_coordinates(results, steps)
-
-
-# ==========================================
-# Group 5: Reconstruction Integrity
-# Tests for logic specific to rebuilding images
-# ==========================================
+        recon.reconstruct_coordinates(results, [meta_cls()])
 
 
 def test_tile_count_integrity(recon):
-    """Test RuntimeError when tile count doesn't match images provided."""
+    """Tile reconstruction must reject mismatched tile counts."""
+    from lmi_utils.preprocess_utils.ops import TileMeta
+
     image = torch.zeros((16, 16, 3))
-
-    tiler_meta = {
-        "n_tiles": [2, 2],  # Expects 4 tiles
-        "tile_size": [8, 8],
-        "stride": [8, 8],
-    }
-    ops = [{"type": "tile", "metadata": [tiler_meta]}]
-
-    # Provide only 1 image instead of 4
+    meta = TileMeta(
+        tile_sizes=[[8, 8]],
+        strides=[[8, 8]],
+        im_sizes=[[16, 16]],
+        scale_sizes=[[16, 16]],
+        n_tiles=[[2, 2]],
+        batch_sizes=[1],
+        num_channels=[3],
+        scale_modes=["padding"],
+        overlap_modes=["average"],
+    )
     with pytest.raises(RuntimeError, match="Expected 4 tiles, found 1"):
-        recon.reconstruct_images([image], ops)
+        recon.reconstruct_images([image], [meta])

--- a/tests/lmi_utils/preprocess_utils/test_flip.py
+++ b/tests/lmi_utils/preprocess_utils/test_flip.py
@@ -1,0 +1,162 @@
+import numpy as np
+import pytest
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+
+def _hwc_image(h, w, c=3):
+    return torch.arange(h * w * c, dtype=torch.float32).reshape(h, w, c)
+
+
+def _empty_results(n=1, **overrides):
+    results = {
+        "boxes": [torch.zeros((0, 4)) for _ in range(n)],
+        "scores": [torch.zeros((0,)) for _ in range(n)],
+        "classes": [np.zeros((0,), dtype=np.int32) for _ in range(n)],
+        "segments": [[] for _ in range(n)],
+        "points": [torch.zeros((0, 1, 3)) for _ in range(n)],
+    }
+    results.update(overrides)
+    return results
+
+
+def _make_results(boxes):
+    segs = [torch.stack([b[[0, 1]], b[[2, 1]], b[[2, 3]], b[[0, 3]]]) for b in boxes]
+    cx = (boxes[:, 0] + boxes[:, 2]) / 2
+    cy = (boxes[:, 1] + boxes[:, 3]) / 2
+    pts = torch.cat([torch.stack([cx, cy], dim=-1).unsqueeze(1), torch.ones(len(boxes), 1, 1)], dim=-1)
+    return _empty_results(boxes=[boxes], segments=[segs], points=[pts])
+
+
+@pytest.mark.parametrize(
+    "lr, ud",
+    [(True, False), (False, True), (True, True), (False, False)],
+)
+def test_flip_forward_pixels(lr, ud):
+    pre = Preprocessor()
+    img = _hwc_image(4, 5, 1)
+    out, history = pre.preprocess([img], [steps.flip(lr=lr, ud=ud)])
+    expected = img
+    if lr:
+        expected = torch.flip(expected, dims=[1])
+    if ud:
+        expected = torch.flip(expected, dims=[0])
+    assert torch.equal(out[0], expected)
+    assert history[0].lr[0] == lr
+    assert history[0].ud[0] == ud
+    assert history[0].sizes[0] == [5, 4]
+
+
+def test_flip_image_revert_is_involutive():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(8, 6, 3)
+    out, history = pre.preprocess([img], [steps.flip(lr=True, ud=True)])
+
+    restored = rec.reconstruct_images(out, history)
+    assert torch.equal(restored[0], img)
+
+
+def test_flip_revert_coords_xyxy_lr():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True)])
+
+    boxes = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    results = _make_results(boxes)
+    reverted = rec.reconstruct_coordinates(results, history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor([[50.0, 20.0, 70.0, 40.0]]))
+    expected_corners = torch.tensor([[70.0, 20.0], [50.0, 20.0], [50.0, 40.0], [70.0, 40.0]])
+    assert torch.allclose(reverted["segments"][0][0], expected_corners)
+    assert torch.allclose(reverted["points"][0][0, 0], torch.tensor([60.0, 30.0, 1.0]))
+
+
+def test_flip_revert_coords_xyxy_ud():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(ud=True)])
+
+    boxes = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    reverted = rec.reconstruct_coordinates(_make_results(boxes), history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor([[10.0, 60.0, 30.0, 80.0]]))
+
+
+def test_flip_revert_obb_boxes():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True)])
+
+    obb = torch.tensor([[[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]]])
+    reverted = rec.reconstruct_coordinates(_empty_results(boxes=[obb]), history)
+    expected = torch.tensor([[[70.0, 20.0], [50.0, 20.0], [50.0, 40.0], [70.0, 40.0]]])
+    assert torch.allclose(reverted["boxes"][0], expected)
+
+
+def test_flip_revert_masks():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(4, 5, 1)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True, ud=True)])
+
+    mask = torch.zeros((1, 4, 5), dtype=torch.float32)
+    mask[0, 0, 0] = 1.0
+    reverted = rec.reconstruct_coordinates(_empty_results(masks=[mask]), history)
+    assert reverted["masks"][0][0, -1, -1] == 1.0
+    assert reverted["masks"][0][0, 0, 0] == 0.0
+
+
+@pytest.mark.parametrize(
+    "lr, ud, expected",
+    [
+        (False, True, [[[10.0, 80.0], [30.0, 80.0], [30.0, 60.0], [10.0, 60.0]]]),
+        (True, True, [[[70.0, 80.0], [50.0, 80.0], [50.0, 60.0], [70.0, 60.0]]]),
+    ],
+)
+def test_flip_revert_obb_ud_and_both(lr, ud, expected):
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=lr, ud=ud)])
+
+    obb = torch.tensor([[[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]]])
+    reverted = rec.reconstruct_coordinates(_empty_results(boxes=[obb]), history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor(expected))
+
+
+def test_flip_obb_apply_coords_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True, ud=True)])
+
+    obb = torch.tensor([[[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]]])
+    forward = rec.apply_coordinates(_empty_results(boxes=[obb]), history)
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], obb)
+
+
+def test_flip_revert_segments_variable_length():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True)])
+
+    seg_short = torch.tensor([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]])
+    seg_long = torch.tensor([[5.0, 5.0], [70.0, 15.0]])
+    results = _empty_results(segments=[[seg_short, seg_long]])
+    reverted = rec.reconstruct_coordinates(results, history)
+    out_segs = reverted["segments"][0]
+    assert len(out_segs) == 2
+    assert torch.allclose(out_segs[0], torch.tensor([[70.0, 20.0], [50.0, 40.0], [30.0, 60.0]]))
+    assert torch.allclose(out_segs[1], torch.tensor([[75.0, 5.0], [10.0, 15.0]]))
+
+
+def test_flip_apply_coords_is_inverse_of_revert():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(100, 80, 3)
+    _out, history = pre.preprocess([img], [steps.flip(lr=True, ud=True)])
+
+    boxes = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    original = _make_results(boxes)
+    forward = rec.apply_coordinates(original, history)
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], boxes)
+    assert torch.allclose(round_trip["points"][0], original["points"][0])

--- a/tests/lmi_utils/preprocess_utils/test_pad.py
+++ b/tests/lmi_utils/preprocess_utils/test_pad.py
@@ -1,0 +1,191 @@
+import numpy as np
+import pytest
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+
+def _hwc_image(h, w, c=3):
+    return torch.arange(h * w * c, dtype=torch.float32).reshape(h, w, c)
+
+
+def _empty_results(n=1, **overrides):
+    results = {
+        "boxes": [torch.zeros((0, 4)) for _ in range(n)],
+        "scores": [torch.zeros((0,)) for _ in range(n)],
+        "classes": [np.zeros((0,), dtype=np.int32) for _ in range(n)],
+        "segments": [[] for _ in range(n)],
+        "points": [torch.zeros((0, 1, 3)) for _ in range(n)],
+    }
+    results.update(overrides)
+    return results
+
+
+def test_pad_forward_explicit_pad_op():
+    pre = Preprocessor()
+    img = torch.ones((10, 8, 3), dtype=torch.float32)
+    out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    assert out[0].shape == (19, 13, 3)
+    assert history[0].pads[0] == [2, 3, 4, 5]
+    assert out[0][4:14, 2:10].eq(1).all()
+    assert out[0][:4].eq(0).all()
+
+
+def test_pad_forward_target_size_centers_padding():
+    pre = Preprocessor()
+    img = torch.ones((10, 8, 3), dtype=torch.float32)
+    out, history = pre.preprocess([img], [steps.pad(width=12, height=14)])
+
+    assert out[0].shape == (14, 12, 3)
+    assert history[0].pads[0] == [2, 2, 2, 2]
+
+
+def test_pad_forward_target_size_center_crops_when_smaller():
+    pre = Preprocessor()
+    img = _hwc_image(20, 16, 3)
+    out, history = pre.preprocess([img], [steps.pad(width=10, height=12)])
+
+    assert out[0].shape == (12, 10, 3)
+    pad = history[0].pads[0]
+    assert pad[0] + pad[1] == 10 - 16
+    assert pad[2] + pad[3] == 12 - 20
+
+
+def test_pad_invalid_pad_length_raises():
+    with pytest.raises(ValueError, match="must be \\[L, R, T, B\\]"):
+        steps.pad(pad=[1, 2, 3])
+
+
+def test_pad_revert_image_restores_original_size():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    restored = rec.reconstruct_images(out, history)
+    assert restored[0].shape == img.shape
+    assert torch.equal(restored[0], img)
+
+
+def test_pad_revert_coords_subtracts_offset():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    results = _empty_results(
+        boxes=[torch.tensor([[5.0, 6.0, 9.0, 12.0]])],
+        segments=[[torch.tensor([[5.0, 6.0], [9.0, 6.0], [9.0, 12.0], [5.0, 12.0]])]],
+        points=[torch.tensor([[[7.0, 9.0, 1.0]]])],
+    )
+    reverted = rec.reconstruct_coordinates(results, history)
+    assert torch.allclose(reverted["boxes"][0], torch.tensor([[3.0, 2.0, 7.0, 8.0]]))
+    assert torch.allclose(reverted["segments"][0][0], torch.tensor([[3.0, 2.0], [7.0, 2.0], [7.0, 8.0], [3.0, 8.0]]))
+    assert torch.allclose(reverted["points"][0], torch.tensor([[[5.0, 5.0, 1.0]]]))
+
+
+def test_pad_apply_coords_adds_offset_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    original = _empty_results(boxes=[torch.tensor([[3.0, 2.0, 7.0, 8.0]])])
+    forward = rec.apply_coordinates(original, history)
+    assert torch.allclose(forward["boxes"][0], torch.tensor([[5.0, 6.0, 9.0, 12.0]]))
+
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], original["boxes"][0])
+
+
+def test_pad_empty_results_passthrough():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[1, 1, 1, 1])])
+
+    reverted = rec.reconstruct_coordinates(_empty_results(), history)
+    assert reverted["boxes"][0].shape == (0, 4)
+
+
+def test_pad_apply_coords_pads_masks():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    masks = torch.ones((1, 10, 8))
+    forward = rec.apply_coordinates(_empty_results(masks=[masks]), history)
+    out_masks = forward["masks"][0]
+    assert out_masks.shape == (1, 19, 13)
+    assert out_masks[0, 4:14, 2:10].eq(1).all()
+    assert out_masks[0, :4].eq(0).all()
+    assert out_masks[0, 14:].eq(0).all()
+    assert out_masks[0, :, :2].eq(0).all()
+    assert out_masks[0, :, 10:].eq(0).all()
+
+
+def test_pad_revert_coords_crops_masks_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    padded_mask = torch.zeros((1, 19, 13))
+    padded_mask[0, 4:14, 2:10] = 1.0
+    reverted = rec.reconstruct_coordinates(_empty_results(masks=[padded_mask]), history)
+    out_masks = reverted["masks"][0]
+    assert out_masks.shape == (1, 10, 8)
+    assert out_masks.eq(1).all()
+
+
+def test_pad_masks_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    masks = torch.rand((2, 10, 8))
+    forward = rec.apply_coordinates(_empty_results(masks=[masks]), history)
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.equal(round_trip["masks"][0], masks)
+
+
+def test_pad_obb_boxes_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    obb_orig = torch.tensor([[[3.0, 2.0], [7.0, 2.0], [7.0, 8.0], [3.0, 8.0]]])
+    forward = rec.apply_coordinates(_empty_results(boxes=[obb_orig]), history)
+    expected_padded = torch.tensor([[[5.0, 6.0], [9.0, 6.0], [9.0, 12.0], [5.0, 12.0]]])
+    assert forward["boxes"][0].shape == (1, 4, 2)
+    assert torch.allclose(forward["boxes"][0], expected_padded)
+
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], obb_orig)
+
+
+def test_pad_segments_variable_length():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[2, 3, 4, 5])])
+
+    seg_short = torch.tensor([[5.0, 7.0]])
+    seg_long = torch.tensor([[3.0, 6.0], [5.0, 8.0], [7.0, 10.0]])
+    results = _empty_results(segments=[[seg_short, seg_long]])
+    reverted = rec.reconstruct_coordinates(results, history)
+    out_segs = reverted["segments"][0]
+    assert torch.allclose(out_segs[0], torch.tensor([[3.0, 3.0]]))
+    assert torch.allclose(out_segs[1], torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))
+
+
+def test_pad_masks_with_negative_pad_crops_and_zero_pads_on_revert():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc_image(10, 8, 3)
+    _out, history = pre.preprocess([img], [steps.pad(pad=[-1, -1, 2, 2])])
+    assert _out[0].shape == (14, 6, 3)
+
+    masks = torch.ones((1, 10, 8))
+    forward = rec.apply_coordinates(_empty_results(masks=[masks]), history)
+    out_masks = forward["masks"][0]
+    assert out_masks.shape == (1, 14, 6)
+    assert out_masks[0, 2:12].eq(1).all()
+    assert out_masks[0, :2].eq(0).all()
+    assert out_masks[0, 12:].eq(0).all()

--- a/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocess_pipeline.py
@@ -2,20 +2,14 @@ import numpy as np
 import pytest
 import torch
 
+from lmi_utils.preprocess_utils import steps
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
 
 @pytest.fixture
 def pipeline():
-    """
-    Initializes the real Preprocessor and Reconstructor.
-    """
-    # Initialize classes
-    prep = Preprocessor()
-    recon = Reconstructor()
-
-    return prep, recon
+    return Preprocessor(), Reconstructor()
 
 
 @pytest.mark.parametrize("input_type", ["numpy", "torch"])
@@ -27,9 +21,7 @@ def test_tiling_lossless_reconstruction(pipeline, input_type):
     else:
         input_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
 
-    steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-
-    final_images, ops = prep.preprocess(input_image, steps)
+    final_images, ops = prep.preprocess(input_image, [steps.tile(tile_size=50, stride=50)])
 
     assert len(final_images) == 4
     assert final_images[0].shape == (50, 50, 3)
@@ -56,13 +48,13 @@ def test_nested_pipeline_flow(pipeline, input_type):
     else:
         input_image = np.random.randint(0, 256, (128, 128, 3), dtype=np.uint8)
 
-    steps = [
-        {"type": "resize", "configuration": {"width": 64, "height": 64}},
-        {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
-        {"type": "tile", "configuration": {"tile_size": 16, "stride": 16}},
+    configs = [
+        steps.resize(width=64, height=64),
+        steps.tile(tile_size=32, stride=32),
+        steps.tile(tile_size=16, stride=16),
     ]
 
-    final_images, ops = prep.preprocess(input_image, steps)
+    final_images, ops = prep.preprocess(input_image, configs)
 
     assert len(final_images) == 16
     assert final_images[0].shape == (16, 16, 3)
@@ -88,15 +80,12 @@ def test_nested_pipeline_flow(pipeline, input_type):
 )
 def test_nested_tiling_lossless(pipeline, input_shape, tile_configs, expected_count, final_shape):
     prep, recon = pipeline
-    steps = [{"type": "tile", "configuration": {"tile_size": ts, "stride": st}} for ts, st in tile_configs]
+    configs = [steps.tile(tile_size=ts, stride=st) for ts, st in tile_configs]
 
     input_image = np.random.randint(0, 256, input_shape, dtype=np.uint8)
-    final_images, ops = prep.preprocess(input_image, steps)
+    final_images, ops = prep.preprocess(input_image, configs)
 
-    # Ensure the number of tiles is right
     assert len(final_images) == expected_count
-
-    # Ensure the shapes of final images are right
     for img in final_images:
         assert img.shape == final_shape
 
@@ -111,8 +100,6 @@ def test_nested_tiling_lossless(pipeline, input_shape, tile_configs, expected_co
 
 @pytest.mark.parametrize("input_type", ["numpy", "torch"])
 def test_incremental_reconstruction(pipeline, input_type):
-    """Test that reconstruction works correctly at each stage of a multi-step pipeline."""
-
     def check_integrity(original, restored):
         is_list = isinstance(original, list)
         if not is_list:
@@ -142,20 +129,19 @@ def test_incremental_reconstruction(pipeline, input_type):
             np.random.randint(0, 256, (150, 140, 3), dtype=np.uint8),
         ]
 
-    steps = [
-        {"type": "resize", "configuration": {"width": 64, "height": 64}},
-        {"type": "tile", "configuration": {"tile_size": 32, "stride": 32}},
-        {"type": "tile", "configuration": {"tile_size": 16, "stride": 8}},
-        {"type": "tile", "configuration": {"tile_size": 8, "stride": 4}},
+    pipeline_steps = [
+        steps.resize(width=64, height=64),
+        steps.tile(tile_size=32, stride=32),
+        steps.tile(tile_size=16, stride=8),
+        steps.tile(tile_size=8, stride=4),
     ]
 
     intermediate_states = []
-    for i in range(len(steps)):
-        images, ops = prep.preprocess(input_images, steps[: i + 1])
+    for i in range(len(pipeline_steps)):
+        images, ops = prep.preprocess(input_images, pipeline_steps[: i + 1])
         intermediate_states.append((images, ops))
 
-    # verify reconstruction at each stage
-    for i in range(len(intermediate_states) - 1, 0, -1):  # skip resize because lossy
+    for i in range(len(intermediate_states) - 1, 0, -1):
         inputs = intermediate_states[i - 1][0]
         images, ops = intermediate_states[i]
         restored = recon.reconstruct_images(images, ops[-1:])
@@ -166,14 +152,12 @@ def test_tiling_images_with_varying_channels(pipeline):
     prep, recon = pipeline
 
     input_images = [
-        torch.randint(0, 256, (100, 100), dtype=torch.uint8),  # Single channel image
-        torch.randint(0, 256, (120, 130, 1), dtype=torch.uint8),  # Single channel with channel dim
-        torch.randint(0, 256, (80, 90, 3), dtype=torch.uint8),  # Regular 3-channel image
+        torch.randint(0, 256, (100, 100), dtype=torch.uint8),
+        torch.randint(0, 256, (120, 130, 1), dtype=torch.uint8),
+        torch.randint(0, 256, (80, 90, 3), dtype=torch.uint8),
     ]
 
-    steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-
-    final_images, ops = prep.preprocess(input_images, steps)
+    final_images, ops = prep.preprocess(input_images, [steps.tile(tile_size=50, stride=50)])
 
     expected_tile_counts = [4, 9, 4]
     assert len(final_images) == sum(expected_tile_counts)

--- a/tests/lmi_utils/preprocess_utils/test_preprocessor.py
+++ b/tests/lmi_utils/preprocess_utils/test_preprocessor.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 
+from lmi_utils.preprocess_utils import steps
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 
 logger = logging.getLogger()
@@ -18,24 +19,15 @@ logger = logging.getLogger()
 )
 def test_preprocessor_resize(im, wh, par):
     preprocessor = Preprocessor()
-    processing_steps = [
-        {
-            "type": "resize",
-            "configuration": {"width": wh[0], "height": wh[1], "preserve_aspect": par},
-        }
-    ]
-    ims, operators = preprocessor.preprocess(im, processing_steps)
+    ims, _ = preprocessor.preprocess(im, [steps.resize(width=wh[0], height=wh[1], preserve_aspect=par)])
     im_out = ims[0]
-    expected_w = wh[0] if wh[0] is not None else im.shape[1]
-    expected_h = wh[1] if wh[1] is not None else im.shape[0]
-    assert im_out.shape[1] == expected_w
-    assert im_out.shape[0] == expected_h
+    assert im_out.shape[1] == wh[0]
+    assert im_out.shape[0] == wh[1]
     assert isinstance(im_out, type(im))
 
 
 @pytest.mark.parametrize("input_type", ["numpy", "torch"])
 def test_preprocessor_4d_batch_input(input_type):
-    """Test that a 4D BHWC batch is split into individual images before processing."""
     preprocessor = Preprocessor()
     B, H, W, C = 3, 100, 100, 3
     if input_type == "torch":
@@ -43,8 +35,7 @@ def test_preprocessor_4d_batch_input(input_type):
     else:
         batch = np.random.randint(0, 256, (B, H, W, C), dtype=np.uint8)
 
-    steps = [{"type": "resize", "configuration": {"width": 64, "height": 64}}]
-    ims, history = preprocessor.preprocess(batch, steps)
+    ims, _ = preprocessor.preprocess(batch, [steps.resize(width=64, height=64)])
 
     assert len(ims) == B
     for im in ims:

--- a/tests/lmi_utils/preprocess_utils/test_reconstruct_coordinates.py
+++ b/tests/lmi_utils/preprocess_utils/test_reconstruct_coordinates.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 
+from lmi_utils.preprocess_utils import steps
 from lmi_utils.preprocess_utils.preprocessor import Preprocessor
 from lmi_utils.preprocess_utils.reconstructor import Reconstructor
 
@@ -11,20 +12,7 @@ def pipeline():
     return Preprocessor(), Reconstructor()
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-
 def _make_full_results(boxes_list, tile_hw=None):
-    """
-    Build a results dict with all coordinate fields populated.
-
-    - boxes:    (N, 4) [x1, y1, x2, y2]
-    - segments: 4-corner polygon per box, list of (4, 2) tensors — distinct structure
-    - points:   box centroid + visibility=1, (N, 1, 3)             — distinct values
-    - masks:    all-ones (N, H, W) — only included when tile_hw=(H, W) is given
-    """
     segs_list, pts_list, masks_list = [], [], []
     for boxes in boxes_list:
         if len(boxes) == 0:
@@ -36,8 +24,8 @@ def _make_full_results(boxes_list, tile_hw=None):
             segs_list.append([torch.stack([b[[0, 1]], b[[2, 1]], b[[2, 3]], b[[0, 3]]]) for b in boxes])
             cx = (boxes[:, 0] + boxes[:, 2]) / 2
             cy = (boxes[:, 1] + boxes[:, 3]) / 2
-            xy = torch.stack([cx, cy], dim=-1).unsqueeze(1)  # (N, 1, 2)
-            pts_list.append(torch.cat([xy, torch.ones(len(boxes), 1, 1)], dim=-1))  # (N, 1, 3)
+            xy = torch.stack([cx, cy], dim=-1).unsqueeze(1)
+            pts_list.append(torch.cat([xy, torch.ones(len(boxes), 1, 1)], dim=-1))
             if tile_hw is not None:
                 masks_list.append(torch.ones(len(boxes), tile_hw[0], tile_hw[1]))
 
@@ -54,49 +42,36 @@ def _make_full_results(boxes_list, tile_hw=None):
 
 
 def _corners(boxes):
-    """Expected 4-corner polygon list matching _make_full_results segments."""
     return [torch.stack([b[[0, 1]], b[[2, 1]], b[[2, 3]], b[[0, 3]]]) for b in boxes]
 
 
 def _centroids(boxes):
-    """Expected (N, 1, 3) centroid+visibility tensor matching _make_full_results points."""
     cx = (boxes[:, 0] + boxes[:, 2]) / 2
     cy = (boxes[:, 1] + boxes[:, 3]) / 2
-    xy = torch.stack([cx, cy], dim=-1).unsqueeze(1)  # (N, 1, 2)
-    return torch.cat([xy, torch.ones(len(boxes), 1, 1)], dim=-1)  # (N, 1, 3)
+    xy = torch.stack([cx, cy], dim=-1).unsqueeze(1)
+    return torch.cat([xy, torch.ones(len(boxes), 1, 1)], dim=-1)
 
 
 def _assert_mask_quadrant(canvas, det_idx, y_slice, x_slice, h, w):
-    """Assert a single mask is 1.0 inside the given slices and 0.0 everywhere else."""
     ref = torch.zeros(h, w)
     ref[y_slice, x_slice] = 1.0
     assert torch.all(canvas[det_idx] == ref), f"mask[{det_idx}] placement mismatch"
 
 
 def _assert_coords(reverted, image_idx, expected_boxes, atol=1.0):
-    """Assert boxes, segments, and points all match the expected transformation."""
     boxes = reverted["boxes"][image_idx].float()
     assert torch.allclose(boxes, expected_boxes.float(), atol=atol), f"boxes mismatch: {boxes}"
-
     for seg, exp in zip(reverted["segments"][image_idx], _corners(expected_boxes)):
         assert torch.allclose(seg.float(), exp.float(), atol=atol), "segment mismatch"
-
     pts = reverted["points"][image_idx].float()
     assert torch.allclose(pts, _centroids(expected_boxes).float(), atol=atol), "points mismatch"
 
 
-# ---------------------------------------------------------------------------
-# Resize
-# ---------------------------------------------------------------------------
-
-
 class TestResize:
     def test_uniform_scale(self, pipeline):
-        """2x downscale (200→100) should double every coordinate on revert; masks are resized back."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
         boxes = torch.tensor([[10.0, 20.0, 40.0, 45.0]])
         results = _make_full_results([boxes])
@@ -106,27 +81,21 @@ class TestResize:
         assert reverted["masks"][0].shape == (1, 200, 200)
 
     def test_independent_xy_scales(self, pipeline):
-        """x and y axes scale independently; each reverts by its own factor; masks revert to original dims."""
         prep, recon = pipeline
-        # 300(H)×200(W) → 100×100: x_revert=×2, y_revert=×3
         image = np.random.randint(0, 256, (300, 200, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
         boxes = torch.tensor([[10.0, 20.0, 40.0, 60.0]])
         results = _make_full_results([boxes])
         results["masks"] = [torch.ones(1, 100, 100)]
         reverted = recon.reconstruct_coordinates(results, history)
-        # x: ×2 → [20, 80];  y: ×3 → [60, 180]
         _assert_coords(reverted, 0, torch.tensor([[20.0, 60.0, 80.0, 180.0]]))
         assert reverted["masks"][0].shape == (1, 300, 200)
 
     def test_empty_boxes_all_keys_preserved(self, pipeline):
-        """All result keys survive revert even when every coordinate field is an empty tensor."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
         empty = torch.zeros((0, 4))
         results = _make_full_results([empty])
@@ -138,11 +107,9 @@ class TestResize:
         assert len(reverted["points"][0]) == 0
 
     def test_multiple_images_resize(self, pipeline):
-        """Reversion is applied independently per image; each image's masks revert to its own original dims."""
         prep, recon = pipeline
         images = [np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8) for _ in range(2)]
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(images, steps)
+        _, history = prep.preprocess(images, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
         boxes0 = torch.tensor([[10.0, 15.0, 30.0, 35.0]])
         boxes1 = torch.tensor([[20.0, 25.0, 45.0, 40.0]])
@@ -157,39 +124,25 @@ class TestResize:
         assert reverted["masks"][1].shape == (1, 200, 200)
 
     def test_preserve_aspect_resize(self, pipeline):
-        """preserve_aspect=True pads after resize; masks are unpadded then resized back to original dims."""
         prep, recon = pipeline
-        # 200(H)×100(W) → 100×100 preserve_aspect: resize to 50×100, pad 25 left/right
         image = np.random.randint(0, 256, (200, 100, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": True}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=True)])
 
         boxes = torch.tensor([[35.0, 10.0, 75.0, 90.0]])
         results = _make_full_results([boxes])
         results["masks"] = [torch.ones(1, 100, 100)]
         reverted = recon.reconstruct_coordinates(results, history)
 
-        # Undo pad (crop 25 from each side): 100×100 → 100×50
-        # Undo resize (to orig 200H×100W): 100×50 → 200×100
         assert reverted["masks"][0].shape == (1, 200, 100)
         _assert_coords(reverted, 0, torch.tensor([[20.0, 20.0, 100.0, 180.0]]))
 
 
-# ---------------------------------------------------------------------------
-# Tile
-# ---------------------------------------------------------------------------
-
-
 class TestTile:
     def test_shifts_all_fields_by_tile_offset(self, pipeline):
-        """Each tile's boxes, segments, points, and masks are shifted by that tile's offset."""
         prep, recon = pipeline
-        # 100×100, tile=50, stride=50 → 4 non-overlapping tiles, canvas=(100,100)
         image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=50, stride=50)])
 
-        # Row-major order: (0,0)→(x=0,y=0), (0,1)→(50,0), (1,0)→(0,50), (1,1)→(50,50)
         tile_box = torch.tensor([[3.0, 7.0, 15.0, 25.0]])
         results = _make_full_results([tile_box] * 4, tile_hw=(50, 50))
         reverted = recon.reconstruct_coordinates(results, history)
@@ -205,7 +158,7 @@ class TestTile:
         )
         _assert_coords(reverted, 0, expected, atol=1e-3)
 
-        out = reverted["masks"][0]  # (4, 100, 100)
+        out = reverted["masks"][0]
         assert out.shape == (4, 100, 100)
         _assert_mask_quadrant(out, 0, slice(0, 50), slice(0, 50), 100, 100)
         _assert_mask_quadrant(out, 1, slice(0, 50), slice(50, 100), 100, 100)
@@ -213,11 +166,9 @@ class TestTile:
         _assert_mask_quadrant(out, 3, slice(50, 100), slice(50, 100), 100, 100)
 
     def test_empty_detections_per_tile(self, pipeline):
-        """Tiles with no detections produce empty results for every field, and all keys are preserved."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=50, stride=50)])
 
         empty = torch.zeros((0, 4))
         results = _make_full_results([empty] * 4, tile_hw=(50, 50))
@@ -230,33 +181,27 @@ class TestTile:
         assert len(reverted["masks"][0]) == 0
 
     def test_partial_detections_across_tiles(self, pipeline):
-        """Only tiles with detections contribute to the merged output."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=50, stride=50)])
 
         empty = torch.zeros((0, 4))
         det = torch.tensor([[6.0, 9.0, 22.0, 35.0]])
-        # Only tile (row=1, col=1) has a detection → offset (x=50, y=50)
         results = _make_full_results([empty, empty, empty, det], tile_hw=(50, 50))
         reverted = recon.reconstruct_coordinates(results, history)
 
         _assert_coords(reverted, 0, torch.tensor([[56.0, 59.0, 72.0, 85.0]]), atol=1e-3)
 
-        out = reverted["masks"][0]  # (1, 100, 100)
+        out = reverted["masks"][0]
         assert out.shape == (1, 100, 100)
         assert torch.all(out[0, 50:100, 50:100] == 1.0)
         assert torch.all(out[0, :50, :] == 0.0) and torch.all(out[0, 50:, :50] == 0.0)
 
     def test_multiple_images_tile(self, pipeline):
-        """Each original image's tiles are grouped and merged independently."""
         prep, recon = pipeline
         images = [np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8) for _ in range(2)]
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(images, steps)
+        _, history = prep.preprocess(images, [steps.tile(tile_size=50, stride=50)])
 
-        # 8 tiles total (4 per image), each with 1 detection
         tile_box = torch.tensor([[4.0, 11.0, 18.0, 28.0]])
         results = _make_full_results([tile_box] * 8, tile_hw=(50, 50))
         reverted = recon.reconstruct_coordinates(results, history)
@@ -267,36 +212,10 @@ class TestTile:
             assert len(reverted["segments"][i]) == 4
             assert reverted["masks"][i].shape == (4, 100, 100)
 
-    def test_padding_mode_canvas_matches_padded_size(self, pipeline):
-        """When scale_mode='padding' pads the image to fit the tile grid, the mask canvas
-        is the padded scale_size rather than the original image size."""
-        prep, recon = pipeline
-        # 90×90 with tile=50, stride=50: (90-50)%50=40≠0 → scale_size=100 (padded to fit 2×2)
-        # is_interp=False → no coord scaling; canvas=(100,100), not (90,90)
-        image = np.random.randint(0, 256, (90, 90, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(image, steps)
-
-        empty = torch.zeros((0, 4))
-        det = torch.tensor([[3.0, 4.0, 12.0, 14.0]])
-        # Tile (row=1, col=1): offset (x=50, y=50), no scale factor (padding mode)
-        results = _make_full_results([empty, empty, empty, det], tile_hw=(50, 50))
-        reverted = recon.reconstruct_coordinates(results, history)
-
-        _assert_coords(reverted, 0, torch.tensor([[53.0, 54.0, 62.0, 64.0]]), atol=1e-3)
-
-        out = reverted["masks"][0]  # canvas is (100, 100), not (90, 90)
-        assert out.shape == (1, 100, 100)
-        assert torch.all(out[0, 50:100, 50:100] == 1.0)
-        assert torch.all(out[0, :50, :] == 0.0) and torch.all(out[0, 50:, :50] == 0.0)
-
     def test_overlapping_stride_shifts_all_fields(self, pipeline):
-        """stride < tile_size → overlapping tiles; offsets are still col*stride / row*stride."""
         prep, recon = pipeline
-        # 90×90, tile=60, stride=30 → 2×2 grid; offsets (x,y): (0,0),(30,0),(0,30),(30,30)
         image = np.random.randint(0, 256, (90, 90, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 60, "stride": 30}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=60, stride=30)])
 
         tile_box = torch.tensor([[5.0, 8.0, 20.0, 25.0]])
         results = _make_full_results([tile_box] * 4, tile_hw=(60, 60))
@@ -304,54 +223,41 @@ class TestTile:
 
         expected = torch.tensor(
             [
-                [5.0, 8.0, 20.0, 25.0],  # tile (0,0): no offset
-                [35.0, 8.0, 50.0, 25.0],  # tile (0,1): x+30
-                [5.0, 38.0, 20.0, 55.0],  # tile (1,0): y+30
-                [35.0, 38.0, 50.0, 55.0],  # tile (1,1): x+30, y+30
+                [5.0, 8.0, 20.0, 25.0],
+                [35.0, 8.0, 50.0, 25.0],
+                [5.0, 38.0, 20.0, 55.0],
+                [35.0, 38.0, 50.0, 55.0],
             ]
         )
         _assert_coords(reverted, 0, expected, atol=1e-3)
 
-        # Tile (1,1) mask (det index 3) is pasted at (paste_y=30, paste_x=30)
-        out = reverted["masks"][0]  # (4, 90, 90)
+        out = reverted["masks"][0]
         assert out.shape == (4, 90, 90)
         assert torch.all(out[3, 30:90, 30:90] == 1.0)
         assert torch.all(out[3, :30, :] == 0.0) and torch.all(out[3, :, :30] == 0.0)
 
     def test_overlapping_stride_three_column_grid_middle_tile(self, pipeline):
-        """stride=25, tile=50 on a 100x50 (HxW) image → 1x3 grid; middle tile offset is x=25."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (50, 100, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 25}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=50, stride=25)])
 
         empty = torch.zeros((0, 4))
         det = torch.tensor([[2.0, 6.0, 18.0, 30.0]])
-        # Tile index 1 is (row=0, col=1) → offset x=25, y=0
         reverted = recon.reconstruct_coordinates(_make_full_results([empty, det, empty]), history)
 
         _assert_coords(reverted, 0, torch.tensor([[27.0, 6.0, 43.0, 30.0]]), atol=1e-3)
 
 
-# ---------------------------------------------------------------------------
-# Resize + Tile combined
-# ---------------------------------------------------------------------------
-
-
 class TestPipeline:
     def test_resize_then_tile_reverts_both(self, pipeline):
-        """Coordinates pass through tile revert then resize revert in order."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
-        steps = [
-            {"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}},
-            {"type": "tile", "configuration": {"tile_size": 50, "stride": 50}},
+        configs = [
+            steps.resize(width=100, height=100, preserve_aspect=False),
+            steps.tile(tile_size=50, stride=50),
         ]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, configs)
 
-        # Detection in tile (row=1, col=1): box [7, 12, 25, 38]
-        # Revert tile (offset x=50, y=50): [57, 62, 75, 88]
-        # Revert resize (scale=2):          [114, 124, 150, 176]
         empty = torch.zeros((0, 4))
         det = torch.tensor([[7.0, 12.0, 25.0, 38.0]])
         reverted = recon.reconstruct_coordinates(_make_full_results([empty, empty, empty, det]), history)
@@ -359,16 +265,10 @@ class TestPipeline:
         _assert_coords(reverted, 0, torch.tensor([[114.0, 124.0, 150.0, 176.0]]))
 
     def test_tile_internal_interpolation_scales_coordinates(self, pipeline):
-        """scale_mode='interpolation' rescales the image to fit tiles; coordinate revert
-        undoes the scale factor (sx=sy=90/120=0.75 here) after applying the tile offset."""
         prep, recon = pipeline
-        # 90×90 doesn't divide evenly into 60×60 tiles; tiler upscales to 120×120
         image = np.random.randint(0, 256, (90, 90, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 60, "stride": 60, "scale_mode": "interpolation"}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=60, stride=60, scale_mode="interpolation")])
 
-        # Tile (row=1, col=1) offset (x=60, y=60):
-        # [4,8,20,20] + (60,60,60,60) = [64,68,80,80] × 0.75 = [48,51,60,60]
         empty = torch.zeros((0, 4))
         det = torch.tensor([[4.0, 8.0, 20.0, 20.0]])
         reverted = recon.reconstruct_coordinates(_make_full_results([empty, empty, empty, det]), history)
@@ -376,24 +276,13 @@ class TestPipeline:
         _assert_coords(reverted, 0, torch.tensor([[48.0, 51.0, 60.0, 60.0]]), atol=1e-3)
 
 
-# ---------------------------------------------------------------------------
-# OBB — oriented bounding boxes
-# ---------------------------------------------------------------------------
-
-
 class TestOBB:
-    """Oriented bounding boxes have shape (N, 4, 2) and take a separate code path in both
-    the resize and tile revert handlers."""
-
     def test_obb_resize(self, pipeline):
-        """Each OBB's 4 corners are independently reverted via revert_to_origin(box, ops)."""
         prep, recon = pipeline
-        # 200×200 → 100×100: revert doubles every coordinate
         image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
-        obb = torch.tensor([[[10.0, 15.0], [20.0, 10.0], [25.0, 20.0], [15.0, 25.0]]])  # (1, 4, 2)
+        obb = torch.tensor([[[10.0, 15.0], [20.0, 10.0], [25.0, 20.0], [15.0, 25.0]]])
         results = {"boxes": [obb], "scores": [torch.ones(1)], "classes": [np.zeros(1, dtype=np.int32)]}
         reverted = recon.reconstruct_coordinates(results, history)
 
@@ -401,15 +290,12 @@ class TestOBB:
         assert torch.allclose(reverted["boxes"][0].float(), expected, atol=1.0)
 
     def test_obb_tile(self, pipeline):
-        """OBB corners are shifted by the tile offset broadcast over (N, 4, 2)."""
         prep, recon = pipeline
         image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        steps = [{"type": "tile", "configuration": {"tile_size": 50, "stride": 50}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.tile(tile_size=50, stride=50)])
 
-        # Tile (row=1, col=1): offset (x=50, y=50); all corners get +50 on each axis
         empty_obb = torch.zeros((0, 4, 2))
-        obb = torch.tensor([[[3.0, 5.0], [15.0, 3.0], [18.0, 12.0], [6.0, 14.0]]])  # (1, 4, 2)
+        obb = torch.tensor([[[3.0, 5.0], [15.0, 3.0], [18.0, 12.0], [6.0, 14.0]]])
         results = {
             "boxes": [empty_obb, empty_obb, empty_obb, obb],
             "scores": [torch.zeros(0)] * 3 + [torch.ones(1)],
@@ -423,42 +309,26 @@ class TestOBB:
         assert torch.allclose(merged.float(), expected, atol=1e-3)
 
 
-# ---------------------------------------------------------------------------
-# Points variants
-# ---------------------------------------------------------------------------
-
-
 class TestPoints:
     def test_points_shapes_and_visibility(self, pipeline):
-        """(N,K,2) without visibility and (N,K,3) with mixed visibility are both reverted
-        correctly; xy coords are scaled and the visibility channel is left unchanged."""
         prep, recon = pipeline
-        # 200×200 → 100×100: revert doubles every coordinate
         image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 100, "height": 100, "preserve_aspect": False}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=100, height=100, preserve_aspect=False)])
 
         boxes = torch.tensor([[10.0, 20.0, 40.0, 60.0]])
         base = {"boxes": [boxes], "scores": [torch.ones(1)], "classes": [np.zeros(1, dtype=np.int32)], "segments": [[]]}
 
-        # (N=1, K=2, 2) — no visibility channel
         pts_no_vis = torch.tensor([[[15.0, 25.0], [35.0, 55.0]]])
         rev_no_vis = recon.reconstruct_coordinates({**base, "points": [pts_no_vis]}, history)
         assert rev_no_vis["points"][0].shape == (1, 2, 2)
         assert torch.allclose(rev_no_vis["points"][0].float(), torch.tensor([[[30.0, 50.0], [70.0, 110.0]]]), atol=1.0)
 
-        # (N=1, K=3, 3) — three keypoints with mixed visibility; vis column must be unchanged
         pts_vis = torch.tensor([[[15.0, 25.0, 1.0], [30.0, 40.0, 0.0], [45.0, 55.0, 1.0]]])
         rev_vis = recon.reconstruct_coordinates({**base, "points": [pts_vis]}, history)
         assert rev_vis["points"][0].shape == (1, 3, 3)
         assert torch.allclose(
             rev_vis["points"][0].float(), torch.tensor([[[30.0, 50.0, 1.0], [60.0, 80.0, 0.0], [90.0, 110.0, 1.0]]]), atol=1.0
         )
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
 
 
 class TestEdgeCases:
@@ -472,7 +342,6 @@ class TestEdgeCases:
     def test_empty_results_returns_empty(self, pipeline):
         prep, recon = pipeline
         image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        steps = [{"type": "resize", "configuration": {"width": 50, "height": 50}}]
-        _, history = prep.preprocess(image, steps)
+        _, history = prep.preprocess(image, [steps.resize(width=50, height=50)])
         reverted = recon.reconstruct_coordinates({}, history)
         assert reverted == {}

--- a/tests/lmi_utils/preprocess_utils/test_resize.py
+++ b/tests/lmi_utils/preprocess_utils/test_resize.py
@@ -1,0 +1,163 @@
+"""Focused tests for ResizeOperation."""
+
+import numpy as np
+import pytest
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.ops import ResizeMeta
+from lmi_utils.preprocess_utils.ops.resize import ResizeOperation
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+from lmi_utils.preprocess_utils.reconstructor import Reconstructor
+
+
+def _hwc(h, w, c=3):
+    return torch.arange(h * w * c, dtype=torch.float32).reshape(h, w, c)
+
+
+def _empty_results(n=1, **overrides):
+    results = {
+        "boxes": [torch.zeros((0, 4)) for _ in range(n)],
+        "scores": [torch.zeros((0,)) for _ in range(n)],
+        "classes": [np.zeros((0,), dtype=np.int32) for _ in range(n)],
+        "segments": [[] for _ in range(n)],
+        "points": [torch.zeros((0, 1, 3)) for _ in range(n)],
+    }
+    results.update(overrides)
+    return results
+
+
+def test_resize_noop_when_target_matches_input():
+    pre = Preprocessor()
+    img = _hwc(40, 60, 3)
+    out, history = pre.preprocess([img], [steps.resize(width=60, height=40)])
+
+    assert out[0].shape == (40, 60, 3)
+    assert torch.equal(out[0], img)
+    meta = history[0]
+    assert meta.src_sizes[0] == [60, 40]
+    assert meta.dst_sizes[0] == [60, 40]
+    assert meta.pads[0] == [0, 0, 0, 0]
+
+
+def test_resize_defaults_to_current_dim_when_width_or_height_missing():
+    pre = Preprocessor()
+    img = _hwc(40, 60, 3)
+
+    out_w, _ = pre.preprocess([img], [steps.resize(height=20)])
+    assert out_w[0].shape == (20, 60, 3)
+
+    out_h, _ = pre.preprocess([img], [steps.resize(width=30)])
+    assert out_h[0].shape == (40, 30, 3)
+
+
+def test_resize_apply_coordinates_forward_scales_and_pads():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(200, 100, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=100, height=100, preserve_aspect=True)])
+
+    results = _empty_results(boxes=[torch.tensor([[10.0, 20.0, 90.0, 180.0]])])
+    forwarded = rec.apply_coordinates(results, history)
+    assert torch.allclose(forwarded["boxes"][0], torch.tensor([[30.0, 10.0, 70.0, 90.0]]), atol=1e-4)
+
+
+def test_resize_apply_coordinates_masks_preserve_aspect():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(200, 100, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=100, height=100, preserve_aspect=True)])
+
+    masks = torch.ones((1, 200, 100))
+    forwarded = rec.apply_coordinates(_empty_results(masks=[masks]), history)
+
+    out = forwarded["masks"][0]
+    assert out.shape == (1, 100, 100)
+    assert torch.all(out[:, :, :25] == 0)
+    assert torch.all(out[:, :, 75:] == 0)
+    assert torch.all(out[:, :, 25:75] == 1)
+
+
+def test_resize_apply_then_revert_is_identity_on_boxes():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(120, 80, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=40, height=60)])
+
+    src_box = torch.tensor([[8.0, 12.0, 40.0, 90.0]])
+    forwarded = rec.apply_coordinates(_empty_results(boxes=[src_box]), history)
+    reverted = rec.reconstruct_coordinates(forwarded, history)
+    assert torch.allclose(reverted["boxes"][0], src_box, atol=1e-4)
+
+
+def test_resize_obb_boxes_round_trip():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(200, 100, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=50, height=100)])
+
+    obb_orig = torch.tensor([[[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]]])
+    forward = rec.apply_coordinates(_empty_results(boxes=[obb_orig]), history)
+    expected = torch.tensor([[[5.0, 10.0], [15.0, 10.0], [15.0, 20.0], [5.0, 20.0]]])
+    assert forward["boxes"][0].shape == (1, 4, 2)
+    assert torch.allclose(forward["boxes"][0], expected, atol=1e-4)
+
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], obb_orig, atol=1e-4)
+
+
+def test_resize_segments_variable_length():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(200, 100, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=50, height=100)])
+
+    seg_short = torch.tensor([[5.0, 10.0]])
+    seg_long = torch.tensor([[2.5, 5.0], [12.5, 25.0], [40.0, 90.0]])
+    results = _empty_results(segments=[[seg_short, seg_long]])
+    reverted = rec.reconstruct_coordinates(results, history)
+    out_segs = reverted["segments"][0]
+    assert torch.allclose(out_segs[0], torch.tensor([[10.0, 20.0]]), atol=1e-4)
+    assert torch.allclose(out_segs[1], torch.tensor([[5.0, 10.0], [25.0, 50.0], [80.0, 180.0]]), atol=1e-4)
+
+
+def test_resize_preserve_aspect_pads_top_bottom_for_wide_image():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(60, 200, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=100, height=100, preserve_aspect=True)])
+
+    meta = history[0]
+    assert meta.src_sizes[0] == [200, 60]
+    assert meta.dst_sizes[0] == [100, 30]
+    pL, pR, pT, pB = meta.pads[0]
+    assert pL == 0 and pR == 0
+    assert pT + pB == 70
+
+    box_orig = torch.tensor([[40.0, 20.0, 80.0, 40.0]])
+    forward = rec.apply_coordinates(_empty_results(boxes=[box_orig]), history)
+    expected = torch.tensor([[20.0, 10.0 + pT, 40.0, 20.0 + pT]])
+    assert torch.allclose(forward["boxes"][0], expected, atol=1e-4)
+
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], box_orig, atol=1e-4)
+
+
+def test_resize_preserve_aspect_no_pad_when_aspect_matches():
+    pre, rec = Preprocessor(), Reconstructor()
+    img = _hwc(100, 200, 3)
+    _out, history = pre.preprocess([img], [steps.resize(width=100, height=50, preserve_aspect=True)])
+
+    meta = history[0]
+    assert meta.src_sizes[0] == [200, 100]
+    assert meta.dst_sizes[0] == [100, 50]
+    assert meta.pads[0] == [0, 0, 0, 0]
+
+    box_orig = torch.tensor([[10.0, 20.0, 80.0, 40.0]])
+    forward = rec.apply_coordinates(_empty_results(boxes=[box_orig]), history)
+    assert torch.allclose(forward["boxes"][0], torch.tensor([[5.0, 10.0, 40.0, 20.0]]), atol=1e-4)
+
+    round_trip = rec.reconstruct_coordinates(forward, history)
+    assert torch.allclose(round_trip["boxes"][0], box_orig, atol=1e-4)
+
+
+def test_resize_revert_images_length_mismatch_raises():
+    op = ResizeOperation()
+    img = _hwc(10, 10, 3)
+    meta = ResizeMeta(src_sizes=[[10, 10], [10, 10]], dst_sizes=[[10, 10], [10, 10]], pads=[[0, 0, 0, 0], [0, 0, 0, 0]])
+    with pytest.raises(ValueError, match=r"resize: input length \(1\) != metadata length \(2\)"):
+        op.revert_images([img], meta)

--- a/tests/lmi_utils/preprocess_utils/test_steps.py
+++ b/tests/lmi_utils/preprocess_utils/test_steps.py
@@ -1,0 +1,131 @@
+"""Tests for the typed steps namespace.
+
+Verifies that each forward alias constructs the matching Config dataclass with
+the expected field values, and that the resulting Configs pass through
+Preprocessor.preprocess.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from lmi_utils.preprocess_utils import steps
+from lmi_utils.preprocess_utils.ops import (
+    CropConfig,
+    FlipConfig,
+    PadConfig,
+    ResizeConfig,
+    TileConfig,
+)
+from lmi_utils.preprocess_utils.preprocessor import Preprocessor
+
+
+def test_resize_full_kwargs():
+    cfg = steps.resize(width=640, height=480, preserve_aspect=True, mode="bilinear")
+    assert isinstance(cfg, ResizeConfig)
+    assert cfg.width == 640 and cfg.height == 480
+    assert cfg.preserve_aspect is True and cfg.mode == "bilinear"
+
+
+def test_resize_partial_kwargs_defaults():
+    cfg = steps.resize(width=640)
+    assert cfg.width == 640
+    assert cfg.height is None
+    assert cfg.preserve_aspect is False
+    assert cfg.mode == "bilinear"
+
+
+def test_resize_with_id():
+    assert steps.resize(width=128, height=128, id="r1").id == "r1"
+
+
+def test_crop():
+    cfg = steps.crop(boxes=[[1, 2, 3, 4]])
+    assert isinstance(cfg, CropConfig)
+    assert cfg.boxes == [[1, 2, 3, 4]]
+
+
+def test_crop_with_id():
+    assert steps.crop(boxes=[[0, 0, 10, 10]], id="c1").id == "c1"
+
+
+def test_flip_defaults():
+    cfg = steps.flip()
+    assert isinstance(cfg, FlipConfig)
+    assert cfg.lr is False and cfg.ud is False
+
+
+def test_flip_lr_ud():
+    cfg = steps.flip(lr=True, ud=True)
+    assert cfg.lr is True and cfg.ud is True
+
+
+def test_pad_with_wh():
+    cfg = steps.pad(width=512, height=512)
+    assert isinstance(cfg, PadConfig)
+    assert cfg.width == 512 and cfg.height == 512 and cfg.pad is None and cfg.value == 0
+
+
+def test_pad_with_explicit_pad():
+    cfg = steps.pad(pad=[5, 5, 3, 3], value=128)
+    assert cfg.pad == [5, 5, 3, 3]
+    assert cfg.value == 128
+
+
+def test_tile():
+    cfg = steps.tile(tile_size=[256, 256], stride=[128, 128])
+    assert isinstance(cfg, TileConfig)
+    assert cfg.tile_size == [256, 256]
+    assert cfg.stride == [128, 128]
+    assert cfg.scale_mode == "padding"
+    assert cfg.overlap_mode == "average"
+
+
+def test_tile_with_modes():
+    cfg = steps.tile(tile_size=64, stride=32, scale_mode="interpolation", overlap_mode="average", id="t")
+    assert cfg.scale_mode == "interpolation" and cfg.id == "t"
+
+
+def test_id_defaults_to_none():
+    assert steps.resize(width=64, height=64).id is None
+    assert steps.crop(boxes=[[0, 0, 1, 1]]).id is None
+    assert steps.flip().id is None
+
+
+def test_config_runs_through_preprocessor():
+    img = torch.rand(100, 80, 3)
+    pipeline = [
+        steps.resize(width=64, height=64, preserve_aspect=True),
+        steps.flip(lr=True),
+    ]
+    imgs, history = Preprocessor().preprocess(img, pipeline)
+    assert len(imgs) == 1
+    assert imgs[0].shape[:2] == (64, 64)
+    assert len(history) == 2
+
+
+def test_invalid_crop_config_raises():
+    with pytest.raises(ValueError, match="non-empty list"):
+        steps.crop(boxes=[])
+
+
+def test_invalid_pad_length_raises():
+    with pytest.raises(ValueError, match=r"\[L, R, T, B\]"):
+        steps.pad(pad=[1, 2, 3])
+
+
+def test_parse_steps_dict_to_config():
+    """JSON manifests are bridged through parse_steps."""
+    from lmi_utils.preprocess_utils import parse_steps
+
+    manifest = [
+        {"type": "resize", "configuration": {"width": 224, "height": 224, "preserve_aspect": True}},
+    ]
+    configs = parse_steps(manifest)
+    assert isinstance(configs[0], ResizeConfig)
+    assert configs[0].width == 224
+
+    img = np.random.rand(80, 60, 3).astype(np.float32)
+    a_imgs, _ = Preprocessor().preprocess(img, configs)
+    b_imgs, _ = Preprocessor().preprocess(img, [steps.resize(width=224, height=224, preserve_aspect=True)])
+    assert np.allclose(a_imgs[0], b_imgs[0])

--- a/tests/object_detectors/detectron2_lmi/test_model.py
+++ b/tests/object_detectors/detectron2_lmi/test_model.py
@@ -176,13 +176,11 @@ def test_compare_with_original_model_nonsquare(og_cpu_model, model_cpu, imgs_coc
 def test_operators(model, imgs_coco, caplog):
     image = imgs_coco[0]
     h, w = image.shape[:2]
-    rh, rw = 512, 480
-    logger.info(f"Original image size: {(h, w)}, resizing to {(rh, rw)} for testing operators. model.image_size={model.image_size}")
-    assert (rh, rw) != tuple(model.image_size)
-    image_resized = cv2.resize(image, (rw, rh))
-    operators = [{"resize": [rw, rh, w, h]}]
-    with caplog.at_level(logging.WARNING):
-        outputs, _ = model.predict(image_resized, configs=0.9, return_segments=False, operators=operators)
+    image_resized = cv2.resize(image, (512, 512))
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+    operators = [ResizeMeta(src_sizes=[[w, h]], dst_sizes=[[512, 512]], pads=[[0, 0, 0, 0]])]
+    outputs, _ = model.predict(image_resized, configs=0.9, return_segments=False, operators=operators)
     outputs = {k: v[0] for k, v in outputs.items()}
 
     assert not [r for r in caplog.records if "model input" in r.message], "PT backend is size-flexible; no resize guard expected"
@@ -208,7 +206,9 @@ def test_operators_no_masks(model, imgs_coco):
     image = imgs_coco[0]
     h, w = image.shape[:2]
     image_resized = cv2.resize(image, (512, 512))
-    operators = [{"resize": [512, 512, w, h]}]
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+    operators = [ResizeMeta(src_sizes=[[w, h]], dst_sizes=[[512, 512]], pads=[[0, 0, 0, 0]])]
     outputs, _ = model.predict(image_resized, configs=1, operators=operators)
     outputs = {k: v[0] for k, v in outputs.items()}
 
@@ -216,12 +216,21 @@ def test_operators_no_masks(model, imgs_coco):
 
 
 def test_batch_operators(model, imgs_coco):
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
     images = imgs_coco
     original_sizes = [img.shape[:2] for img in images]
     off_sizes = [(512, 640), (576, 704), (704, 512)]  # (h, w), non-square
     resized_dims = [off_sizes[i % len(off_sizes)] for i in range(len(images))]
     images_resized = [cv2.resize(img, (rw, rh)) for img, (rh, rw) in zip(images, resized_dims)]
-    operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+    # Per-image metadata: one resize entry, batch length == batch size.
+    operators = [
+        ResizeMeta(
+            src_sizes=[[w, h] for h, w in original_sizes],
+            dst_sizes=[[rw, rh] for (rh, rw) in resized_dims],
+            pads=[[0, 0, 0, 0] for _ in original_sizes],
+        )
+    ]
     outputs, _ = model.predict(images_resized, configs=0.8, operators=operators)
     _assert_batch_counts(outputs, KEYS, len(images))
     os.makedirs(OUT_DIR, exist_ok=True)

--- a/tests/object_detectors/detectron2_lmi/test_trt.py
+++ b/tests/object_detectors/detectron2_lmi/test_trt.py
@@ -85,11 +85,16 @@ def test_batch_operators(trt_model, imgs_coco):
 
     images = imgs_coco
     original_sizes = [img.shape[:2] for img in images]
-    # Per-image varied off-sizes (!= engine input) exercise the stretch guard across the batch.
-    resized_dims = [(th + dh, tw + dw) for dh, dw in (SIZE_OFFSETS[i % len(SIZE_OFFSETS)] for i in range(len(images)))]
-    assert all((rh, rw) != (th, tw) for rh, rw in resized_dims)
-    resized = [cv2.resize(img, (rw, rh)) for img, (rh, rw) in zip(images, resized_dims)]
-    operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+    resized = [cv2.resize(img, (tw, th)) for img in images]
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+    operators = [
+        ResizeMeta(
+            src_sizes=[[w, h] for h, w in original_sizes],
+            dst_sizes=[[tw, th] for _ in original_sizes],
+            pads=[[0, 0, 0, 0] for _ in original_sizes],
+        )
+    ]
 
     outputs, _ = model.predict(resized, configs=confs, operators=operators)
     _assert_batch_counts(outputs, KEYS, len(images))
@@ -111,11 +116,19 @@ def test_batch_operators_cuda(trt_model, imgs_coco):
 
     images = imgs_coco
     original_sizes = [img.shape[:2] for img in images]
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
     # Per-image varied off-sizes (!= engine input) passed as CUDA tensors: the guard stretches each
     # on-device to the engine size while the resize operator reverts boxes/masks to the original frame.
     resized_dims = [(th + dh, tw + dw) for dh, dw in (SIZE_OFFSETS[i % len(SIZE_OFFSETS)] for i in range(len(images)))]
     resized = [torch.from_numpy(cv2.resize(img, (rw, rh))).cuda() for img, (rh, rw) in zip(images, resized_dims)]
-    operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+    operators = [
+        ResizeMeta(
+            src_sizes=[[w, h] for h, w in original_sizes],
+            dst_sizes=[[rw, rh] for (rh, rw) in resized_dims],
+            pads=[[0, 0, 0, 0] for _ in original_sizes],
+        )
+    ]
 
     outputs, _ = model.predict(resized, configs=confs, operators=operators)
     _assert_batch_counts(outputs, KEYS, len(images))

--- a/tests/object_detectors/od_core/test_normalize_operators.py
+++ b/tests/object_detectors/od_core/test_normalize_operators.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lmi_utils.preprocess_utils.ops import CropMeta, ResizeMeta
 from object_detectors.od_core.od_base import ODBase
 
 
@@ -7,35 +8,55 @@ def test_none_operators_returns_empty_per_image():
     assert ODBase._normalize_operators(None, 3) == [[], [], []]
 
 
-def test_single_chain_broadcasts_to_batch():
-    chain = [{"resize": [640, 640, 1280, 720]}, {"pad": [0, 0, 80, 80]}]
-    result = ODBase._normalize_operators(chain, 2)
-    assert result == [chain, chain]
+def test_broadcast_metadata_length_one():
+    """Length-1 Meta broadcasts to every image in the batch."""
+    history = [ResizeMeta(src_sizes=[[1280, 720]], dst_sizes=[[640, 640]], pads=[[0, 0, 0, 0]])]
+    result = ODBase._normalize_operators(history, 2)
+    assert len(result) == 2
+    for chain in result:
+        m = chain[0]
+        assert isinstance(m, ResizeMeta)
+        assert m.src_sizes == [[1280, 720]]
+        assert m.dst_sizes == [[640, 640]]
 
 
-def test_per_image_chains_passthrough():
-    chains = [[{"resize": [640, 640, 1280, 720]}], [{"pad": [0, 0, 80, 80]}]]
-    assert ODBase._normalize_operators(chains, 2) == chains
-
-
-def test_length_mismatch_raises():
-    chains = [[{"resize": [640, 640, 1280, 720]}]]
-    with pytest.raises(ValueError, match="must match batch size"):
-        ODBase._normalize_operators(chains, 2)
-
-
-def test_preprocessor_history_flat_chain_rejected():
+def test_per_image_metadata_sliced():
+    """Length-B Meta yields each image's own slice."""
     history = [
-        {"type": "resize", "metadata": [{"orig_size": [1280, 720], "new_size": [640, 640]}]},
+        ResizeMeta(
+            src_sizes=[[1280, 720], [1024, 768]],
+            dst_sizes=[[640, 640], [640, 640]],
+            pads=[[0, 0, 0, 0], [0, 0, 0, 0]],
+        )
     ]
-    with pytest.raises(ValueError, match="Preprocessor history"):
+    result = ODBase._normalize_operators(history, 2)
+    assert result[0][0].src_sizes == [[1280, 720]]
+    assert result[1][0].src_sizes == [[1024, 768]]
+
+
+def test_id_preserved_through_slice():
+    # CropMeta has no id field — runtime ids live on Configs, not Metas — but the slicing
+    # preserves all scalar attributes regardless.
+    history = [CropMeta(boxes=[[0, 0, 10, 10]], orig_sizes=[[100, 100]])]
+    result = ODBase._normalize_operators(history, 1)
+    assert isinstance(result[0][0], CropMeta)
+    assert result[0][0].boxes == [[0, 0, 10, 10]]
+
+
+def test_metadata_length_mismatch_raises():
+    history = [
+        ResizeMeta(
+            src_sizes=[[1280, 720]] * 3,
+            dst_sizes=[[640, 640]] * 3,
+            pads=[[0, 0, 0, 0]] * 3,
+        )
+    ]
+    with pytest.raises(ValueError, match="not 1 .*or 2 "):
         ODBase._normalize_operators(history, 2)
 
 
-def test_preprocessor_history_per_image_rejected():
-    history_per_image = [
-        [{"type": "resize", "metadata": [{"orig_size": [1280, 720], "new_size": [640, 640]}]}],
-        [{"type": "tile", "metadata": [{"grid": [2, 2]}]}],
-    ]
-    with pytest.raises(ValueError, match="Preprocessor history"):
-        ODBase._normalize_operators(history_per_image, 2)
+def test_legacy_dict_shape_rejected():
+    """Dict-based history is no longer accepted; must be typed Meta."""
+    legacy = [{"type": "resize", "metadata": [{}]}]
+    with pytest.raises(ValueError, match="typed Meta records"):
+        ODBase._normalize_operators(legacy, 2)

--- a/tests/object_detectors/rf_detr_lmi/test_model.py
+++ b/tests/object_detectors/rf_detr_lmi/test_model.py
@@ -251,7 +251,7 @@ class Test_Rfdetr_Model:
 
         os.makedirs(OUT_DIR, exist_ok=True)
         for idx, img in enumerate(imgs_coco):
-            h, w = original_sizes[idx]
+            w, h = original_sizes[idx]
             out = {k: v[idx] for k, v in batch_outputs.items()}
             _assert_nonempty_out(out)
             _assert_scores_geq(out, 0.5)

--- a/tests/object_detectors/rf_detr_lmi/test_model.py
+++ b/tests/object_detectors/rf_detr_lmi/test_model.py
@@ -211,7 +211,9 @@ class Test_Rfdetr_Model:
         for idx, img in enumerate(imgs_coco):
             h, w = img.shape[:2]
             img_resized = cv2.resize(img, (IMAGE_SIZE, IMAGE_SIZE))
-            operators = [{"resize": [IMAGE_SIZE, IMAGE_SIZE, w, h]}]
+            from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+            operators = [ResizeMeta(src_sizes=[[w, h]], dst_sizes=[[IMAGE_SIZE, IMAGE_SIZE]], pads=[[0, 0, 0, 0]])]
 
             batch_outputs, _ = obj_detector.predict(img_resized, configs=0.5, operators=operators, return_segments=False)
             out = {k: v[0] for k, v in batch_outputs.items()}
@@ -231,12 +233,17 @@ class Test_Rfdetr_Model:
             cv2.imwrite(os.path.join(OUT_DIR, out_name), cv2.cvtColor(annotated_image, cv2.COLOR_RGB2BGR))
 
     def test_operators_batch(self, imgs_coco, obj_detector):
-        # Per-image non-square input sizes exercise the auto-resize (stretch) guard together
-        # with per-image operators that revert boxes/masks back to each original frame.
-        original_sizes = [img.shape[:2] for img in imgs_coco]  # (h, w)
-        resized_dims = [OFF_SIZES[i % len(OFF_SIZES)] for i in range(len(imgs_coco))]
-        imgs_resized = [cv2.resize(img, (rw, rh)) for img, (rh, rw) in zip(imgs_coco, resized_dims)]
-        operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+        original_sizes = [(img.shape[1], img.shape[0]) for img in imgs_coco]  # (w, h)
+        from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+        operators = [
+            ResizeMeta(
+                src_sizes=[[w, h] for w, h in original_sizes],
+                dst_sizes=[[IMAGE_SIZE, IMAGE_SIZE] for _ in original_sizes],
+                pads=[[0, 0, 0, 0] for _ in original_sizes],
+            )
+        ]
+        imgs_resized = [cv2.resize(img, (IMAGE_SIZE, IMAGE_SIZE)) for img in imgs_coco]
 
         batch_outputs, _ = obj_detector.predict(imgs_resized, configs=0.5, operators=operators)
 

--- a/tests/object_detectors/rf_detr_lmi/test_trt.py
+++ b/tests/object_detectors/rf_detr_lmi/test_trt.py
@@ -75,12 +75,20 @@ def test_trt_warmup(trt_model):
 
 
 def test_operators_batch(imgs_coco, trt_model):
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
     # Non-square inputs (!= engine input) exercise the antialiased stretch guard together with
     # per-image operators that revert boxes/masks back to each original frame.
     original_sizes = [img.shape[:2] for img in imgs_coco]  # (h, w)
     resized_dims = [OFF_SIZES[i % len(OFF_SIZES)] for i in range(len(imgs_coco))]
     imgs_resized = [cv2.resize(img, (rw, rh)) for img, (rh, rw) in zip(imgs_coco, resized_dims)]
-    operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+    operators = [
+        ResizeMeta(
+            src_sizes=[[w, h] for (h, w) in original_sizes],
+            dst_sizes=[[rw, rh] for (rh, rw) in resized_dims],
+            pads=[[0, 0, 0, 0] for _ in original_sizes],
+        )
+    ]
 
     batch_outputs, _ = trt_model.predict(imgs_resized, configs=0.5, operators=operators)
     assert len(batch_outputs["boxes"]) == len(imgs_coco)
@@ -109,12 +117,20 @@ def test_empty(trt_model):
 
 
 def test_operators_batch_cuda(imgs_coco, trt_model):
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
     # Non-square CUDA-tensor inputs (!= engine input) exercise the on-device antialiased stretch
     # guard together with per-image operators that revert boxes/masks back to each original frame.
     original_sizes = [img.shape[:2] for img in imgs_coco]  # (h, w)
     resized_dims = [OFF_SIZES[i % len(OFF_SIZES)] for i in range(len(imgs_coco))]
     imgs_resized = [torch.from_numpy(cv2.resize(img, (rw, rh))).cuda() for img, (rh, rw) in zip(imgs_coco, resized_dims)]
-    operators = [[{"resize": [rw, rh, w, h]}] for (rh, rw), (h, w) in zip(resized_dims, original_sizes)]
+    operators = [
+        ResizeMeta(
+            src_sizes=[[w, h] for (h, w) in original_sizes],
+            dst_sizes=[[rw, rh] for (rh, rw) in resized_dims],
+            pads=[[0, 0, 0, 0] for _ in original_sizes],
+        )
+    ]
 
     batch_outputs, _ = trt_model.predict(imgs_resized, configs=0.5, operators=operators)
     assert len(batch_outputs["boxes"]) == len(imgs_coco)

--- a/tests/object_detectors/ultralytics_lmi/yolo/test_model_yolo.py
+++ b/tests/object_detectors/ultralytics_lmi/yolo/test_model_yolo.py
@@ -132,9 +132,17 @@ def imgs_dota8():
 
 
 def _load_images(directory, im_dim):
-    """Load and resize images from a directory, returning (images, resized, ops)."""
+    """Load and resize images from a directory.
+
+    Returns:
+        (images, resized, ops) where ``ops`` is a unified preprocessing history with
+        per-image metadata (one ``resize`` entry whose metadata has length == batch).
+    """
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
     paths = [os.path.join(directory, img) for img in os.listdir(directory)]
-    images, resized_images, ops = [], [], []
+    images, resized_images = [], []
+    src_sizes, dst_sizes, pads = [], [], []
     for p in paths:
         if "png" not in p and "jpg" not in p:
             continue
@@ -142,19 +150,49 @@ def _load_images(directory, im_dim):
         h, w = rgb.shape[:2]
         resized_images.append(cv2.resize(rgb, (im_dim, im_dim)))
         images.append(rgb)
-        ops.append([{"resize": (im_dim, im_dim, w, h)}])
+        src_sizes.append([w, h])
+        dst_sizes.append([im_dim, im_dim])
+        pads.append([0, 0, 0, 0])
+    ops = [ResizeMeta(src_sizes=src_sizes, dst_sizes=dst_sizes, pads=pads)]
     return images, resized_images, ops
 
 
 def _nonsquare_batch(images):
-    """Resize each image to a cycling non-square size and build matching per-image operators."""
-    resized, ops = [], []
+    """Resize each image to a cycling non-square size and build a matching unified history.
+
+    Returns ``(resized, ops)`` where ``ops`` is a single-entry ``[ResizeMeta(...)]`` whose
+    per-image metadata lists have length == batch (same shape as ``_load_images``).
+    """
+    from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+    resized, src_sizes, dst_sizes, pads = [], [], [], []
     for i, img in enumerate(images):
         h, w = img.shape[:2]
         rh, rw = OFF_SIZES[i % len(OFF_SIZES)]
         resized.append(cv2.resize(img, (rw, rh)))
-        ops.append([{"resize": (rw, rh, w, h)}])
+        src_sizes.append([w, h])
+        dst_sizes.append([rw, rh])
+        pads.append([0, 0, 0, 0])
+    ops = [ResizeMeta(src_sizes=src_sizes, dst_sizes=dst_sizes, pads=pads)]
     return resized, ops
+
+
+def _shared_ops(per_image_history):
+    """Take a per-image history and produce a single-image (broadcast) variant.
+
+    Used to exercise the "single chain applied to all images" code path: each
+    history entry's per-image fields are collapsed to their first element.
+    """
+    from dataclasses import fields
+
+    out = []
+    for entry in per_image_history:
+        fresh = type(entry).__new__(type(entry))
+        for f in fields(entry):
+            v = getattr(entry, f.name)
+            object.__setattr__(fresh, f.name, v[:1] if isinstance(v, list) else v)
+        out.append(fresh)
+    return out
 
 
 def _assert_empty_output(out, keys, batch_size=1):
@@ -250,8 +288,8 @@ class Test_Yolo_Det:
             # per-image operators
             model.predict(resized_images, configs=0.5, operators=ops_list)
 
-            # shared operators (list[dict] applied to all images)
-            model.predict(resized_images, configs=0.5, operators=ops_list[0])
+            # shared operators (single chain broadcast to all images)
+            model.predict(resized_images, configs=0.5, operators=_shared_ops(ops_list))
 
             # no operators
             model.predict(resized_images, configs=0.5)
@@ -273,13 +311,17 @@ class Test_Yolo_Det:
             _assert_batch_output(out, self.KEYS, num_imgs)
 
     def test_predict_batch_invalid_operators(self, yolo_models, imgs_coco):
-        _, resized_images, ops_list = imgs_coco
+        _, resized_images, _ops_list = imgs_coco
         if len(resized_images) < 2:
             pytest.skip("Not enough images for batch test")
         model = yolo_models["det"][0]
-        # operators length (1) doesn't match batch size (N > 1)
-        with pytest.raises(ValueError):
-            model.predict(resized_images, configs=0.5, operators=[ops_list[0]])
+        # Per-image metadata length doesn't match batch size (and != 1, so no broadcast).
+        from lmi_utils.preprocess_utils.ops import ResizeMeta
+
+        # 7 entries — not 1 (broadcast) and not batch size, so should raise.
+        bad = [ResizeMeta(src_sizes=[[10, 10]] * 7, dst_sizes=[[640, 640]] * 7, pads=[[0, 0, 0, 0]] * 7)]
+        with pytest.raises(ValueError, match="not 1"):
+            model.predict(resized_images, configs=0.5, operators=bad)
 
     def test_insize_input_no_warning(self, imgs_coco, caplog):
         """An in-size input (== image_size) is passed through with no resize warning."""
@@ -336,8 +378,8 @@ class Test_Yolo_Seg:
             for img_idx in range(num_images):
                 assert len(out["segments"][img_idx]) == 0
 
-            # shared operators
-            model.predict(resized_images, configs=0.5, operators=batch_ops[0])
+            # shared operators (single chain broadcast to all images)
+            model.predict(resized_images, configs=0.5, operators=_shared_ops(batch_ops))
 
             # no operators
             model.predict(resized_images, configs=0.5)
@@ -396,8 +438,8 @@ class Test_Yolo_Obb:
             # per-image operators
             out, _ = model.predict(resized_images, configs=0.5, operators=ops_list)
 
-            # shared operators
-            out2, _ = model.predict(resized_images, configs=0.5, operators=ops_list[0])
+            # shared operators (single chain broadcast to all images)
+            model.predict(resized_images, configs=0.5, operators=_shared_ops(ops_list))
 
             # no operators
             out3, _ = model.predict(resized_images, configs=0.5)
@@ -455,8 +497,8 @@ class Test_Yolo_Pose:
             # per-image operators
             out, _ = model.predict(resized_images, configs=0.5, operators=ops_list)
 
-            # shared operators
-            out2, _ = model.predict(resized_images, configs=0.5, operators=ops_list[0])
+            # shared operators (single chain broadcast to all images)
+            model.predict(resized_images, configs=0.5, operators=_shared_ops(ops_list))
 
             # no operators
             out3, _ = model.predict(resized_images, configs=0.5)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
### Replace the dict-based op interface with a typed contract.

Previously, preprocessing ops were passed around as dicts. Now, call builder functions instead of hand-writing dicts.

### Scope of this change:

1. Migrated resize, crop, flip, and pad to the new typed ops.
2. revert_to_origin/revert_mask_to_origin/revert_masks_to_origin now takes a builder function to reverse an op. 
3. crop-to-label is ignored — pipeline users must handle it manually.

<!-- One sentence describing what this PR does and why. -->

**Type:** <!-- feat | fix | chore | refactor | test | docs | ci --> refactor!

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
