### PR TITLE
fix: lazy backend discovery and better registry error reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Guidance for Claude Code when working in this repository.
 
 ## Adding a Backend
 
-A backend only registers if it's discoverable — see the `ModelRegistry` docstring in `lmi_common/model_registry.py` for the `PACKAGES` / `.model` / `@register` contract.
+A backend only registers if it's discoverable — see the `ModelRegistry` docstring in `lmi_common/model_registry.py` for the `PACKAGES` / `@register` contract. New backends need a framework → module entry in the registry's `PACKAGES` dict.
 
 ## Do Not Modify
 
@@ -19,13 +19,28 @@ A backend only registers if it's discoverable — see the `ModelRegistry` docstr
 
 ## Running Tests Locally
 
-Needs NVIDIA Container Toolkit + a GPU. From the repo root:
+Needs NVIDIA Container Toolkit + a GPU. Run tests yourself, directly in these containers. Prefer a targeted run over the full suite
+while iterating:
 
 ```bash
+# plain pytest on a file/dir (no TRT engine building)
+docker compose -f tests/docker-compose.yaml run --rm test_ais_v1_all pytest tests/lmi_common/ -q
+
+# a suite group, building any missing TRT engines first: all-v1 | od | utils | cls | ad-v1 | ad-v2
+docker compose -f tests/docker-compose.yaml run --rm test_ais_v1_all bash tests/run_tests.sh od
+
+# full suite (v1 then v2) — for final verification
 docker compose -f tests/docker-compose.yaml up --build
 ```
 
