### PR TITLE
refactor: consolidate the default resize and warn every mismatch

### DIFF
--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -163,19 +163,22 @@ class ODBase(abc.ABC):
 
         return all_results, {"preproc": t_preproc, "proc": t_proc, "postproc": t_postproc}
 
-    def _fit_to_input_size(self, images: List[ImageLike], preserve_aspect: bool = True, resize_fn=None) -> List[ImageLike]:
-        """Resize off-size images to the model input (``self.image_size``)
+    def _fit_to_input_size(
+        self,
+        images: List[ImageLike],
+        preserve_aspect: bool = True,
+        resize_fn=None,
+        channels_first: bool = False,
+    ) -> List[ImageLike]:
+        """Resize off-size images to the model input (``self.image_size``). Perform resize_and_pad by default.
 
-        args:
-            ``images``: list of HWC images (numpy or tensor) to check and resize if needed.
-            ``preserve_aspect`` must match the backend's convention:
-                ``True`` (letterbox) for backends reconstructing letterbox geometry,
-                ``False`` (stretch) for those mapping normalized boxes to the full frame.
+        Args:
+            ``images``: images (numpy or tensor) to resize if they don't match the model input.
+            ``preserve_aspect``: ``True`` for letterbox, ``False`` for stretch. Only affects the
+                default resize_and_pad and the warning wording (ignored when ``resize_fn`` is given).
+            ``resize_fn``: optional resize function ``(image, (th, tw)) -> image`` to use. Overrides the default resize_and_pad when given.
+            ``channels_first``: ``True`` if images are CHW, else HWC.
 
-            ``resize_fn``: optional ``(image, (th, tw)) -> image`` used in place of ``resize_and_pad``
-            (e.g. YOLO's letterbox); ``preserve_aspect`` then only affects the warning wording.
-
-        Raises ``ValueError`` when ``self.image_size`` is unset.
         """
         target = getattr(self, "image_size", None)
         if not target:
@@ -187,7 +190,7 @@ class ODBase(abc.ABC):
         th, tw = int(target[0]), int(target[1])
         out, mismatched = [], None
         for im in images:
-            h, w = im.shape[:2]
+            h, w = (im.shape[1], im.shape[2]) if channels_first else im.shape[:2]
             if (h, w) != (th, tw):
                 mismatched = mismatched or (h, w)
                 if resize_fn is not None:
@@ -197,17 +200,13 @@ class ODBase(abc.ABC):
             out.append(im)
 
         if mismatched is not None:
-            self._warn_resize_once(mismatched[0], mismatched[1], th, tw, "letterbox" if preserve_aspect else "stretch")
-        return out
-
-    def _warn_resize_once(self, h: int, w: int, th: int, tw: int, mode: str) -> None:
-        """Warn once per instance that an off-size input is being auto-resized to the model input."""
-        if not getattr(self, "_input_size_warned", False):
-            self._input_size_warned = True
+            mh, mw = mismatched
+            mode = "letterbox" if preserve_aspect else "stretch"
             self.logger.warning(
-                f"Input size {h}x{w} != model input {th}x{tw}; auto-resizing ({mode}) to fit. "
+                f"Input size {mh}x{mw} != model input {th}x{tw}; auto-resizing ({mode}) to fit. "
                 "Add a matching resize to your preprocessing pipeline to silence this and avoid the extra resize."
             )
+        return out
 
     @staticmethod
     def _to_numpy(data):

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -74,24 +74,19 @@ class RfdetrBase(ODBase):
             return F.to_tensor(image).to(self.device)
         return image.permute(2, 0, 1).to(self.device).float() / 255.0
 
-    def _fit_to_input_size(self, img_tensor: torch.Tensor) -> torch.Tensor:
-        """Stretch a CHW float tensor to self.image_size, warning once per instance."""
-        th, tw = int(self.image_size[0]), int(self.image_size[1])
-        h, w = img_tensor.shape[1], img_tensor.shape[2]
-        if (h, w) == (th, tw):
-            return img_tensor
-        self._warn_resize_once(h, w, th, tw, "stretch")
-        return F.resize(img_tensor, [th, tw], antialias=True)
-
     def preprocess(self, images: List[ImageLike]) -> torch.Tensor:
         """Preprocess input image(s) to a BCHW normalized tensor.
 
-        RF-DETR is trained with a square (stretch) resize — not letterbox — applied with
-        antialiasing on the float tensor, so off-size inputs are fit to self.image_size that way.
+        RF-DETR is trained with a square (stretch) resize, applied with antialiasing on the float tensor.
         """
         if not isinstance(images, list):
             images = [images]
-        tensors = [self._fit_to_input_size(self._to_float_chw(img)) for img in images]
+
+        def resize_stretch(img_tensor, size):
+            return F.resize(img_tensor, [size[0], size[1]], antialias=True)
+
+        tensors = [self._to_float_chw(img) for img in images]
+        tensors = self._fit_to_input_size(tensors, preserve_aspect=False, resize_fn=resize_stretch, channels_first=True)
         return torch.stack([F.normalize(t, self.means, self.stds) for t in tensors])
 
     @staticmethod


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
consolidate the default resize function and warn every mismatch

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
