### PR TITLE
fix: add padding value for default resize

### DIFF
--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -211,6 +211,8 @@ model = ObjectDetector(
 
 Supported step types: `resize`, `tile`. Steps can be chained and nested (e.g. resize → tile → tile).
 
+When an OD model's preprocessed input still doesn't match its training size, the pipeline auto-injects a final resize. A letterbox injection pads with the model's `RESIZE_PAD_VALUE` (`114` for YOLO, `0` otherwise) to match training-time padding. A manifest-declared `resize` step pads with `0` unless its configuration sets `pad_value`.
+
 **Resize with Object Detection**
 
 OD model role from gofactory:
@@ -321,7 +323,7 @@ When you need to apply preprocessing **beyond what the model manifest declares**
 
 | Step builder | Required kwargs | Notes |
 |---|---|---|
-| `steps.resize(width=..., height=..., preserve_aspect=False, mode="bilinear")` | — | Each dim defaults to the source image's matching dim |
+| `steps.resize(width=..., height=..., preserve_aspect=False, pad_value=0, mode="bilinear")` | — | Each dim defaults to the source image's matching dim. `pad_value` is the letterbox fill, only used when `preserve_aspect=True` (e.g. `114` to match YOLO) |
 | `steps.crop(boxes=...)` | `boxes` | One `[x1, y1, x2, y2]` per image |
 | `steps.flip(lr=False, ud=False)` | — | Defaults to a no-op |
 | `steps.pad(width=None, height=None, pad=None, value=0)` | one of `width/height` or `pad` | `pad=[L, R, T, B]` for explicit padding |

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -248,7 +248,7 @@ class PipelineBase(metaclass=ABCMeta):
         """Append a resize so an OD model's preprocessed input matches its training size.
 
         No-op for non-OD models and when the size already matches.
-        Letterbox backends pad with 0, not their native fill — configure an explicit resize for exact fidelity.
+        Letterbox padding uses the model's RESIZE_PAD_VALUE.
         """
         model = self.models.get(model_role)
         if not isinstance(model, ODBase):
@@ -278,7 +278,7 @@ class PipelineBase(metaclass=ABCMeta):
             f"[{model_role}] preprocessed size {(h, w)} != model input {(th, tw)}; injecting a resize. "
             "Configure a matching resize step in global preprocessing to remove this."
         )
-        resize_step = [steps.resize(width=tw, height=th, preserve_aspect=preserve)]
+        resize_step = [steps.resize(width=tw, height=th, preserve_aspect=preserve, pad_value=model.RESIZE_PAD_VALUE)]
         processed, extra = self.preprocessor.preprocess(processed, resize_step)
         return processed, history + extra
 

--- a/lmi_utils/preprocess_utils/ops/resize.py
+++ b/lmi_utils/preprocess_utils/ops/resize.py
@@ -16,12 +16,14 @@ class ResizeConfig(Config):
     width: target width. Defaults to current width.
     height: target height. Defaults to current height.
     preserve_aspect: scale-to-fit preserving aspect ratio then pad (letterbox).
+    pad_value: fill value for letterbox padding (only used when preserve_aspect). 0 is black; use 114 to match YOLO.
     mode: interpolation mode passed to ``resize_image``.
     """
 
     width: Optional[int] = None
     height: Optional[int] = None
     preserve_aspect: bool = False
+    pad_value: int = 0
     mode: str = "bilinear"
 
 
@@ -81,7 +83,7 @@ class ResizeOperation(Operation[ResizeConfig, ResizeMeta]):
                 src_sizes.append([w0, h0])
                 dst_sizes.append([w1, h1])
                 if w1 != tw or h1 != th:
-                    padded, pL, pR, pT, pB = fit_im_to_size(scaled, W=tw, H=th)
+                    padded, pL, pR, pT, pB = fit_im_to_size(scaled, W=tw, H=th, value=config.pad_value)
                     pads.append([pL, pR, pT, pB])
                     out_images.append(padded)
                 else:

--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -27,6 +27,9 @@ class ODBase(abc.ABC):
     # True = letterbox, False = stretch. Required on concrete subclasses (see __init_subclass__).
     RESIZE_PRESERVE_ASPECT: bool = None
 
+    # Letterbox pad fill for auto-injected resize; match training (e.g. 114 for YOLO). Ignored when stretching.
+    RESIZE_PAD_VALUE: int = 0
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         # Skip abstract intermediates; their concrete leaves inherit the value.

--- a/object_detectors/ultralytics_lmi/yolo/model.py
+++ b/object_detectors/ultralytics_lmi/yolo/model.py
@@ -51,6 +51,7 @@ class Yolo(YoloCore, ODBase):
     logger = logging.getLogger("yolo")
 
     RESIZE_PRESERVE_ASPECT = True  # letterbox (see preprocess())
+    RESIZE_PAD_VALUE = LETTERBOX_PAD
 
     def __init__(self, model_path: str, device="cuda", data=None, fp16=False, **kwargs) -> None:
         """init the model

--- a/object_detectors/yolov5_lmi/model.py
+++ b/object_detectors/yolov5_lmi/model.py
@@ -38,6 +38,7 @@ class Yolov5(ODBase):
     logger = logging.getLogger(__name__)
 
     RESIZE_PRESERVE_ASPECT = True  # caller letterboxes; unused internally
+    RESIZE_PAD_VALUE = 114  # yolov5 gray letterbox fill
 
     def __init__(self, weights: str, device="cuda", data=None, fp16=False, **kwargs) -> None:
         """


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
add padding value for default resize

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
