### PR TITLE
refactor: rename the crop to cropbox and use bilinear for resizing masks

### DIFF
--- a/PRERELEASE.md
+++ b/PRERELEASE.md
@@ -324,7 +324,7 @@ When you need to apply preprocessing **beyond what the model manifest declares**
 | Step builder | Required kwargs | Notes |
 |---|---|---|
 | `steps.resize(width=..., height=..., preserve_aspect=False, pad_value=0, mode="bilinear")` | — | Each dim defaults to the source image's matching dim. `pad_value` is the letterbox fill, only used when `preserve_aspect=True` (e.g. `114` to match YOLO) |
-| `steps.crop(boxes=...)` | `boxes` | One `[x1, y1, x2, y2]` per image |
+| `steps.cropbox(boxes=...)` | `boxes` | One `[x1, y1, x2, y2]` per image |
 | `steps.flip(lr=False, ud=False)` | — | Defaults to a no-op |
 | `steps.pad(width=None, height=None, pad=None, value=0)` | one of `width/height` or `pad` | `pad=[L, R, T, B]` for explicit padding |
 | `steps.tile(tile_size=..., stride=..., scale_mode="padding", overlap_mode="average")` | `tile_size`, `stride` | Scalars are broadcast to `[h, w]` |
@@ -339,7 +339,7 @@ class MyPipeline(PipelineBase):
         image = inputs["image"]
 
         ops = [
-            steps.crop(boxes=[[100, 50, 900, 700]]),
+            steps.cropbox(boxes=[[100, 50, 900, 700]]),
             steps.resize(width=640, height=640, preserve_aspect=True),
             steps.flip(lr=True),
         ]
