### PR TITLE
fix(AD): auto resize to input shape for revert_preprocess()

### DIFF
--- a/anomaly_detectors/ad_core/ad_base.py
+++ b/anomaly_detectors/ad_core/ad_base.py
@@ -18,6 +18,10 @@ class ADBase(ABC):
     # Set to a positive integer in subclasses that use a fixed-batch-size model.
     fixed_batch_size: int = None
 
+    # AD models stretch off-size inputs to image_size (no aspect preservation). The pipeline reads
+    # this to record the matching inverse when preprocessing does not already resize to image_size.
+    RESIZE_PRESERVE_ASPECT: bool = False
+
     @property
     def colormap_tensor(self):
         """Lazily initialize and return a [256, 3] turbo colormap tensor on self.device."""

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -9,6 +9,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
+from anomaly_detectors.ad_core.ad_base import ADBase
 from anomaly_detectors.ad_core.anomaly_detector import AnomalyDetector
 from classifiers.cls_core.classifier import Classifier
 from lmi_utils.dataset_utils.representations import (
@@ -246,7 +247,13 @@ class PipelineBase(metaclass=ABCMeta):
 
         images = self.preprocessor.as_image_list(images)
         processed, history = self.preprocessor.preprocess(images, self._preprocessing[model_role])
-        return self._ensure_od_input_size(model_role, images, processed, history)
+
+        model = self.models.get(model_role)
+        if isinstance(model, ODBase):
+            return self._ensure_od_input_size(model_role, images, processed, history)
+        if isinstance(model, ADBase):
+            return self._record_ad_internal_resize(model_role, processed, history)
+        return processed, history
 
     def _ensure_od_input_size(
         self,
@@ -256,19 +263,16 @@ class PipelineBase(metaclass=ABCMeta):
         history: List[Dict[str, Any]],
     ) -> Tuple[List[ImageLike], List[Dict[str, Any]]]:
         """Append a resize so an OD model's preprocessed input matches its training size.
-        No-op for non-OD models and when the size already matches.
+        No-op when the size already matches.
         """
-        model = self.models.get(model_role)
-        if not isinstance(model, ODBase):
-            return processed, history
-
+        model = self.models[model_role]
         th, tw = int(model.image_size[0]), int(model.image_size[1])
         h, w = processed[0].shape[:2]
         if (h, w) == (th, tw):
             return processed, history
 
         if len(processed) != len(images):
-            # Only reachable once OD tiling exists (a tile op changes the image count).
+            # Reachable only once OD tiling exists (a tile op changes the image count).
             raise NotImplementedError(
                 f"Resize injection assumes a 1:1 image mapping, but preprocessing changed the image "
                 f"count ({len(images)} -> {len(processed)}) for OD model '{model_role}'. Add tile-aware "
@@ -282,6 +286,44 @@ class PipelineBase(metaclass=ABCMeta):
         resize_step = [steps.resize(width=tw, height=th, preserve_aspect=model.RESIZE_PRESERVE_ASPECT, pad_value=model.RESIZE_PAD_VALUE)]
         processed, extra = self.preprocessor.preprocess(processed, resize_step)
         return processed, history + extra
+
+    def _record_ad_internal_resize(
+        self,
+        model_role: str,
+        processed: List[ImageLike],
+        history: List[Dict[str, Any]],
+    ) -> Tuple[List[ImageLike], List[Dict[str, Any]]]:
+        """Record an AD model's internal fit-to-size as an inverse-only resize step.
+
+        The forward image is left off-size for the model to resize internally, so ``predict()`` scores are
+        unchanged. This only appends the inverse so ``revert_preprocess`` upsamples the score map back to
+        input space (overlay/output, not re-thresholding). No-op when the size already matches.
+        """
+        model = self.models[model_role]
+        th, tw = int(model.image_size[0]), int(model.image_size[1])
+
+        if all(tuple(p.shape[:2]) == (th, tw) for p in processed):
+            return processed, history
+
+        if len(processed) != 1:
+            # A tile op split the image; per-tile score reverting is not handled.
+            raise NotImplementedError(
+                f"AD inverse-resize assumes a single off-size image for '{model_role}', but preprocessing "
+                f"produced {len(processed)}. Configure a resize to {(th, tw)} in global preprocessing."
+            )
+
+        if model.RESIZE_PRESERVE_ASPECT:
+            # Letterbox would need the model's internal pad metadata to invert; only stretch is supported.
+            raise NotImplementedError(f"AD inverse-resize for '{model_role}' only supports a stretch (RESIZE_PRESERVE_ASPECT=False).")
+
+        h, w = processed[0].shape[:2]
+        # Model maps (h, w) -> (th, tw) internally; record the inverse so revert resizes the score map back.
+        meta = steps.revert_resize(src_sizes=[[w, h]], dst_sizes=[[tw, th]], pads=[[0, 0, 0, 0]])
+        self.logger.warning(
+            f"[{model_role}] preprocessed size {(h, w)} != model input {(th, tw)}; recording an inverse-resize "
+            "so the score map reverts to input space. Add a matching resize step in global preprocessing to silence this."
+        )
+        return processed, history + [meta]
 
     def revert_preprocess(self, data, ops: List[Meta]):
         """Invert preprocessing transforms on either image data (AD) or detection coordinates (OD).

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -285,6 +285,38 @@ def test_pipeline_AD(version, preprocessing_steps, expected_types):
         assert orig_shape == h_shape, f"Shape mismatch: {orig_shape} vs {h_shape}"
 
 
+def test_pipeline_AD_records_inverse_resize_on_size_mismatch(caplog):
+    """When AD preprocessing does not reach the model's input size, the forward image is left untouched
+    (the model resizes internally) and an inverse-resize is recorded so the score map still reverts to
+    the original input shape."""
+    model_path = os.path.abspath("tests/assets/models/ad/model_v1/model.ts")
+    image_dir = os.path.abspath("tests/assets/images/nvtec-ad")
+
+    # Configure a resize to the wrong size (320) for a 224 model: no resize reaches image_size.
+    preprocessing_steps = [{"type": "resize", "id": "r1", "configuration": {"height": 320, "width": 320}}]
+    model_roles = _build_ad_model_roles("3", model_path, preprocessing_steps)
+
+    pipeline = PipelineAD(version="3")
+    pipeline.load(model_roles, {})
+
+    image_files = [os.path.join(image_dir, f) for f in os.listdir(image_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+    assert len(image_files) > 0, "No images found in assets"
+    image = cv2.cvtColor(cv2.imread(image_files[0]), cv2.COLOR_BGR2RGB)
+
+    with caplog.at_level(logging.WARNING):
+        results = pipeline.predict({}, {"images": [image]})
+
+    ops_list = results["ops_list"]
+    # Configured resize + recorded inverse-resize, the latter not physically applied to the forward image.
+    actual_types = [type(op).__name__.removesuffix("Meta").lower() for op in ops_list]
+    assert actual_types == ["resize", "resize"], f"Unexpected history: {actual_types}"
+    assert any("recording an inverse-resize" in r.message for r in caplog.records), "Expected an inverse-resize warning"
+
+    # The reverted heatmap must still match the original input shape.
+    heatmap = results["outputs"]["annotated"][0]
+    assert heatmap.shape[:2] == image.shape[:2], f"Shape mismatch: {heatmap.shape[:2]} vs {image.shape[:2]}"
+
+
 def test_version_1_error():
     pipeline = PipelineOD(version="1")
     model_roles = {"mock-model": {"model_role": "mock-model"}}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
AD model's predict() returns a warpped 224x224 image. If no-op were defined in gloabl proprocessing for that model, the revert_preprocess() does not revert at all, while users expect it back to the input's shape.

This PR auto resizes to input shape after calling revert_preprocess() even though no-op exists in global preprocessing, and emits a warning.

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