-See `tests/docker-compose.yaml` and `tests/dockerfile.tests` for the services and images. The `v1`/`v2` split isolates the incompatible Anomalib versions (`test_v1.py` → `1.1.1`, `test_v2.py` → `2.*`, which can't share an env). Each service runs `bash tests/run_tests.sh <arg>`; HTML reports land in `tests/outputs/`.
+The `v1`/`v2` split isolates the incompatible Anomalib versions (`test_v1.py` → `1.1.1`, `test_v2.py` → `2.*`, which can't share an
+env). Anything Anomalib v2 must use the v2 service with `--no-deps` (otherwise `run` triggers the full v1 suite it depends on):
+
+```bash
+docker compose -f tests/docker-compose.yaml run --rm --no-deps test_ais_ad_v2 bash tests/run_tests.sh ad-v2
+```
+
+See `tests/docker-compose.yaml` and `tests/dockerfile.tests` for the services and images. HTML reports land in `tests/outputs/`.
 
 ## Commits
 

--- a/anomaly_detectors/ad_core/anomaly_detector.py
+++ b/anomaly_detectors/ad_core/anomaly_detector.py
@@ -3,9 +3,6 @@ from typing import Any, Dict
 
 from .anomaly_detector_registry import AnomalyDetectorRegistry
 
-# auto register anomaly detectors
-AnomalyDetectorRegistry.auto_register_models()
-
 
 class AnomalyDetector:
     def __new__(cls, metadata: Dict[str, Any], *args, **kwargs):

--- a/anomaly_detectors/ad_core/anomaly_detector_registry.py
+++ b/anomaly_detectors/ad_core/anomaly_detector_registry.py
@@ -8,8 +8,12 @@ logger = logging.getLogger(__name__)
 
 
 class AnomalyDetectorRegistry(ModelRegistry):
-    PACKAGES = ["anomaly_detectors.anomalib_lmi", "anomaly_detectors.ad_core"]
-    TARGET_MODULE_SUFFIXES = [".model"]
+    PACKAGES = {
+        "anomalib": ["anomaly_detectors.anomalib_lmi.v0.model"],
+        "anomalib0": ["anomaly_detectors.anomalib_lmi.v0.model"],
+        "anomalib1": ["anomaly_detectors.anomalib_lmi.v1.model"],
+        "anomalib2": ["anomaly_detectors.anomalib_lmi.v2.model"],
+    }
     _registry = {}
 
     @classmethod

--- a/classifiers/cls_core/classifier.py
+++ b/classifiers/cls_core/classifier.py
@@ -4,9 +4,6 @@ from typing import Any, Dict
 from .classifier_registry import ClassifierRegistry
 from .cls_base import ClassifierBase
 
-# register models automatically
-ClassifierRegistry.auto_register_models()
-
 
 class Classifier(ClassifierBase):
     def __new__(cls, metadata: Dict[str, Any], *args, **kwargs):

--- a/classifiers/cls_core/classifier_registry.py
+++ b/classifiers/cls_core/classifier_registry.py
@@ -2,6 +2,7 @@ from lmi_common.model_registry import ModelRegistry
 
 
 class ClassifierRegistry(ModelRegistry):
-    PACKAGES = ["classifiers.ultralytics_lmi"]
-    TARGET_MODULE_SUFFIXES = [".model"]
+    PACKAGES = {
+        "ultralytics": ["classifiers.ultralytics_lmi.yolo.model"],
+    }
     _registry = {}

--- a/lmi_common/model_registry.py
+++ b/lmi_common/model_registry.py
@@ -1,28 +1,33 @@
 import importlib
 import json
 import logging
-import pkgutil
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
 logger = logging.getLogger(__name__)
+
+
+class DuplicateRegistrationError(ValueError):
+    """Two classes registered the same lookup key — a code bug, so discovery re-raises it instead of skipping."""
 
 
 class ModelRegistry:
     """Base class for metadata-driven model registries.
 
-    Subclasses must define ``PACKAGES``, ``TARGET_MODULE_SUFFIXES``, and
-    ``_registry`` as class attributes — enforced at class definition time.
+    Subclasses must define ``PACKAGES`` and ``_registry`` as class attributes —
+    enforced at class definition time.
 
-    Discovery is lazy: the first ``get_class`` call imports the backend modules
-    to trigger registration. Call ``auto_register_models()`` to discover eagerly.
-    Backend modules that fail to import are skipped; their errors are recorded
-    and included in the ``get_class`` error message on a failed lookup.
+    ``PACKAGES`` maps a lowercase framework name to the modules whose import
+    triggers registration of its backends. ``get_class`` imports only the
+    modules for the requested framework; on an unknown framework or a lookup
+    miss it falls back to importing everything (``auto_register_models``).
+    Modules that fail to import are skipped; their errors are recorded and
+    included in the ``get_class`` error message on a failed lookup. The one
+    exception is ``DuplicateRegistrationError``, which propagates immediately.
 
     Usage::
 
         class MyRegistry(ModelRegistry):
-            PACKAGES = ["my_package.backend_a", "my_package.backend_b"]
-            TARGET_MODULE_SUFFIXES = [".model"]
+            PACKAGES = {"my_fw": ["my_package.backend_a.model"]}
             _registry = {}
 
         @MyRegistry.register({
@@ -34,20 +39,21 @@ class ModelRegistry:
         class MyBackend: ...
     """
 
-    PACKAGES: List[str] = []
-    TARGET_MODULE_SUFFIXES: List[str] = []
+    PACKAGES: Dict[str, List[str]] = {}
     _registry: Dict[Tuple[str, str, str, str, str], Type] = {}
     _discovered: bool = False
+    _attempted_imports: Set[str] = set()
     _failed_imports: Dict[str, str] = {}
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        required = ("PACKAGES", "TARGET_MODULE_SUFFIXES", "_registry")
+        required = ("PACKAGES", "_registry")
         missing = [attr for attr in required if attr not in cls.__dict__]
         if missing:
             raise TypeError(f"{cls.__name__} must define: {', '.join(missing)}")
         cls._discovered = False
+        cls._attempted_imports = set()
         cls._failed_imports = {}
 
     @classmethod
@@ -95,7 +101,7 @@ class ModelRegistry:
                             key = cls._generate_key(framework, model_name, task, version, info)
                             if key in cls._registry:
                                 existing_cls = cls._registry[key]
-                                raise ValueError(
+                                raise DuplicateRegistrationError(
                                     f"Combination already registered: "
                                     f"framework='{framework}', model_name='{model_name}', "
                                     f"task='{task}', version='{version}', info='{json.dumps(info, sort_keys=True)}' "
@@ -119,9 +125,6 @@ class ModelRegistry:
 
     @classmethod
     def get_class(cls, metadata: Dict[str, Any]) -> Type:
-        if not cls._discovered:
-            cls.auto_register_models()
-
         framework: Optional[str] = metadata.get("framework") or metadata.get("package")
         model_name: Optional[str] = metadata.get("model_name") or metadata.get("algorithm")
         task: Optional[str] = cls._get_task(metadata)
@@ -132,9 +135,20 @@ class ModelRegistry:
                 "Lookup metadata must include 'framework' (or 'package'), 'model_name' (or 'algorithm'), and 'task' (or 'model_type')."
             )
 
+        modules = cls.PACKAGES.get(framework.lower())
+        if modules is not None:
+            cls._import_modules(modules)
+        elif not cls._discovered:
+            cls.auto_register_models()
+
         version: str = cls._get_version(metadata, framework)
         key = cls._generate_key(framework, model_name, task, version, info)
         wrapper_cls = cls._registry.get(key)
+
+        if wrapper_cls is None and not cls._discovered:
+            # Self-heal an incomplete PACKAGES entry, and list every known key in the error below.
+            cls.auto_register_models()
+            wrapper_cls = cls._registry.get(key)
 
         if wrapper_cls is None:
             available_keys = "\n".join(map(str, cls._registry.keys()))
@@ -154,27 +168,28 @@ class ModelRegistry:
         return wrapper_cls
 
     @classmethod
-    def auto_register_models(cls):
-        """Dynamically discovers and imports modules to trigger registration.
+    def _import_modules(cls, module_names: List[str]):
+        """Import each module once to trigger registration; record failures in ``_failed_imports``.
 
-        Import failures are logged and recorded in ``_failed_imports`` so a later
-        failed lookup can point at the root cause.
+        ``DuplicateRegistrationError`` propagates — it signals a code bug, not a missing dependency.
         """
-        logger.info(f"Starting auto-discovery of models in: {cls.PACKAGES}")
-        cls._discovered = True
-        for package_name in cls.PACKAGES:
-            try:
-                package = importlib.import_module(package_name)
-            except Exception as e:
-                logger.warning(f"Failed to import package '{package_name}': {e}. Skipping.")
-                cls._failed_imports[package_name] = f"{type(e).__name__}: {e}"
+        for module_name in module_names:
+            if module_name in cls._attempted_imports:
                 continue
-            for _, module_name, _ in pkgutil.walk_packages(package.__path__, package_name + "."):
-                if any(module_name.endswith(suffix) for suffix in cls.TARGET_MODULE_SUFFIXES):
-                    try:
-                        importlib.import_module(module_name)
-                        logger.info(f"Successfully imported {module_name}")
-                        cls._failed_imports.pop(module_name, None)
-                    except Exception as e:
-                        logger.warning(f"Failed to import {module_name}: {e}")
-                        cls._failed_imports[module_name] = f"{type(e).__name__}: {e}"
+            cls._attempted_imports.add(module_name)
+            try:
+                importlib.import_module(module_name)
+                logger.info(f"Successfully imported {module_name}")
+            except DuplicateRegistrationError:
+                raise
+            except Exception as e:
+                logger.warning(f"Failed to import {module_name}: {e}")
+                cls._failed_imports[module_name] = f"{type(e).__name__}: {e}"
+
+    @classmethod
+    def auto_register_models(cls):
+        """Eagerly import every backend module listed in ``PACKAGES``."""
+        all_modules = sorted({module for modules in cls.PACKAGES.values() for module in modules})
+        logger.info(f"Starting auto-discovery of models in: {all_modules}")
+        cls._discovered = True
+        cls._import_modules(all_modules)

--- a/lmi_common/model_registry.py
+++ b/lmi_common/model_registry.py
@@ -13,6 +13,11 @@ class ModelRegistry:
     Subclasses must define ``PACKAGES``, ``TARGET_MODULE_SUFFIXES``, and
     ``_registry`` as class attributes — enforced at class definition time.
 
+    Discovery is lazy: the first ``get_class`` call imports the backend modules
+    to trigger registration. Call ``auto_register_models()`` to discover eagerly.
+    Backend modules that fail to import are skipped; their errors are recorded
+    and included in the ``get_class`` error message on a failed lookup.
+
     Usage::
 
         class MyRegistry(ModelRegistry):
@@ -32,6 +37,8 @@ class ModelRegistry:
     PACKAGES: List[str] = []
     TARGET_MODULE_SUFFIXES: List[str] = []
     _registry: Dict[Tuple[str, str, str, str, str], Type] = {}
+    _discovered: bool = False
+    _failed_imports: Dict[str, str] = {}
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
@@ -40,6 +47,8 @@ class ModelRegistry:
         missing = [attr for attr in required if attr not in cls.__dict__]
         if missing:
             raise TypeError(f"{cls.__name__} must define: {', '.join(missing)}")
+        cls._discovered = False
+        cls._failed_imports = {}
 
     @classmethod
     def _generate_key(
@@ -86,13 +95,13 @@ class ModelRegistry:
                             key = cls._generate_key(framework, model_name, task, version, info)
                             if key in cls._registry:
                                 existing_cls = cls._registry[key]
-                                logger.warning(
+                                raise ValueError(
                                     f"Combination already registered: "
                                     f"framework='{framework}', model_name='{model_name}', "
                                     f"task='{task}', version='{version}', info='{json.dumps(info, sort_keys=True)}' "
-                                    f"points to {existing_cls.__module__}. Cannot re-register with {wrapper_cls.__module__}."
+                                    f"points to {existing_cls.__module__}.{existing_cls.__name__}. "
+                                    f"Cannot re-register with {wrapper_cls.__module__}.{wrapper_cls.__name__}."
                                 )
-                                continue
                             cls._registry[key] = wrapper_cls
             return wrapper_cls
 
@@ -110,6 +119,9 @@ class ModelRegistry:
 
     @classmethod
     def get_class(cls, metadata: Dict[str, Any]) -> Type:
+        if not cls._discovered:
+            cls.auto_register_models()
+
         framework: Optional[str] = metadata.get("framework") or metadata.get("package")
         model_name: Optional[str] = metadata.get("model_name") or metadata.get("algorithm")
         task: Optional[str] = cls._get_task(metadata)
@@ -126,30 +138,43 @@ class ModelRegistry:
 
         if wrapper_cls is None:
             available_keys = "\n".join(map(str, cls._registry.keys()))
+            failed_note = ""
+            if cls._failed_imports:
+                failed_lines = "\n".join(f"  {module}: {error}" for module, error in cls._failed_imports.items())
+                failed_note = f"\nNote: these backend modules failed to import and could not register:\n{failed_lines}"
             raise ValueError(
                 f"No class found registered for combination: "
                 f"framework='{framework.lower()}', model_name='{model_name.lower()}', "
                 f"task='{task.lower()}', version='{version}', info='{json.dumps(info, sort_keys=True)}'.\n"
                 f"Lookup key: {key}\n"
                 f"Available keys:\n{available_keys}"
+                f"{failed_note}"
             )
 
         return wrapper_cls
 
     @classmethod
     def auto_register_models(cls):
-        """Dynamically discovers and imports modules to trigger registration."""
+        """Dynamically discovers and imports modules to trigger registration.
+
+        Import failures are logged and recorded in ``_failed_imports`` so a later
+        failed lookup can point at the root cause.
+        """
         logger.info(f"Starting auto-discovery of models in: {cls.PACKAGES}")
+        cls._discovered = True
         for package_name in cls.PACKAGES:
             try:
                 package = importlib.import_module(package_name)
-            except ImportError as e:
+            except Exception as e:
                 logger.warning(f"Failed to import package '{package_name}': {e}. Skipping.")
+                cls._failed_imports[package_name] = f"{type(e).__name__}: {e}"
                 continue
             for _, module_name, _ in pkgutil.walk_packages(package.__path__, package_name + "."):
                 if any(module_name.endswith(suffix) for suffix in cls.TARGET_MODULE_SUFFIXES):
                     try:
                         importlib.import_module(module_name)
                         logger.info(f"Successfully imported {module_name}")
-                    except ImportError as e:
+                        cls._failed_imports.pop(module_name, None)
+                    except Exception as e:
                         logger.warning(f"Failed to import {module_name}: {e}")
+                        cls._failed_imports[module_name] = f"{type(e).__name__}: {e}"

--- a/object_detectors/od_core/object_detector.py
+++ b/object_detectors/od_core/object_detector.py
@@ -3,9 +3,6 @@ from typing import Any, Dict
 
 from .object_detector_registry import ObjectDetectorRegistry
 
-# register models automatically
-ObjectDetectorRegistry.auto_register_models()
-
 
 class ObjectDetector:
     """Factory that instantiates the correct object-detector backend from a metadata dict.

--- a/object_detectors/od_core/object_detector_registry.py
+++ b/object_detectors/od_core/object_detector_registry.py
@@ -2,11 +2,10 @@ from lmi_common.model_registry import ModelRegistry
 
 
 class ObjectDetectorRegistry(ModelRegistry):
-    PACKAGES = [
-        "object_detectors.ultralytics_lmi",
-        "object_detectors.detectron2_lmi",
-        "object_detectors.yolov5_lmi",
-        "object_detectors.rf_detr_lmi",
-    ]
-    TARGET_MODULE_SUFFIXES = [".model"]
+    PACKAGES = {
+        "ultralytics": ["object_detectors.ultralytics_lmi.yolo.model", "object_detectors.yolov5_lmi.model"],
+        "ultralytics8": ["object_detectors.ultralytics_lmi.yolo.model"],
+        "detectron2": ["object_detectors.detectron2_lmi.model"],
+        "rfdetr": ["object_detectors.rf_detr_lmi.model"],
+    }
     _registry = {}

--- a/tests/lmi_common/test_model_registry.py
+++ b/tests/lmi_common/test_model_registry.py
@@ -27,8 +27,10 @@ class FakeRegistry(ModelRegistry):
 def clear_registry():
     """Reset FakeRegistry between tests so registrations don't bleed over."""
     FakeRegistry._registry.clear()
+    FakeRegistry._failed_imports.clear()
     yield
     FakeRegistry._registry.clear()
+    FakeRegistry._failed_imports.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -168,11 +170,11 @@ def test_register_empty_list_field_raises():
 
 
 # ---------------------------------------------------------------------------
-# register() — duplicate key (should warn, not raise)
+# register() — duplicate key (should raise)
 # ---------------------------------------------------------------------------
 
 
-def test_register_duplicate_key_logs_warning(caplog):
+def test_register_duplicate_key_raises():
     @FakeRegistry.register(
         metadata=dict(
             frameworks=["fw_a"],
@@ -184,7 +186,7 @@ def test_register_duplicate_key_logs_warning(caplog):
     class FirstModel:
         pass
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError, match="already registered"):
 
         @FakeRegistry.register(
             metadata=dict(
@@ -197,10 +199,9 @@ def test_register_duplicate_key_logs_warning(caplog):
         class SecondModel:
             pass
 
-    # First registration should win
+    # First registration stays in place
     key = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
     assert FakeRegistry._registry[key] is FirstModel
-    assert any("already registered" in record.message.lower() for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -355,3 +356,43 @@ def test_auto_register_models_bad_package_logs_warning(caplog):
 
     assert any("this.package.does.not.exist" in record.message for record in caplog.records)
     assert len(RegistryWithBadPackage._registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Lazy discovery and failed-import reporting
+# ---------------------------------------------------------------------------
+
+
+def test_get_class_triggers_discovery_once(monkeypatch):
+    class LazyRegistry(ModelRegistry):
+        PACKAGES = []
+        TARGET_MODULE_SUFFIXES = [".model"]
+        _registry = {}
+
+    calls = []
+    original = LazyRegistry.auto_register_models
+
+    def spy():
+        calls.append(1)
+        original()
+
+    monkeypatch.setattr(LazyRegistry, "auto_register_models", spy)
+
+    @LazyRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
+    class Dummy:
+        pass
+
+    LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
+    LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
+    assert len(calls) == 1, "Discovery should run once, on the first lookup"
+
+
+def test_failed_import_is_recorded_and_surfaced_in_lookup_error():
+    class RegistryWithBadPackage(ModelRegistry):
+        PACKAGES = ["this.package.does.not.exist"]
+        TARGET_MODULE_SUFFIXES = [".model"]
+        _registry = {}
+
+    with pytest.raises(ValueError, match="failed to import"):
+        RegistryWithBadPackage.get_class({"framework": "fw", "model_name": "m", "task": "t"})
+    assert "this.package.does.not.exist" in RegistryWithBadPackage._failed_imports

--- a/tests/lmi_common/test_model_registry.py
+++ b/tests/lmi_common/test_model_registry.py
@@ -2,7 +2,8 @@ import logging
 
 import pytest
 
-from lmi_common.model_registry import ModelRegistry
+import lmi_common.model_registry as model_registry_module
+from lmi_common.model_registry import DuplicateRegistrationError, ModelRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class FakeRegistry(ModelRegistry):
-    PACKAGES = []
-    TARGET_MODULE_SUFFIXES = [".model"]
+    PACKAGES = {}
     _registry = {}
 
 
@@ -26,11 +26,16 @@ class FakeRegistry(ModelRegistry):
 @pytest.fixture(autouse=True)
 def clear_registry():
     """Reset FakeRegistry between tests so registrations don't bleed over."""
-    FakeRegistry._registry.clear()
-    FakeRegistry._failed_imports.clear()
+
+    def reset():
+        FakeRegistry._registry.clear()
+        FakeRegistry._failed_imports.clear()
+        FakeRegistry._attempted_imports.clear()
+        FakeRegistry._discovered = False
+
+    reset()
     yield
-    FakeRegistry._registry.clear()
-    FakeRegistry._failed_imports.clear()
+    reset()
 
 
 # ---------------------------------------------------------------------------
@@ -42,22 +47,20 @@ def test_subclass_missing_all_required_attributes_raises():
     with pytest.raises(TypeError, match="must define"):
 
         class BadRegistry(ModelRegistry):
-            pass  # missing PACKAGES, TARGET_MODULE_SUFFIXES, _registry
+            pass  # missing PACKAGES, _registry
 
 
 def test_subclass_missing_one_required_attribute_raises():
     with pytest.raises(TypeError, match="must define"):
 
         class PartialRegistry(ModelRegistry):
-            PACKAGES = []
-            TARGET_MODULE_SUFFIXES = [".model"]
+            PACKAGES = {}
             # missing _registry
 
 
 def test_subclass_with_all_required_attributes_is_fine():
     class GoodRegistry(ModelRegistry):
-        PACKAGES = []
-        TARGET_MODULE_SUFFIXES = []
+        PACKAGES = {}
         _registry = {}
 
     assert hasattr(GoodRegistry, "_registry")
@@ -186,7 +189,7 @@ def test_register_duplicate_key_raises():
     class FirstModel:
         pass
 
-    with pytest.raises(ValueError, match="already registered"):
+    with pytest.raises(DuplicateRegistrationError, match="already registered"):
 
         @FakeRegistry.register(
             metadata=dict(
@@ -345,17 +348,16 @@ def test_auto_register_models_empty_packages_is_noop():
     assert len(FakeRegistry._registry) == 0
 
 
-def test_auto_register_models_bad_package_logs_warning(caplog):
-    class RegistryWithBadPackage(ModelRegistry):
-        PACKAGES = ["this.package.does.not.exist"]
-        TARGET_MODULE_SUFFIXES = [".model"]
+def test_auto_register_models_bad_module_logs_warning(caplog):
+    class RegistryWithBadModule(ModelRegistry):
+        PACKAGES = {"fw": ["this.module.does.not.exist"]}
         _registry = {}
 
     with caplog.at_level(logging.WARNING):
-        RegistryWithBadPackage.auto_register_models()
+        RegistryWithBadModule.auto_register_models()
 
-    assert any("this.package.does.not.exist" in record.message for record in caplog.records)
-    assert len(RegistryWithBadPackage._registry) == 0
+    assert any("this.module.does.not.exist" in record.message for record in caplog.records)
+    assert len(RegistryWithBadModule._registry) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -363,10 +365,9 @@ def test_auto_register_models_bad_package_logs_warning(caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_get_class_triggers_discovery_once(monkeypatch):
+def test_get_class_unknown_framework_triggers_full_discovery_once(monkeypatch):
     class LazyRegistry(ModelRegistry):
-        PACKAGES = []
-        TARGET_MODULE_SUFFIXES = [".model"]
+        PACKAGES = {}
         _registry = {}
 
     calls = []
@@ -384,15 +385,83 @@ def test_get_class_triggers_discovery_once(monkeypatch):
 
     LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
     LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    assert len(calls) == 1, "Discovery should run once, on the first lookup"
+    assert len(calls) == 1, "Full discovery should run once, on the first lookup"
+
+
+def test_get_class_imports_only_requested_framework(monkeypatch):
+    class TargetedRegistry(ModelRegistry):
+        PACKAGES = {"fw_a": ["fake.module_a"], "fw_b": ["fake.module_b"]}
+        _registry = {}
+
+    imported = []
+
+    def fake_import(name):
+        imported.append(name)
+        if name == "fake.module_a":
+
+            @TargetedRegistry.register(metadata=dict(frameworks=["fw_a"], model_names=["m"], tasks=["t"], versions=["v1"]))
+            class BackendA:
+                pass
+
+    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
+
+    cls = TargetedRegistry.get_class({"framework": "fw_a", "model_name": "m", "task": "t"})
+    assert cls.__name__ == "BackendA"
+    assert imported == ["fake.module_a"], "Only the requested framework's module should be imported"
+
+
+def test_get_class_miss_falls_back_to_full_discovery(monkeypatch):
+    """An incomplete PACKAGES entry self-heals: a miss after the targeted import triggers full discovery."""
+
+    class IncompleteRegistry(ModelRegistry):
+        PACKAGES = {"fw_a": ["fake.module_a"], "fw_b": ["fake.module_b"]}
+        _registry = {}
+
+    imported = []
+
+    def fake_import(name):
+        imported.append(name)
+        if name == "fake.module_b":
+            # fw_a's backend actually lives in fw_b's module — missing from the fw_a map entry
+            @IncompleteRegistry.register(metadata=dict(frameworks=["fw_a"], model_names=["m"], tasks=["t"], versions=["v1"]))
+            class BackendA:
+                pass
+
+    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
+
+    cls = IncompleteRegistry.get_class({"framework": "fw_a", "model_name": "m", "task": "t"})
+    assert cls.__name__ == "BackendA"
+    assert imported == ["fake.module_a", "fake.module_b"]
+
+
+def test_duplicate_registration_during_import_propagates(monkeypatch):
+    """A duplicate key is a code bug: it must not be downgraded to a recorded import failure."""
+
+    class CollidingRegistry(ModelRegistry):
+        PACKAGES = {"fw": ["fake.colliding_module"]}
+        _registry = {}
+
+    def fake_import(name):
+        @CollidingRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
+        class First:
+            pass
+
+        @CollidingRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
+        class Second:
+            pass
+
+    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
+
+    with pytest.raises(DuplicateRegistrationError, match="already registered"):
+        CollidingRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
+    assert "fake.colliding_module" not in CollidingRegistry._failed_imports
 
 
 def test_failed_import_is_recorded_and_surfaced_in_lookup_error():
-    class RegistryWithBadPackage(ModelRegistry):
-        PACKAGES = ["this.package.does.not.exist"]
-        TARGET_MODULE_SUFFIXES = [".model"]
+    class RegistryWithBadModule(ModelRegistry):
+        PACKAGES = {"fw": ["this.module.does.not.exist"]}
         _registry = {}
 
     with pytest.raises(ValueError, match="failed to import"):
-        RegistryWithBadPackage.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    assert "this.package.does.not.exist" in RegistryWithBadPackage._failed_imports
+        RegistryWithBadModule.get_class({"framework": "fw", "model_name": "m", "task": "t"})
+    assert "this.module.does.not.exist" in RegistryWithBadModule._failed_imports


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
- defer auto_register_models() to the first get_class() call; importing a factory no longer imports every backend
- record backend import failures (any exception, not just ImportError) and surface them in the get_class() lookup error
- raise on duplicate registry keys instead of warning

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