@@ -361,7 +361,7 @@ This section covers the other case: the image was preprocessed **outside** the `
 
 | Step builder | Key fields (per-image lists, length B) |
 |---|---|
-| `steps.revert_crop(boxes=..., orig_sizes=...)` | `boxes` = `[x1, y1, x2, y2]` used; `orig_sizes` = `[W, H]` of the pre-crop canvas |
+| `steps.revert_cropbox(boxes=..., orig_sizes=...)` | `boxes` = `[x1, y1, x2, y2]` used; `orig_sizes` = `[W, H]` of the pre-crop canvas |
 | `steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...)` | `src_sizes` / `dst_sizes` = `[W, H]`; `pads` = `[L, R, T, B]` letterbox padding |
 | `steps.revert_pad(pads=...)` | `pads` = `[L, R, T, B]` applied |
 | `steps.revert_flip(lr=..., ud=..., sizes=...)` | `lr`, `ud` flags; `sizes` = `[W, H]` of the flipped image |
@@ -374,7 +374,7 @@ from lmi_utils.preprocess_utils import steps
 
 # foreground_im was already cropped from the full-resolution image at [x1, y1, x2, y2];
 # original canvas was W x H. Build the matching history and let predict() revert for us.
-history = [steps.revert_crop(boxes=[[x1, y1, x2, y2]], orig_sizes=[[W, H]])]
+history = [steps.revert_cropbox(boxes=[[x1, y1, x2, y2]], orig_sizes=[[W, H]])]
 
 results, _ = model.predict(foreground_im, 0.5, operators=history)
 # results["boxes"][0] is now in the original (W, H) coordinate space.

--- a/lmi_utils/gadget_utils/pipeline_utils.py
+++ b/lmi_utils/gadget_utils/pipeline_utils.py
@@ -362,11 +362,7 @@ _RECONSTRUCTORS = {}  # interpolation mode -> Reconstructor (image-revert resamp
 
 
 def _reconstructor(interpolation: str = "bilinear"):
-    """Return a shared ``Reconstructor`` whose resize op reverts images with ``interpolation``.
-
-    ``"nearest"`` preserves binary/label masks; ``"bilinear"`` suits continuous-tone images.
-    Lazy import to avoid cycles.
-    """
+    """Return a shared ``Reconstructor`` whose resize op reverts images with ``interpolation``."""
     recon = _RECONSTRUCTORS.get(interpolation)
     if recon is None:
         from lmi_utils.preprocess_utils.ops import ResizeOperation
@@ -387,8 +383,7 @@ def revert_mask_to_origin(mask, operations: list, interpolation: str = "bilinear
     Args:
         mask: np.array or torch.Tensor, shape (H, W) or (H, W, C).
         operations: list of typed ``Meta`` records (one per preprocessing step), batch size 1.
-        interpolation: resize-revert mode. Use ``"nearest"`` for binary/label masks
-            (bilinear erodes them on upscale); ``"bilinear"`` for continuous-tone images.
+        interpolation: resize-revert mode. Default is ``"bilinear"``.
 
     Returns:
         Mask reverted to original-image space, same type as input.
@@ -399,10 +394,7 @@ def revert_mask_to_origin(mask, operations: list, interpolation: str = "bilinear
 @torch.inference_mode()
 def revert_masks_to_origin(masks, operations: list, interpolation: str = "bilinear"):
     """
-    Revert a stack of mask images (N, H, W) to original-image space.
-
-    Batched form of :func:`revert_mask_to_origin`. Pass ``interpolation="nearest"`` for
-    binary/label instance masks.
+    Revert a stack of mask images (N, H, W) to original-image space. Batched form of :func:`revert_mask_to_origin`.
     """
     if len(masks) == 0:
         return []

--- a/lmi_utils/image_utils/img_resize.py
+++ b/lmi_utils/image_utils/img_resize.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 
 from lmi_utils.gadget_utils.pipeline_utils import fit_im_to_size, resize_image
+from lmi_utils.preprocess_utils import steps
 from lmi_utils.system_utils.path_utils import get_relative_paths
 
 logger = logging.getLogger(__name__)
@@ -33,12 +34,8 @@ def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwar
 
     kwargs:
         mode (str): interpolation mode. Default "bilinear".
-        return_operators (bool): if True, also return a history list (new schema).
-        operators (list): seed history list. ``return_operators=True`` returns
-            ``seed + new_entries``. Each entry is::
-
-                {"type": "resize", "metadata": [{"src_size": [w, h], "dst_size": [w, h], "pad"?: [L, R, T, B]}]}
-                {"type": "pad",    "metadata": [{"pad": [L, R, T, B]}]}
+        return_operators (bool): if True, also return a history list of typed ``Meta`` records.
+        operators (list): history list.
 
     Returns:
         Image (always), and history list when ``return_operators=True``.
@@ -57,14 +54,14 @@ def resize_and_pad(image, width=None, height=None, preserve_aspect=False, **kwar
             w1 = int(scale * w0)
             h1 = int(scale * h0)
             im_out = resize_image(image, W=w1, H=h1, mode=mode)
-            entry = {"type": "resize", "metadata": [{"src_size": [w0, h0], "dst_size": [w1, h1]}]}
+            pad = [0, 0, 0, 0]
             if w1 != tw or h1 != th:
                 im_out, pad_l, pad_r, pad_t, pad_b = fit_im_to_size(im_out, tw, th)
-                entry["metadata"][0]["pad"] = [pad_l, pad_r, pad_t, pad_b]
-            operators.append(entry)
+                pad = [pad_l, pad_r, pad_t, pad_b]
+            operators.append(steps.revert_resize(src_sizes=[[w0, h0]], dst_sizes=[[w1, h1]], pads=[pad]))
         else:
             im_out = resize_image(image, W=tw, H=th, mode=mode)
-            operators.append({"type": "resize", "metadata": [{"src_size": [w0, h0], "dst_size": [tw, th]}]})
+            operators.append(steps.revert_resize(src_sizes=[[w0, h0]], dst_sizes=[[tw, th]], pads=[[0, 0, 0, 0]]))
 
     if kwargs.get("return_operators", False) is True:
         return im_out, operators

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -297,7 +297,7 @@ class PipelineBase(metaclass=ABCMeta):
             from lmi_utils.preprocess_utils import steps
             ops = [
                 steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...),
-                steps.revert_crop(boxes=..., orig_sizes=...),
+                steps.revert_cropbox(boxes=..., orig_sizes=...),
             ]
 
         in the same order they were applied during preprocessing.

--- a/lmi_utils/preprocess_utils/_parser.py
+++ b/lmi_utils/preprocess_utils/_parser.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Type
 
 from .operation import Config
 from .ops import (
-    CropConfig,
+    CropBoxConfig,
     FlipConfig,
     PadConfig,
     ResizeConfig,
@@ -19,7 +19,7 @@ from .ops import (
 
 # Manifest "type" string -> Config dataclass.
 STEP_TYPES: Dict[str, Type[Config]] = {
-    "crop": CropConfig,
+    "cropbox": CropBoxConfig,
     "flip": FlipConfig,
     "pad": PadConfig,
     "resize": ResizeConfig,

--- a/lmi_utils/preprocess_utils/ops/__init__.py
+++ b/lmi_utils/preprocess_utils/ops/__init__.py
@@ -1,13 +1,13 @@
-from .crop import CropConfig, CropMeta, CropOperation
+from .cropbox import CropBoxConfig, CropBoxMeta, CropBoxOperation
 from .flip import FlipConfig, FlipMeta, FlipOperation
 from .pad import PadConfig, PadMeta, PadOperation
 from .resize import ResizeConfig, ResizeMeta, ResizeOperation
 from .tile import TileConfig, TileMeta, TileOperation
 
 __all__ = [
-    "CropConfig",
-    "CropMeta",
-    "CropOperation",
+    "CropBoxConfig",
+    "CropBoxMeta",
+    "CropBoxOperation",
     "FlipConfig",
     "FlipMeta",
     "FlipOperation",

--- a/lmi_utils/preprocess_utils/ops/cropbox.py
+++ b/lmi_utils/preprocess_utils/ops/cropbox.py
@@ -8,7 +8,7 @@ from ..operation import Config, Meta, Operation
 
 
 @dataclass
-class CropConfig(Config):
+class CropBoxConfig(Config):
     """Crop each image to a per-image box.
 
     boxes: list of [x1, y1, x2, y2], one per input image.
@@ -18,15 +18,15 @@ class CropConfig(Config):
 
     def __post_init__(self):
         if not isinstance(self.boxes, list) or not self.boxes:
-            raise ValueError(f"CropConfig: 'boxes' must be a non-empty list, got {self.boxes!r}")
+            raise ValueError(f"CropBoxConfig: 'boxes' must be a non-empty list, got {self.boxes!r}")
         for i, box in enumerate(self.boxes):
             if len(box) != 4:
-                raise ValueError(f"CropConfig: boxes[{i}] must have 4 elements [x1,y1,x2,y2], got {box!r}")
+                raise ValueError(f"CropBoxConfig: boxes[{i}] must have 4 elements [x1,y1,x2,y2], got {box!r}")
 
 
 @dataclass
-class CropMeta(Meta):
-    """Batched crop metadata.
+class CropBoxMeta(Meta):
+    """Batched crop-to-box metadata.
 
     boxes: clamped [x1, y1, x2, y2] actually used per image.
     orig_sizes: [W, H] per image, used to restore the canvas on revert.
@@ -37,17 +37,17 @@ class CropMeta(Meta):
 
     def __post_init__(self):
         if len(self.boxes) != len(self.orig_sizes):
-            raise ValueError(f"CropMeta: boxes ({len(self.boxes)}) and orig_sizes ({len(self.orig_sizes)}) lengths must match")
+            raise ValueError(f"CropBoxMeta: boxes ({len(self.boxes)}) and orig_sizes ({len(self.orig_sizes)}) lengths must match")
 
 
-class CropOperation(Operation[CropConfig, CropMeta]):
-    config_cls = CropConfig
-    meta_cls = CropMeta
+class CropBoxOperation(Operation[CropBoxConfig, CropBoxMeta]):
+    config_cls = CropBoxConfig
+    meta_cls = CropBoxMeta
 
     @torch.inference_mode()
-    def forward(self, images: List[torch.Tensor], config: CropConfig) -> Tuple[List[torch.Tensor], CropMeta]:
+    def forward(self, images: List[torch.Tensor], config: CropBoxConfig) -> Tuple[List[torch.Tensor], CropBoxMeta]:
         if len(config.boxes) != len(images):
-            raise ValueError(f"crop: boxes length ({len(config.boxes)}) != image count ({len(images)})")
+            raise ValueError(f"cropbox: boxes length ({len(config.boxes)}) != image count ({len(images)})")
 
         out_images: List[torch.Tensor] = []
         out_boxes: List[List[int]] = []
@@ -62,12 +62,12 @@ class CropOperation(Operation[CropConfig, CropMeta]):
             out_boxes.append([x1, y1, x2, y2])
             out_sizes.append([W, H])
 
-        return out_images, CropMeta(boxes=out_boxes, orig_sizes=out_sizes)
+        return out_images, CropBoxMeta(boxes=out_boxes, orig_sizes=out_sizes)
 
     @torch.inference_mode()
-    def revert_images(self, images: List[torch.Tensor], meta: CropMeta) -> List[torch.Tensor]:
+    def revert_images(self, images: List[torch.Tensor], meta: CropBoxMeta) -> List[torch.Tensor]:
         if len(images) != len(meta.boxes):
-            raise ValueError(f"crop: image count ({len(images)}) != meta count ({len(meta.boxes)})")
+            raise ValueError(f"cropbox: image count ({len(images)}) != meta count ({len(meta.boxes)})")
         restored = []
         for img, box, size in zip(images, meta.boxes, meta.orig_sizes):
             x1, y1, _, _ = box
@@ -84,15 +84,15 @@ class CropOperation(Operation[CropConfig, CropMeta]):
         return restored
 
     @torch.inference_mode()
-    def revert_coords(self, results: List[Dict[str, Any]], meta: CropMeta) -> List[Dict[str, Any]]:
+    def revert_coords(self, results: List[Dict[str, Any]], meta: CropBoxMeta) -> List[Dict[str, Any]]:
         if len(results) != len(meta.boxes):
-            raise ValueError(f"crop: results count ({len(results)}) != meta count ({len(meta.boxes)})")
+            raise ValueError(f"cropbox: results count ({len(results)}) != meta count ({len(meta.boxes)})")
         return [self._apply_single(r, b, s, forward=False) for r, b, s in zip(results, meta.boxes, meta.orig_sizes)]
 
     @torch.inference_mode()
-    def apply_coords(self, results: List[Dict[str, Any]], meta: CropMeta) -> List[Dict[str, Any]]:
+    def apply_coords(self, results: List[Dict[str, Any]], meta: CropBoxMeta) -> List[Dict[str, Any]]:
         if len(results) != len(meta.boxes):
-            raise ValueError(f"crop: results count ({len(results)}) != meta count ({len(meta.boxes)})")
+            raise ValueError(f"cropbox: results count ({len(results)}) != meta count ({len(meta.boxes)})")
         return [self._apply_single(r, b, s, forward=True) for r, b, s in zip(results, meta.boxes, meta.orig_sizes)]
 
     @staticmethod

--- a/lmi_utils/preprocess_utils/ops/resize.py
+++ b/lmi_utils/preprocess_utils/ops/resize.py
@@ -53,7 +53,7 @@ class ResizeOperation(Operation[ResizeConfig, ResizeMeta]):
     meta_cls = ResizeMeta
 
     def __init__(self, image_mode: str = "bilinear"):
-        """image_mode: ``revert_images`` interpolation. ``"nearest"`` for binary/label masks."""
+        """image_mode: ``revert_images`` interpolation."""
         self.image_mode = image_mode
 
     @torch.inference_mode()
@@ -163,19 +163,26 @@ def _apply_resize(result: Dict[str, Any], src: List[int], dst: List[int], pad: L
 
 
 def _resample_masks(masks: torch.Tensor, src_size: List[int], dst_size: List[int], pad: List[int], *, pad_after: bool) -> torch.Tensor:
-    """Resample instance masks between original space (src) and preprocessed space (dst+pad).
+    """Resample binary instance masks between original space (src) and preprocessed space (dst+pad).
 
     pad_after=True: src -> dst -> pad (forward).
     pad_after=False: strip pad -> dst -> src (revert).
+
+    Masks are resampled with bilinear (for antialiased edges) and re-thresholded to strict 0/1, so the
+    result stays binary and downstream consumers testing ``mask > 0`` remain correct. Returns float32.
     """
     import torch.nn.functional as F
+
+    def _resize_binary(m: torch.Tensor, size) -> torch.Tensor:
+        resized = F.interpolate(m.float().unsqueeze(1), size=size, mode="bilinear", align_corners=False).squeeze(1)
+        return (resized > 0.5).float()
 
     src_w, src_h = src_size
     dst_w, dst_h = dst_size
     pad_L, pad_R, pad_T, pad_B = pad
     if pad_after:
         # forward: resize to (dst_h, dst_w), then pad to (dst_h + pT+pB, dst_w + pL+pR)
-        resized = F.interpolate(masks.float().unsqueeze(1), size=(dst_h, dst_w), mode="nearest").squeeze(1)
+        resized = _resize_binary(masks, (dst_h, dst_w))
         if pad_L or pad_R or pad_T or pad_B:
             n = resized.shape[0]
             canvas_h = dst_h + pad_T + pad_B
@@ -188,4 +195,4 @@ def _resample_masks(masks: torch.Tensor, src_size: List[int], dst_size: List[int
     if pad_L or pad_T:
         # mask shape: (N, H, W). Strip pad from a (dst_h+pT+pB, dst_w+pL+pR) canvas.
         masks = masks[:, pad_T : pad_T + dst_h, pad_L : pad_L + dst_w]
-    return F.interpolate(masks.float().unsqueeze(1), size=(src_h, src_w), mode="nearest").squeeze(1)
+    return _resize_binary(masks, (src_h, src_w))

--- a/lmi_utils/preprocess_utils/ops/tile.py
+++ b/lmi_utils/preprocess_utils/ops/tile.py
@@ -226,7 +226,12 @@ def _shift_tile_coords(
         if scaled:
             new_h = max(1, round(masks.shape[1] * sy))
             new_w = max(1, round(masks.shape[2] * sx))
-            masks = torch.nn.functional.interpolate(masks.float().unsqueeze(1), size=(new_h, new_w), mode="nearest").squeeze(1)
+            masks = (
+                torch.nn.functional.interpolate(
+                    masks.float().unsqueeze(1), size=(new_h, new_w), mode="bilinear", align_corners=False
+                ).squeeze(1)
+                > 0.5
+            ).float()
             paste_y = round(offset_y * sy)
             paste_x = round(offset_x * sx)
         else:

--- a/lmi_utils/preprocess_utils/preprocessor.py
+++ b/lmi_utils/preprocess_utils/preprocessor.py
@@ -5,7 +5,7 @@ from lmi_utils.image_utils.types import ImageBatch, ImageLike
 from .base import BaseProcessor
 from .operation import Config, Meta, Operation
 from .ops import (
-    CropOperation,
+    CropBoxOperation,
     FlipOperation,
     PadOperation,
     ResizeOperation,
@@ -30,7 +30,7 @@ class Preprocessor(BaseProcessor):
         PadOperation,
         FlipOperation,
         TileOperation,
-        CropOperation,
+        CropBoxOperation,
     )
 
     @classmethod

--- a/lmi_utils/preprocess_utils/reconstructor.py
+++ b/lmi_utils/preprocess_utils/reconstructor.py
@@ -5,7 +5,7 @@ from lmi_utils.image_utils.types import ImageLike
 from .base import BaseProcessor
 from .operation import Meta, Operation
 from .ops import (
-    CropOperation,
+    CropBoxOperation,
     FlipOperation,
     PadOperation,
     ResizeOperation,
@@ -28,7 +28,7 @@ class Reconstructor(BaseProcessor):
         PadOperation,
         FlipOperation,
         TileOperation,
-        CropOperation,
+        CropBoxOperation,
     )
 
     @classmethod

--- a/lmi_utils/preprocess_utils/steps.py
+++ b/lmi_utils/preprocess_utils/steps.py
@@ -1,19 +1,19 @@
 """Public namespace for building preprocessing pipelines.
 
 Forward (used with self.preprocessor.preprocess in pipeline):
-    steps.crop(boxes=...)
+    steps.cropbox(boxes=...)
     steps.resize(width=..., height=..., preserve_aspect=...)
     ...
 
 Inverse (used with self.revert_preprocess in pipeline):
-    steps.revert_crop(boxes=..., orig_sizes=...)
+    steps.revert_cropbox(boxes=..., orig_sizes=...)
     steps.revert_resize(src_sizes=..., dst_sizes=..., pads=...)
     ...
 """
 
 from .ops import (
-    CropConfig,
-    CropMeta,
+    CropBoxConfig,
+    CropBoxMeta,
     FlipConfig,
     FlipMeta,
     PadConfig,
@@ -25,26 +25,26 @@ from .ops import (
 )
 
 # forward
-crop = CropConfig
+cropbox = CropBoxConfig
 resize = ResizeConfig
 pad = PadConfig
 flip = FlipConfig
 tile = TileConfig
 
 # inverse
-revert_crop = CropMeta
+revert_cropbox = CropBoxMeta
 revert_resize = ResizeMeta
 revert_pad = PadMeta
 revert_flip = FlipMeta
 revert_tile = TileMeta
 
 __all__ = [
-    "crop",
+    "cropbox",
     "resize",
     "pad",
     "flip",
     "tile",
-    "revert_crop",
+    "revert_cropbox",
     "revert_resize",
     "revert_pad",
     "revert_flip",

--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -69,10 +69,8 @@ class ODBase(abc.ABC):
             configs: Confidence threshold (float) or per-class thresholds (dict).
             operators: Unified preprocessing history for coordinate reversion. Accepts:
                 - None: no coordinate reversion.
-                - List of history entries of shape
-                  ``{"type": str, "metadata": [<per_image_dict>, ...], "id"?: str}``,
-                  matching what ``Preprocessor.preprocess()`` returns. ``metadata`` length
-                  must be 1 (broadcast to all images) or equal to batch size (per-image).
+                - List of history entries matching what ``Preprocessor.preprocess()`` returns.
+                  ``metadata`` length must be 1 (broadcast to all images) or equal to batch size (per-image).
         kwargs:
             batch_size (int): chunk size for dynamic mini-batch inference (default: None = all at once).
                 Ignored when self.fixed_batch_size is set.
@@ -386,8 +384,8 @@ class ODBase(abc.ABC):
         # masks
         masks = results.get("masks")
         if masks is not None and len(masks):
-            # binary instance masks: nearest preserves them (bilinear erodes on upscale)
-            results["masks"] = pipeline_utils.revert_masks_to_origin(masks, operators, interpolation="nearest")
+            reverted = pipeline_utils._reconstructor().reconstruct_coordinates({"masks": [masks]}, operators)["masks"][0]
+            results["masks"] = reverted.to(masks.dtype) if torch.is_tensor(masks) else reverted.astype(masks.dtype)
 
         # segments
         segments = results.get("segments")

--- a/object_detectors/ultralytics_lmi/yolo/run_model.py
+++ b/object_detectors/ultralytics_lmi/yolo/run_model.py
@@ -8,17 +8,18 @@ import numpy as np
 from tqdm import tqdm
 
 from lmi_utils.gadget_utils.pipeline_utils import (
+    _reconstructor,
     fit_im_to_size,
     get_img_path_batches,
     plot_one_box,
     plot_one_rbox,
     resize_image,
-    revert_masks_to_origin,
     revert_to_origin,
 )
 from lmi_utils.label_utils.bbox_utils import get_rotated_bbox
 from lmi_utils.label_utils.csv_utils import write_to_csv
 from lmi_utils.label_utils.shapes import Mask, Rect
+from lmi_utils.preprocess_utils import steps
 from object_detectors.ultralytics_lmi.yolo.model import Yolo, YoloObb, YoloPose, YoloSeg
 
 BATCH_SIZE = 1
@@ -147,15 +148,16 @@ if __name__ == "__main__":
                 )
                 logger.warning(f"{im1.shape}, resizing")
                 operators.append(
-                    {
-                        "type": "resize",
-                        "metadata": [{"src_size": [im0.shape[1], im0.shape[0]], "dst_size": [im1.shape[1], im1.shape[0]]}],
-                    }
+                    steps.revert_resize(
+                        src_sizes=[[im0.shape[1], im0.shape[0]]],
+                        dst_sizes=[[im1.shape[1], im1.shape[0]]],
+                        pads=[[0, 0, 0, 0]],
+                    )
                 )
 
             if args.pad:
                 im1, pad_L, pad_R, pad_T, pad_B = fit_im_to_size(im=im1, H=args.pad[0], W=args.pad[1])
-                operators.append({"type": "pad", "metadata": [{"pad": [pad_L, pad_R, pad_T, pad_B]}]})
+                operators.append(steps.revert_pad(pads=[[pad_L, pad_R, pad_T, pad_B]]))
                 logger.warning(f"{im1.shape}, padding")
 
             if args.sz[0] != im1.shape[0] or args.sz[1] != im1.shape[1]:
@@ -187,6 +189,9 @@ if __name__ == "__main__":
                 points = results["points"][0] if "points" in results else []
                 if use_revert_to_origin:
                     boxes = revert_to_origin(boxes, operators)
+                    if masks is not None and len(masks):
+                        # revert the whole mask stack once via the coordinate path (bilinear + re-threshold)
+                        masks = _reconstructor().reconstruct_coordinates({"masks": [masks]}, operators)["masks"][0]
 
                 # loop through each box
                 for j in range(len(boxes) - 1, -1, -1):
@@ -194,9 +199,7 @@ if __name__ == "__main__":
                     mask = None
                     if masks is not None:
                         mask = masks[j]
-                        if use_revert_to_origin:
-                            mask = revert_masks_to_origin(masks, operators, interpolation="nearest")
-                        else:
+                        if not use_revert_to_origin:
                             mask = cv2.resize(mask, (im_out.shape[1], im_out.shape[0]))
                     box = boxes[j]
                     if not use_revert_to_origin:

--- a/object_detectors/yolov5_lmi/model.py
+++ b/object_detectors/yolov5_lmi/model.py
@@ -286,7 +286,7 @@ class Yolov5(ODBase):
             segs = results["segments"][0]
             # convert mask to sensor space
             result_contours = [pipeline_utils.revert_to_origin(seg, operators) for seg in segs]
-            masks = pipeline_utils.revert_masks_to_origin(masks, operators, interpolation="nearest")
+            masks = pipeline_utils.revert_masks_to_origin(masks, operators)
             results_dict["segments"] = result_contours
             results_dict["masks"] = masks
 

--- a/tests/lmi_utils/image_utils/test_img_resize.py
+++ b/tests/lmi_utils/image_utils/test_img_resize.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from lmi_utils.image_utils.img_resize import resize_and_pad
+from lmi_utils.preprocess_utils.ops import ResizeMeta
 
 
 @pytest.mark.parametrize(
@@ -23,11 +24,11 @@ def test_resize_and_pad(input_shape, target_w, target_h):
 
     assert output.shape == (target_h, target_w, 3)
     assert len(ops) == 1
-    assert ops[0]["type"] == "resize"
-    md = ops[0]["metadata"][0]
-    assert md["src_size"] == [w, h]
-    assert md["dst_size"] == [target_w, target_h]
-    assert "pad" not in md
+    meta = ops[0]
+    assert isinstance(meta, ResizeMeta)
+    assert meta.src_sizes[0] == [w, h]
+    assert meta.dst_sizes[0] == [target_w, target_h]
+    assert meta.pads[0] == [0, 0, 0, 0]
 
 
 @pytest.mark.parametrize(
@@ -47,20 +48,15 @@ def test_resize_and_pad_preserve_aspect(input_shape, target_w, target_h, expecte
 
     assert output.shape == (target_h, target_w, 3)
     assert len(ops) == 1
-    assert ops[0]["type"] == "resize"
-
-    md = ops[0]["metadata"][0]
-    assert md["src_size"] == [w, h]
-    assert md["dst_size"] == [expected_resize[0], expected_resize[1]]
+    meta = ops[0]
+    assert isinstance(meta, ResizeMeta)
+    assert meta.src_sizes[0] == [w, h]
+    assert meta.dst_sizes[0] == [expected_resize[0], expected_resize[1]]
 
     exp_pad_w, exp_pad_h = expected_pad
-    if exp_pad_w or exp_pad_h:
-        assert "pad" in md
-        pad_l, pad_r, pad_t, pad_b = md["pad"]
-        assert pad_l + pad_r == exp_pad_w
-        assert pad_t + pad_b == exp_pad_h
-    else:
-        assert "pad" not in md
+    pad_l, pad_r, pad_t, pad_b = meta.pads[0]
+    assert pad_l + pad_r == exp_pad_w
+    assert pad_t + pad_b == exp_pad_h
 
 
 @pytest.mark.parametrize("input_type", ["numpy", "torch"])
@@ -81,8 +77,9 @@ def test_resize_and_pad_polymorphism(input_type):
 
     assert output.shape == (100, 100)
 
-    md = ops[0]["metadata"][0]
-    assert md["src_size"] == [50, 50]
-    assert md["dst_size"] == [100, 100]
+    meta = ops[0]
+    assert isinstance(meta, ResizeMeta)
+    assert meta.src_sizes[0] == [50, 50]
+    assert meta.dst_sizes[0] == [100, 100]
     # 50x50 → 100x100 preserve aspect: no padding (already square).
-    assert "pad" not in md
+    assert meta.pads[0] == [0, 0, 0, 0]

--- a/tests/lmi_utils/preprocess_utils/test_chain_pipeline.py
+++ b/tests/lmi_utils/preprocess_utils/test_chain_pipeline.py
@@ -1,4 +1,4 @@
-"""Cross-op chain tests covering flip/pad mixed with crop/resize/tile, plus forward
+"""Cross-op chain tests covering flip/pad mixed with cropbox/resize/tile, plus forward
 apply_coords round-trips through full pipelines."""
 
 import numpy as np
@@ -33,12 +33,12 @@ def pipeline():
     return Preprocessor(), Reconstructor()
 
 
-def test_pad_then_crop_image_round_trip(pipeline):
+def test_pad_then_cropbox_image_round_trip(pipeline):
     pre, rec = pipeline
     img = torch.ones((10, 8, 3), dtype=torch.float32)
     configs = [
         steps.pad(pad=[2, 3, 4, 5]),
-        steps.crop(boxes=[[2, 4, 10, 14]]),
+        steps.cropbox(boxes=[[2, 4, 10, 14]]),
     ]
     out, history = pre.preprocess([img], configs)
     assert out[0].shape == (10, 8, 3)
@@ -70,7 +70,7 @@ def test_full_pipeline_coord_round_trip(pipeline):
     img = _hwc_image(100, 80, 3)
     configs = [
         steps.pad(pad=[4, 4, 6, 6]),
-        steps.crop(boxes=[[8, 10, 80, 100]]),
+        steps.cropbox(boxes=[[8, 10, 80, 100]]),
         steps.resize(width=64, height=64, preserve_aspect=False),
         steps.flip(lr=True, ud=True),
     ]
@@ -92,7 +92,7 @@ def test_full_pipeline_image_reconstructs_to_padded_then_original_shape(pipeline
     img = _hwc_image(100, 80, 3)
     configs = [
         steps.pad(pad=[4, 4, 6, 6]),
-        steps.crop(boxes=[[8, 10, 80, 100]]),
+        steps.cropbox(boxes=[[8, 10, 80, 100]]),
         steps.resize(width=64, height=64, preserve_aspect=False),
         steps.flip(lr=True, ud=True),
     ]

--- a/tests/lmi_utils/preprocess_utils/test_cropbox.py
+++ b/tests/lmi_utils/preprocess_utils/test_cropbox.py
@@ -22,10 +22,10 @@ def _empty_results(n=1, **overrides):
     return results
 
 
-def test_crop_forward_basic():
+def test_cropbox_forward_basic():
     pre = Preprocessor()
     img = _hwc_image(100, 80, 3)
-    out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+    out, history = pre.preprocess([img], [steps.cropbox(boxes=[[10, 20, 60, 90]])])
 
     assert len(out) == 1
     assert out[0].shape == (70, 50, 3)
@@ -33,19 +33,19 @@ def test_crop_forward_basic():
     assert history[0].orig_sizes[0] == [80, 100]
 
 
-def test_crop_clamps_out_of_bounds():
+def test_cropbox_clamps_out_of_bounds():
     pre = Preprocessor()
     img = _hwc_image(50, 50, 3)
-    out, history = pre.preprocess([img], [steps.crop(boxes=[[-5, -5, 100, 100]])])
+    out, history = pre.preprocess([img], [steps.cropbox(boxes=[[-5, -5, 100, 100]])])
 
     assert out[0].shape == (50, 50, 3)
     assert history[0].boxes[0] == [0, 0, 50, 50]
 
 
-def test_crop_revert_image_pastes_into_canvas():
+def test_cropbox_revert_image_pastes_into_canvas():
     pre, rec = Preprocessor(), Reconstructor()
     img = torch.ones((100, 80, 3), dtype=torch.float32)
-    out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+    out, history = pre.preprocess([img], [steps.cropbox(boxes=[[10, 20, 60, 90]])])
 
     restored = rec.reconstruct_images(out, history)
     assert restored[0].shape == (100, 80, 3)
@@ -56,20 +56,20 @@ def test_crop_revert_image_pastes_into_canvas():
     assert restored[0][:, 60:].eq(0).all()
 
 
-def test_crop_revert_coords_adds_offset_to_boxes():
+def test_cropbox_revert_coords_adds_offset_to_boxes():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[10, 20, 60, 90]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[10, 20, 60, 90]])])
 
     results = _empty_results(boxes=[torch.tensor([[5.0, 5.0, 15.0, 15.0]])])
     reverted = rec.reconstruct_coordinates(results, history)
     assert torch.allclose(reverted["boxes"][0], torch.tensor([[15.0, 25.0, 25.0, 35.0]]))
 
 
-def test_crop_revert_coords_boxes_obb():
+def test_cropbox_revert_coords_boxes_obb():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[5, 10, 55, 80]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[5, 10, 55, 80]])])
 
     obb = torch.tensor([[[0.0, 0.0], [10.0, 0.0], [10.0, 5.0], [0.0, 5.0]]])
     results = _empty_results(boxes=[obb])
@@ -79,10 +79,10 @@ def test_crop_revert_coords_boxes_obb():
     assert torch.allclose(reverted["boxes"][0], expected)
 
 
-def test_crop_revert_coords_segments_variable_length():
+def test_cropbox_revert_coords_segments_variable_length():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[15, 20, 60, 90]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[15, 20, 60, 90]])])
 
     seg_a = torch.tensor([[0.0, 0.0], [5.0, 0.0], [5.0, 5.0]])
     seg_b = torch.tensor([[1.0, 2.0], [3.0, 4.0], [7.0, 8.0], [9.0, 0.0]])
@@ -94,10 +94,10 @@ def test_crop_revert_coords_segments_variable_length():
     assert torch.allclose(out_segs[1], seg_b + torch.tensor([15.0, 20.0]))
 
 
-def test_crop_revert_coords_points_preserve_visibility():
+def test_cropbox_revert_coords_points_preserve_visibility():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[8, 15, 48, 95]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[8, 15, 48, 95]])])
 
     pts = torch.tensor([[[0.0, 0.0, 2.0], [20.0, 40.0, 1.0], [39.0, 79.0, 0.0]]])
     results = _empty_results(points=[pts])
@@ -107,10 +107,10 @@ def test_crop_revert_coords_points_preserve_visibility():
     assert torch.allclose(reverted["points"][0], expected)
 
 
-def test_crop_revert_coords_masks_paste_into_full_canvas():
+def test_cropbox_revert_coords_masks_paste_into_full_canvas():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[12, 25, 72, 95]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[12, 25, 72, 95]])])
 
     mask = torch.ones((1, 70, 60), dtype=torch.float32)
     results = _empty_results(masks=[mask])
@@ -121,10 +121,10 @@ def test_crop_revert_coords_masks_paste_into_full_canvas():
     assert out_mask[0, :25].eq(0).all()
 
 
-def test_crop_apply_coords_forward_inverse_of_revert():
+def test_cropbox_apply_coords_forward_inverse_of_revert():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[20, 30, 70, 90]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[20, 30, 70, 90]])])
 
     orig = _empty_results(
         boxes=[torch.tensor([[25.0, 35.0, 65.0, 75.0]])],
@@ -142,10 +142,10 @@ def test_crop_apply_coords_forward_inverse_of_revert():
     assert torch.allclose(round_trip["points"][0], orig["points"][0])
 
 
-def test_crop_apply_coords_masks_crops_full_image_masks():
+def test_cropbox_apply_coords_masks_crops_full_image_masks():
     pre, rec = Preprocessor(), Reconstructor()
     img = _hwc_image(100, 80, 3)
-    _out, history = pre.preprocess([img], [steps.crop(boxes=[[18, 22, 78, 92]])])
+    _out, history = pre.preprocess([img], [steps.cropbox(boxes=[[18, 22, 78, 92]])])
 
     full = torch.zeros((1, 100, 80), dtype=torch.float32)
     full[0, 22:92, 18:78] = 1.0
@@ -155,10 +155,10 @@ def test_crop_apply_coords_masks_crops_full_image_masks():
     assert applied["masks"][0].eq(1).all()
 
 
-def test_crop_manual_revert_via_steps_namespace():
-    """Manual inverse without history — build a CropMeta directly via steps.revert_crop."""
+def test_cropbox_manual_revert_via_steps_namespace():
+    """Manual inverse without history — build a CropBoxMeta directly via steps.revert_cropbox."""
     rec = Reconstructor()
     results = _empty_results(boxes=[torch.tensor([[5.0, 5.0, 15.0, 15.0]])])
-    history = [steps.revert_crop(boxes=[[10, 20, 60, 90]], orig_sizes=[[80, 100]])]
+    history = [steps.revert_cropbox(boxes=[[10, 20, 60, 90]], orig_sizes=[[80, 100]])]
     reverted = rec.reconstruct_coordinates(results, history)
     assert torch.allclose(reverted["boxes"][0], torch.tensor([[15.0, 25.0, 25.0, 35.0]]))

--- a/tests/lmi_utils/preprocess_utils/test_reconstruct_coordinates.py
+++ b/tests/lmi_utils/preprocess_utils/test_reconstruct_coordinates.py
@@ -137,6 +137,43 @@ class TestResize:
         _assert_coords(reverted, 0, torch.tensor([[20.0, 20.0, 100.0, 180.0]]))
 
 
+class TestBinaryMaskResample:
+    """Masks resample via bilinear in _resample_masks, re-thresholded to strict 0/1 (float32)."""
+
+    def test_revert_stays_binary(self, pipeline):
+        prep, recon = pipeline
+        image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+        _, history = prep.preprocess(image, [steps.resize(width=64, height=64, preserve_aspect=False)])
+
+        # non-uniform mask: bilinear yields fractional edge values unless re-thresholded
+        mask = torch.zeros(1, 64, 64)
+        mask[:, 10:40, 12:50] = 1.0
+        out = recon.reconstruct_coordinates({"masks": [mask]}, history)["masks"][0]
+
+        assert out.shape == (1, 200, 200)
+        assert out.dtype == torch.float32
+        assert set(torch.unique(out).tolist()) <= {0.0, 1.0}
+
+    def test_apply_forward_stays_binary(self, pipeline):
+        prep, recon = pipeline
+        image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+        _, history = prep.preprocess(image, [steps.resize(width=64, height=64, preserve_aspect=True)])
+
+        mask = torch.zeros(1, 200, 200)
+        mask[:, 30:160, 40:175] = 1.0
+        out = recon.apply_coordinates({"masks": [mask]}, history)["masks"][0]
+
+        assert set(torch.unique(out).tolist()) <= {0.0, 1.0}
+
+    def test_full_mask_not_eroded(self, pipeline):
+        prep, recon = pipeline
+        image = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+        _, history = prep.preprocess(image, [steps.resize(width=64, height=64, preserve_aspect=False)])
+
+        out = recon.reconstruct_coordinates({"masks": [torch.ones(1, 64, 64)]}, history)["masks"][0]
+        assert torch.all(out == 1.0)  # a fully-on mask stays fully on (no edge erosion)
+
+
 class TestTile:
     def test_shifts_all_fields_by_tile_offset(self, pipeline):
         prep, recon = pipeline

--- a/tests/lmi_utils/preprocess_utils/test_steps.py
+++ b/tests/lmi_utils/preprocess_utils/test_steps.py
@@ -11,7 +11,7 @@ import torch
 
 from lmi_utils.preprocess_utils import steps
 from lmi_utils.preprocess_utils.ops import (
-    CropConfig,
+    CropBoxConfig,
     FlipConfig,
     PadConfig,
     ResizeConfig,
@@ -39,14 +39,14 @@ def test_resize_with_id():
     assert steps.resize(width=128, height=128, id="r1").id == "r1"
 
 
-def test_crop():
-    cfg = steps.crop(boxes=[[1, 2, 3, 4]])
-    assert isinstance(cfg, CropConfig)
+def test_cropbox():
+    cfg = steps.cropbox(boxes=[[1, 2, 3, 4]])
+    assert isinstance(cfg, CropBoxConfig)
     assert cfg.boxes == [[1, 2, 3, 4]]
 
 
-def test_crop_with_id():
-    assert steps.crop(boxes=[[0, 0, 10, 10]], id="c1").id == "c1"
+def test_cropbox_with_id():
+    assert steps.cropbox(boxes=[[0, 0, 10, 10]], id="c1").id == "c1"
 
 
 def test_flip_defaults():
@@ -88,7 +88,7 @@ def test_tile_with_modes():
 
 def test_id_defaults_to_none():
     assert steps.resize(width=64, height=64).id is None
-    assert steps.crop(boxes=[[0, 0, 1, 1]]).id is None
+    assert steps.cropbox(boxes=[[0, 0, 1, 1]]).id is None
     assert steps.flip().id is None
 
 
@@ -104,9 +104,9 @@ def test_config_runs_through_preprocessor():
     assert len(history) == 2
 
 
-def test_invalid_crop_config_raises():
+def test_invalid_cropbox_config_raises():
     with pytest.raises(ValueError, match="non-empty list"):
-        steps.crop(boxes=[])
+        steps.cropbox(boxes=[])
 
 
 def test_invalid_pad_length_raises():

--- a/tests/object_detectors/od_core/test_normalize_operators.py
+++ b/tests/object_detectors/od_core/test_normalize_operators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lmi_utils.preprocess_utils.ops import CropMeta, ResizeMeta
+from lmi_utils.preprocess_utils.ops import ResizeMeta
 from object_detectors.od_core.od_base import ODBase
 
 
@@ -32,15 +32,6 @@ def test_per_image_metadata_sliced():
     result = ODBase._normalize_operators(history, 2)
     assert result[0][0].src_sizes == [[1280, 720]]
     assert result[1][0].src_sizes == [[1024, 768]]
-
-
-def test_id_preserved_through_slice():
-    # CropMeta has no id field — runtime ids live on Configs, not Metas — but the slicing
-    # preserves all scalar attributes regardless.
-    history = [CropMeta(boxes=[[0, 0, 10, 10]], orig_sizes=[[100, 100]])]
-    result = ODBase._normalize_operators(history, 1)
-    assert isinstance(result[0][0], CropMeta)
-    assert result[0][0].boxes == [[0, 0, 10, 10]]
 
 
 def test_metadata_length_mismatch_raises():


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
rename the crop to cropbox and use bilinear for resizing masks

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
