### PR TITLE
refactor: centralize backend registration in declarative BACKENDS tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ Guidance for Claude Code when working in this repository.
 
 ## Adding a Backend
 
-A backend only registers if it's discoverable — see the `ModelRegistry` docstring in `lmi_common/model_registry.py` for the `PACKAGES` / `@register` contract. New backends need a framework → module entry in the registry's `PACKAGES` dict.
+Backends are declared in each registry's `BACKENDS` table — see the `ModelRegistry` docstring in `lmi_common/model_registry.py`.
+Add one entry with the metadata lists and a `"module:ClassName"` `class_path`. Keep registry modules free of backend imports so
+duplicate-key validation (run at registry import) works in any environment.
 
 ## Do Not Modify
 

--- a/anomaly_detectors/ad_core/anomaly_detector_registry.py
+++ b/anomaly_detectors/ad_core/anomaly_detector_registry.py
@@ -8,13 +8,29 @@ logger = logging.getLogger(__name__)
 
 
 class AnomalyDetectorRegistry(ModelRegistry):
-    PACKAGES = {
-        "anomalib": ["anomaly_detectors.anomalib_lmi.v0.model"],
-        "anomalib0": ["anomaly_detectors.anomalib_lmi.v0.model"],
-        "anomalib1": ["anomaly_detectors.anomalib_lmi.v1.model"],
-        "anomalib2": ["anomaly_detectors.anomalib_lmi.v2.model"],
-    }
-    _registry = {}
+    BACKENDS = [
+        {
+            "frameworks": ["anomalib", "anomalib0"],
+            "model_names": ["patchcore", "padim"],
+            "tasks": ["anomalydetection", "seg"],
+            "versions": ["v0", "v1"],
+            "class_path": "anomaly_detectors.anomalib_lmi.v0.model:AnomalyModel",
+        },
+        {
+            "frameworks": ["anomalib1"],
+            "model_names": ["patchcore", "padim", "efficientad"],
+            "tasks": ["anomalydetection", "seg"],
+            "versions": ["v1"],
+            "class_path": "anomaly_detectors.anomalib_lmi.v1.model:AnomalyModel",
+        },
+        {
+            "frameworks": ["anomalib2"],
+            "model_names": ["patchcore", "padim", "efficientad"],
+            "tasks": ["anomalydetection", "seg"],
+            "versions": ["v2"],
+            "class_path": "anomaly_detectors.anomalib_lmi.v2.model:AnomalyModel",
+        },
+    ]
 
     @classmethod
     def _get_version(cls, metadata: Dict[str, Any], framework: str) -> str:

--- a/anomaly_detectors/ad_core/anomaly_detector_registry.py
+++ b/anomaly_detectors/ad_core/anomaly_detector_registry.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 class AnomalyDetectorRegistry(ModelRegistry):
     BACKENDS = [
         {
-            "frameworks": ["anomalib", "anomalib0"],
+            "frameworks": ["anomalib0"],
             "model_names": ["patchcore", "padim"],
             "tasks": ["anomalydetection", "seg"],
-            "versions": ["v0", "v1"],
+            "versions": ["v0"],
             "class_path": "anomaly_detectors.anomalib_lmi.v0.model:AnomalyModel",
         },
         {
@@ -41,8 +41,7 @@ class AnomalyDetectorRegistry(ModelRegistry):
         match = re.search(r"(\d+)$", framework)
         if match:
             return f"v{match.group(1)}"
-        if framework.lower() != "anomalib":  # bare "anomalib" is a known legacy name
-            logger.warning(f"No 'version' in metadata and no trailing digits in framework '{framework}'; defaulting to 'v1'.")
+        logger.warning(f"No 'version' in metadata and no trailing digits in framework '{framework}'; defaulting to 'v1'.")
         return "v1"
 
     @classmethod

--- a/anomaly_detectors/anomalib_lmi/v0/model.py
+++ b/anomaly_detectors/anomalib_lmi/v0/model.py
@@ -7,21 +7,12 @@ import numpy as np
 import torch
 
 import lmi_utils.gadget_utils.pipeline_utils as pipeline_utils
-from anomaly_detectors.ad_core.anomaly_detector_registry import AnomalyDetectorRegistry
 
 from ..base import Anomalib_Base
 
 Binding = namedtuple("Binding", ("name", "dtype", "shape", "data", "ptr"))
 
 
-@AnomalyDetectorRegistry.register(
-    metadata=dict(
-        frameworks=["anomalib", "anomalib0"],
-        model_names=["patchcore", "padim"],
-        tasks=["anomalydetection", "seg"],
-        versions=["v0", "v1"],
-    )
-)
 class AnomalyModel(Anomalib_Base):
     """
     Desc: Class used for AD model inference.

--- a/anomaly_detectors/anomalib_lmi/v1/model.py
+++ b/anomaly_detectors/anomalib_lmi/v1/model.py
@@ -4,7 +4,6 @@ from typing import Any, Iterable
 
 import torch
 
-from anomaly_detectors.ad_core.anomaly_detector_registry import AnomalyDetectorRegistry
 from lmi_common.model_factory import ModelFactory
 
 from ..base import Anomalib_Base, AnomalibPT, register_backends
@@ -28,14 +27,6 @@ class AnomalibPTv1(AnomalibPT):
         raise TypeError(f"Unknown prediction type: {type(preds)}")
 
 
-@AnomalyDetectorRegistry.register(
-    metadata=dict(
-        frameworks=["anomalib1"],
-        model_names=["patchcore", "padim", "efficientad"],
-        tasks=["anomalydetection", "seg"],
-        versions=["v1"],
-    )
-)
 class AnomalyModel(ModelFactory, Anomalib_Base):
     """AD model factory for Anomalib v1. Dispatches on file extension.
 

--- a/anomaly_detectors/anomalib_lmi/v2/model.py
+++ b/anomaly_detectors/anomalib_lmi/v2/model.py
@@ -3,7 +3,6 @@ from typing import Any, Iterable
 
 import torch
 
-from anomaly_detectors.ad_core.anomaly_detector_registry import AnomalyDetectorRegistry
 from lmi_common.model_factory import ModelFactory
 
 from ..base import Anomalib_Base, AnomalibPT, register_backends
@@ -23,14 +22,6 @@ class AnomalibPTv2(AnomalibPT):
         return preds.anomaly_map
 
 
-@AnomalyDetectorRegistry.register(
-    metadata=dict(
-        frameworks=["anomalib2"],
-        model_names=["patchcore", "padim", "efficientad"],
-        tasks=["anomalydetection", "seg"],
-        versions=["v2"],
-    )
-)
 class AnomalyModel(ModelFactory, Anomalib_Base):
     """AD model factory for Anomalib v2. Dispatches on file extension.
 

--- a/classifiers/cls_core/classifier_registry.py
+++ b/classifiers/cls_core/classifier_registry.py
@@ -2,7 +2,12 @@ from lmi_common.model_registry import ModelRegistry
 
 
 class ClassifierRegistry(ModelRegistry):
-    PACKAGES = {
-        "ultralytics": ["classifiers.ultralytics_lmi.yolo.model"],
-    }
-    _registry = {}
+    BACKENDS = [
+        {
+            "frameworks": ["ultralytics"],
+            "model_names": ["yolo", "yolov8", "yolov11"],
+            "tasks": ["classification"],
+            "versions": ["v1"],
+            "class_path": "classifiers.ultralytics_lmi.yolo.model:YoloCls",
+        },
+    ]

--- a/classifiers/ultralytics_lmi/yolo/model.py
+++ b/classifiers/ultralytics_lmi/yolo/model.py
@@ -8,19 +8,10 @@ from PIL import Image
 from ultralytics.data.augment import classify_transforms
 from ultralytics.utils.torch_utils import smart_inference_mode
 
-from classifiers.cls_core.classifier_registry import ClassifierRegistry
 from classifiers.cls_core.cls_base import ClassifierBase
 from lmi_common.yolo_core import YoloCore
 
 
-@ClassifierRegistry.register(
-    metadata=dict(
-        versions=["v1"],
-        model_names=["yolo", "yolov8", "yolov11"],
-        tasks=["classification"],
-        frameworks=["ultralytics"],
-    )
-)
 class YoloCls(YoloCore, ClassifierBase):
     logger = logging.getLogger("yolo-cls")
 

--- a/lmi_common/model_registry.py
+++ b/lmi_common/model_registry.py
@@ -1,60 +1,53 @@
 import importlib
 import json
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 logger = logging.getLogger(__name__)
 
 
 class DuplicateRegistrationError(ValueError):
-    """Two classes registered the same lookup key — a code bug, so discovery re-raises it instead of skipping."""
+    """Two ``BACKENDS`` entries expand to the same lookup key — a code bug, raised when the registry class is defined."""
 
 
 class ModelRegistry:
     """Base class for metadata-driven model registries.
 
-    Subclasses must define ``PACKAGES`` and ``_registry`` as class attributes —
-    enforced at class definition time.
-
-    ``PACKAGES`` maps a lowercase framework name to the modules whose import
-    triggers registration of its backends. ``get_class`` imports only the
-    modules for the requested framework; on an unknown framework or a lookup
-    miss it falls back to importing everything (``auto_register_models``).
-    Modules that fail to import are skipped; their errors are recorded and
-    included in the ``get_class`` error message on a failed lookup. The one
-    exception is ``DuplicateRegistrationError``, which propagates immediately.
+    Subclasses declare every backend in a ``BACKENDS`` table. The table is
+    expanded and validated at class definition time, so duplicate lookup keys
+    raise ``DuplicateRegistrationError`` as soon as the registry module is
+    imported — without importing any backend.
 
     Usage::
 
         class MyRegistry(ModelRegistry):
-            PACKAGES = {"my_fw": ["my_package.backend_a.model"]}
-            _registry = {}
+            BACKENDS = [
+                {
+                    "frameworks": ["my_fw"],
+                    "model_names": ["my_model"],
+                    "tasks": ["detect"],
+                    "versions": ["v1"],
+                    "class_path": "my_package.backend_a.model:MyBackend",
+                },
+            ]
 
-        @MyRegistry.register({
-            "frameworks": ["my_fw"],
-            "model_names": ["my_model"],
-            "tasks": ["detect"],
-            "versions": ["v1"],
-        })
-        class MyBackend: ...
+    ``class_path`` is a ``"module:ClassName"`` import string; registry modules
+    must not import backends directly so the table stays checkable in any
+    environment. ``get_class`` imports only the single module that provides the
+    requested backend and caches the resolved class.
     """
 
-    PACKAGES: Dict[str, List[str]] = {}
-    _registry: Dict[Tuple[str, str, str, str, str], Type] = {}
-    _discovered: bool = False
-    _attempted_imports: Set[str] = set()
-    _failed_imports: Dict[str, str] = {}
+    BACKENDS: List[Dict[str, Any]] = []
+    _key_map: Dict[Tuple[str, str, str, str, str], str] = {}
+    _class_cache: Dict[Tuple[str, str, str, str, str], Type] = {}
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        required = ("PACKAGES", "_registry")
-        missing = [attr for attr in required if attr not in cls.__dict__]
-        if missing:
-            raise TypeError(f"{cls.__name__} must define: {', '.join(missing)}")
-        cls._discovered = False
-        cls._attempted_imports = set()
-        cls._failed_imports = {}
+        if "BACKENDS" not in cls.__dict__:
+            raise TypeError(f"{cls.__name__} must define: BACKENDS")
+        cls._class_cache = {}
+        cls._key_map = cls._expand_backends()
 
     @classmethod
     def _generate_key(
@@ -74,44 +67,40 @@ class ModelRegistry:
         )
 
     @classmethod
-    def register(cls, metadata: Dict[str, Any]):
-        logger.debug(f"Registering class with metadata: {metadata}")
-        frameworks: Optional[List[str]] = metadata.get("frameworks")
-        model_names: Optional[List[str]] = metadata.get("model_names")
-        tasks: Optional[List[str]] = metadata.get("tasks")
-        versions: Optional[List[str]] = metadata.get("versions")
-        info: Dict[str, Any] = metadata.get("info", {})
+    def _expand_backends(cls) -> Dict[Tuple[str, str, str, str, str], str]:
+        """Expand ``BACKENDS`` into a lookup-key → class_path map, validating entries and rejecting duplicate keys."""
+        key_map: Dict[Tuple[str, str, str, str, str], str] = {}
+        for entry in cls.BACKENDS:
+            frameworks = entry.get("frameworks")
+            model_names = entry.get("model_names")
+            tasks = entry.get("tasks")
+            versions = entry.get("versions")
+            info: Dict[str, Any] = entry.get("info", {})
+            class_path = entry.get("class_path")
 
-        if (
-            not isinstance(frameworks, list)
-            or not isinstance(model_names, list)
-            or not isinstance(tasks, list)
-            or not isinstance(versions, list)
-        ):
-            raise TypeError("'frameworks', 'model_names', 'tasks', and 'versions' must be lists.")
+            if not all(isinstance(field, list) for field in (frameworks, model_names, tasks, versions)):
+                raise TypeError(f"{cls.__name__}: 'frameworks', 'model_names', 'tasks', and 'versions' must be lists in entry: {entry}")
+            if not all([frameworks, model_names, tasks, versions]):
+                raise ValueError(
+                    f"{cls.__name__}: 'frameworks', 'model_names', 'tasks', and 'versions' must be non-empty in entry: {entry}"
+                )
+            if not isinstance(class_path, str) or ":" not in class_path:
+                raise ValueError(f"{cls.__name__}: 'class_path' must be a 'module:ClassName' string in entry: {entry}")
 
-        if not all([frameworks, model_names, tasks, versions]):
-            raise ValueError("Metadata must include 'frameworks', 'model_names', 'tasks', and 'versions' (all non-empty lists).")
-
-        def decorator(wrapper_cls: Type) -> Type:
             for framework in frameworks:
                 for model_name in model_names:
                     for task in tasks:
                         for version in versions:
                             key = cls._generate_key(framework, model_name, task, version, info)
-                            if key in cls._registry:
-                                existing_cls = cls._registry[key]
+                            if key in key_map:
                                 raise DuplicateRegistrationError(
-                                    f"Combination already registered: "
+                                    f"{cls.__name__}: combination already registered: "
                                     f"framework='{framework}', model_name='{model_name}', "
                                     f"task='{task}', version='{version}', info='{json.dumps(info, sort_keys=True)}' "
-                                    f"points to {existing_cls.__module__}.{existing_cls.__name__}. "
-                                    f"Cannot re-register with {wrapper_cls.__module__}.{wrapper_cls.__name__}."
+                                    f"points to '{key_map[key]}'. Cannot re-register with '{class_path}'."
                                 )
-                            cls._registry[key] = wrapper_cls
-            return wrapper_cls
-
-        return decorator
+                            key_map[key] = class_path
+        return key_map
 
     @classmethod
     def _get_version(cls, metadata: Dict[str, Any], framework: str) -> str:
@@ -135,61 +124,40 @@ class ModelRegistry:
                 "Lookup metadata must include 'framework' (or 'package'), 'model_name' (or 'algorithm'), and 'task' (or 'model_type')."
             )
 
-        modules = cls.PACKAGES.get(framework.lower())
-        if modules is not None:
-            cls._import_modules(modules)
-        elif not cls._discovered:
-            cls.auto_register_models()
-
         version: str = cls._get_version(metadata, framework)
         key = cls._generate_key(framework, model_name, task, version, info)
-        wrapper_cls = cls._registry.get(key)
 
-        if wrapper_cls is None and not cls._discovered:
-            # Self-heal an incomplete PACKAGES entry, and list every known key in the error below.
-            cls.auto_register_models()
-            wrapper_cls = cls._registry.get(key)
+        wrapper_cls = cls._class_cache.get(key)
+        if wrapper_cls is not None:
+            return wrapper_cls
 
-        if wrapper_cls is None:
-            available_keys = "\n".join(map(str, cls._registry.keys()))
-            failed_note = ""
-            if cls._failed_imports:
-                failed_lines = "\n".join(f"  {module}: {error}" for module, error in cls._failed_imports.items())
-                failed_note = f"\nNote: these backend modules failed to import and could not register:\n{failed_lines}"
+        class_path = cls._key_map.get(key)
+        if class_path is None:
+            available_keys = "\n".join(map(str, sorted(cls._key_map)))
             raise ValueError(
-                f"No class found registered for combination: "
+                f"No backend registered for combination: "
                 f"framework='{framework.lower()}', model_name='{model_name.lower()}', "
                 f"task='{task.lower()}', version='{version}', info='{json.dumps(info, sort_keys=True)}'.\n"
                 f"Lookup key: {key}\n"
                 f"Available keys:\n{available_keys}"
-                f"{failed_note}"
             )
 
+        wrapper_cls = cls._resolve_class_path(class_path)
+        cls._class_cache[key] = wrapper_cls
         return wrapper_cls
 
     @classmethod
-    def _import_modules(cls, module_names: List[str]):
-        """Import each module once to trigger registration; record failures in ``_failed_imports``.
-
-        ``DuplicateRegistrationError`` propagates — it signals a code bug, not a missing dependency.
-        """
-        for module_name in module_names:
-            if module_name in cls._attempted_imports:
-                continue
-            cls._attempted_imports.add(module_name)
-            try:
-                importlib.import_module(module_name)
-                logger.info(f"Successfully imported {module_name}")
-            except DuplicateRegistrationError:
-                raise
-            except Exception as e:
-                logger.warning(f"Failed to import {module_name}: {e}")
-                cls._failed_imports[module_name] = f"{type(e).__name__}: {e}"
-
-    @classmethod
-    def auto_register_models(cls):
-        """Eagerly import every backend module listed in ``PACKAGES``."""
-        all_modules = sorted({module for modules in cls.PACKAGES.values() for module in modules})
-        logger.info(f"Starting auto-discovery of models in: {all_modules}")
-        cls._discovered = True
-        cls._import_modules(all_modules)
+    def _resolve_class_path(cls, class_path: str) -> Type:
+        """Import the backend module named by ``class_path`` and return its class."""
+        module_name, _, class_name = class_path.partition(":")
+        try:
+            module = importlib.import_module(module_name)
+            logger.info(f"Successfully imported {module_name}")
+        except Exception as e:
+            raise ImportError(f"Backend module '{module_name}' failed to import: {type(e).__name__}: {e}") from e
+        try:
+            return getattr(module, class_name)
+        except AttributeError as e:
+            raise ImportError(
+                f"Module '{module_name}' has no attribute '{class_name}'; check 'class_path' in {cls.__name__}.BACKENDS."
+            ) from e

--- a/lmi_common/model_registry.py
+++ b/lmi_common/model_registry.py
@@ -1,5 +1,4 @@
 import importlib
-import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -38,8 +37,8 @@ class ModelRegistry:
     """
 
     BACKENDS: List[Dict[str, Any]] = []
-    _key_map: Dict[Tuple[str, str, str, str, str], str] = {}
-    _class_cache: Dict[Tuple[str, str, str, str, str], Type] = {}
+    _key_map: Dict[Tuple[str, str, str, str], str] = {}
+    _class_cache: Dict[Tuple[str, str, str, str], Type] = {}
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
@@ -56,26 +55,23 @@ class ModelRegistry:
         model_name: str,
         task: str,
         version: str,
-        info: Dict[str, Any],
-    ) -> Tuple[str, str, str, str, str]:
+    ) -> Tuple[str, str, str, str]:
         return (
             framework.lower(),
             model_name.lower(),
             task.lower(),
             version,
-            json.dumps(info, sort_keys=True),
         )
 
     @classmethod
-    def _expand_backends(cls) -> Dict[Tuple[str, str, str, str, str], str]:
+    def _expand_backends(cls) -> Dict[Tuple[str, str, str, str], str]:
         """Expand ``BACKENDS`` into a lookup-key → class_path map, validating entries and rejecting duplicate keys."""
-        key_map: Dict[Tuple[str, str, str, str, str], str] = {}
+        key_map: Dict[Tuple[str, str, str, str], str] = {}
         for entry in cls.BACKENDS:
             frameworks = entry.get("frameworks")
             model_names = entry.get("model_names")
             tasks = entry.get("tasks")
             versions = entry.get("versions")
-            info: Dict[str, Any] = entry.get("info", {})
             class_path = entry.get("class_path")
 
             if not all(isinstance(field, list) for field in (frameworks, model_names, tasks, versions)):
@@ -91,12 +87,12 @@ class ModelRegistry:
                 for model_name in model_names:
                     for task in tasks:
                         for version in versions:
-                            key = cls._generate_key(framework, model_name, task, version, info)
+                            key = cls._generate_key(framework, model_name, task, version)
                             if key in key_map:
                                 raise DuplicateRegistrationError(
                                     f"{cls.__name__}: combination already registered: "
                                     f"framework='{framework}', model_name='{model_name}', "
-                                    f"task='{task}', version='{version}', info='{json.dumps(info, sort_keys=True)}' "
+                                    f"task='{task}', version='{version}' "
                                     f"points to '{key_map[key]}'. Cannot re-register with '{class_path}'."
                                 )
                             key_map[key] = class_path
@@ -117,7 +113,6 @@ class ModelRegistry:
         framework: Optional[str] = metadata.get("framework") or metadata.get("package")
         model_name: Optional[str] = metadata.get("model_name") or metadata.get("algorithm")
         task: Optional[str] = cls._get_task(metadata)
-        info: Dict[str, Any] = metadata.get("info", {})
 
         if not all([framework, model_name, task]):
             raise ValueError(
@@ -125,7 +120,7 @@ class ModelRegistry:
             )
 
         version: str = cls._get_version(metadata, framework)
-        key = cls._generate_key(framework, model_name, task, version, info)
+        key = cls._generate_key(framework, model_name, task, version)
 
         wrapper_cls = cls._class_cache.get(key)
         if wrapper_cls is not None:
@@ -137,7 +132,7 @@ class ModelRegistry:
             raise ValueError(
                 f"No backend registered for combination: "
                 f"framework='{framework.lower()}', model_name='{model_name.lower()}', "
-                f"task='{task.lower()}', version='{version}', info='{json.dumps(info, sort_keys=True)}'.\n"
+                f"task='{task.lower()}', version='{version}'.\n"
                 f"Lookup key: {key}\n"
                 f"Available keys:\n{available_keys}"
             )

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -119,11 +119,6 @@ class PipelineBase(metaclass=ABCMeta):
         meta_copy = metadata.copy()
         model_type = meta_copy["model_type"].lower()
 
-        # Default to v1, but downgrade to v0 for specific cases
-        meta_copy.setdefault("version", "v1")
-        if meta_copy["package"] == "detectron2":
-            meta_copy["version"] = "v0"
-
         model_classes: Dict[str, Type] = {
             "anomalydetection": AnomalyDetector,
             "classification": Classifier,

--- a/object_detectors/detectron2_lmi/model.py
+++ b/object_detectors/detectron2_lmi/model.py
@@ -9,19 +9,10 @@ from lmi_common.model_factory import ModelFactory
 from lmi_common.trt_engine import TRTEngine
 from lmi_utils.image_utils.types import ImageLike
 from lmi_utils.postprocess_utils.mask_utils import mask_to_polygon_cv2, rescale_masks
-from object_detectors.od_core.object_detector_registry import ObjectDetectorRegistry
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v0"],
-        model_names=["mask_rcnn", "faster_rcnn"],
-        tasks=["od", "seg", "instancesegmentation", "objectdetection"],
-        frameworks=["detectron2"],
-    )
-)
 class Detectron2Model(ModelFactory, ODBase):
     """Factory that dispatches to the correct backend based on model file extension.
 

--- a/object_detectors/od_core/object_detector_registry.py
+++ b/object_detectors/od_core/object_detector_registry.py
@@ -2,10 +2,54 @@ from lmi_common.model_registry import ModelRegistry
 
 
 class ObjectDetectorRegistry(ModelRegistry):
-    PACKAGES = {
-        "ultralytics": ["object_detectors.ultralytics_lmi.yolo.model", "object_detectors.yolov5_lmi.model"],
-        "ultralytics8": ["object_detectors.ultralytics_lmi.yolo.model"],
-        "detectron2": ["object_detectors.detectron2_lmi.model"],
-        "rfdetr": ["object_detectors.rf_detr_lmi.model"],
-    }
-    _registry = {}
+    BACKENDS = [
+        {
+            "frameworks": ["ultralytics", "ultralytics8"],
+            "model_names": ["yolo", "yolov8", "yolov11"],
+            "tasks": ["od", "objectdetection"],
+            "versions": ["v1"],
+            "class_path": "object_detectors.ultralytics_lmi.yolo.model:Yolo",
+        },
+        {
+            "frameworks": ["ultralytics", "ultralytics8"],
+            "model_names": ["yolo", "yolov8", "yolov11"],
+            "tasks": ["seg", "instancesegmentation"],
+            "versions": ["v1"],
+            "class_path": "object_detectors.ultralytics_lmi.yolo.model:YoloSeg",
+        },
+        {
+            "frameworks": ["ultralytics", "ultralytics8"],
+            "model_names": ["yolo", "yolov8", "yolov11"],
+            "tasks": ["obb", "orientedobjectdetection"],
+            "versions": ["v1"],
+            "class_path": "object_detectors.ultralytics_lmi.yolo.model:YoloObb",
+        },
+        {
+            "frameworks": ["ultralytics", "ultralytics8"],
+            "model_names": ["yolo", "yolov8", "yolov11"],
+            "tasks": ["pose", "keypointdetection"],
+            "versions": ["v1"],
+            "class_path": "object_detectors.ultralytics_lmi.yolo.model:YoloPose",
+        },
+        {
+            "frameworks": ["ultralytics"],
+            "model_names": ["yolov5"],
+            "tasks": ["od", "seg", "instancesegmentation", "objectdetection"],
+            "versions": ["v0"],
+            "class_path": "object_detectors.yolov5_lmi.model:Yolov5",
+        },
+        {
+            "frameworks": ["detectron2"],
+            "model_names": ["mask_rcnn", "faster_rcnn"],
+            "tasks": ["od", "seg", "instancesegmentation", "objectdetection"],
+            "versions": ["v0"],
+            "class_path": "object_detectors.detectron2_lmi.model:Detectron2Model",
+        },
+        {
+            "frameworks": ["rfdetr"],
+            "model_names": ["rfdetr"],
+            "tasks": ["od", "seg", "instancesegmentation", "objectdetection"],
+            "versions": ["v1"],
+            "class_path": "object_detectors.rf_detr_lmi.model:RfdetrModel",
+        },
+    ]

--- a/object_detectors/od_core/object_detector_registry.py
+++ b/object_detectors/od_core/object_detector_registry.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from lmi_common.model_registry import ModelRegistry
 
 
@@ -53,3 +55,15 @@ class ObjectDetectorRegistry(ModelRegistry):
             "class_path": "object_detectors.rf_detr_lmi.model:RfdetrModel",
         },
     ]
+
+    @classmethod
+    def _get_version(cls, metadata: Dict[str, Any], framework: str) -> str:
+        version = metadata.get("version")
+        if version:
+            return version
+        # legacy backends predate version metadata; trailing digits in OD framework names
+        # are product names (detectron2, ultralytics8), not versions
+        model_name = (metadata.get("model_name") or metadata.get("algorithm") or "").lower()
+        if framework.lower() == "detectron2" or model_name == "yolov5":
+            return "v0"
+        return "v1"

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -12,7 +12,6 @@ from rfdetr.models.postprocess import PostProcess
 from lmi_common.model_factory import ModelFactory
 from lmi_common.trt_engine import TRTEngine
 from lmi_utils.image_utils.types import ImageLike
-from object_detectors.od_core.object_detector_registry import ObjectDetectorRegistry
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
 
@@ -188,11 +187,6 @@ class RfdetrBase(ODBase):
         return [self._postprocess_single(r, configs, operators[i], return_segments) for i, r in enumerate(rs)]
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v1"], model_names=["rfdetr"], tasks=["od", "seg", "instancesegmentation", "objectdetection"], frameworks=["rfdetr"]
-    )
-)
 class RfdetrModel(ModelFactory, ODBase):
     """Factory that dispatches to the correct backend based on model file extension.
 

--- a/object_detectors/ultralytics_lmi/yolo/model.py
+++ b/object_detectors/ultralytics_lmi/yolo/model.py
@@ -10,7 +10,6 @@ from ultralytics.utils.torch_utils import smart_inference_mode
 from lmi_common.yolo_core import YoloCore
 from lmi_utils.gadget_utils.pipeline_utils import resize_image
 from lmi_utils.image_utils.types import ImageLike, to_rgb
-from object_detectors.od_core.object_detector_registry import ObjectDetectorRegistry
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
 
@@ -39,14 +38,6 @@ def letterbox(image: ImageLike, new_shape, pad_value: int = LETTERBOX_PAD) -> Im
     return chw.permute(1, 2, 0)
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v1"],
-        model_names=["yolo", "yolov8", "yolov11"],
-        tasks=["od", "objectdetection"],
-        frameworks=["ultralytics", "ultralytics8"],
-    )
-)
 class Yolo(YoloCore, ODBase):
     logger = logging.getLogger("yolo")
 
@@ -184,14 +175,6 @@ class Yolo(YoloCore, ODBase):
         return self.construct_results(preds2, img, orig_imgs, confs, operators=operators, **kwargs)
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v1"],
-        model_names=["yolo", "yolov8", "yolov11"],
-        tasks=["seg", "instancesegmentation"],
-        frameworks=["ultralytics", "ultralytics8"],
-    )
-)
 class YoloSeg(Yolo):
     logger = logging.getLogger("yolo-seg")
 
@@ -274,14 +257,6 @@ class YoloSeg(Yolo):
         return super().postprocess(preds[0], **kwargs)
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v1"],
-        model_names=["yolo", "yolov8", "yolov11"],
-        tasks=["obb", "orientedobjectdetection"],
-        frameworks=["ultralytics", "ultralytics8"],
-    )
-)
 class YoloObb(Yolo):
     logger = logging.getLogger("yolo-obb")
 
@@ -331,14 +306,6 @@ class YoloObb(Yolo):
         return result, keep
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v1"],
-        model_names=["yolo", "yolov8", "yolov11"],
-        tasks=["pose", "keypointdetection"],
-        frameworks=["ultralytics", "ultralytics8"],
-    )
-)
 class YoloPose(Yolo):
     logger = logging.getLogger("yolo-pose")
 

--- a/object_detectors/yolov5_lmi/model.py
+++ b/object_detectors/yolov5_lmi/model.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 
 import lmi_utils.gadget_utils.pipeline_utils as pipeline_utils
-from object_detectors.od_core.object_detector_registry import ObjectDetectorRegistry
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.ultralytics_lmi.yolo.model import Yolo
 
@@ -26,14 +25,6 @@ from utils.segment.general import masks2segments, process_mask_native  # noqa: E
 from utils.torch_utils import smart_inference_mode  # noqa: E402
 
 
-@ObjectDetectorRegistry.register(
-    metadata=dict(
-        versions=["v0"],
-        model_names=["yolov5"],
-        tasks=["od", "seg", "instancesegmentation", "objectdetection"],
-        frameworks=["ultralytics"],
-    )
-)
 class Yolov5(ODBase):
     logger = logging.getLogger(__name__)
 

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
@@ -19,13 +19,17 @@ def test_backends_table_covers_known_detectors():
         key2 = AnomalyDetectorRegistry._generate_key(*key)
         assert key2 in AnomalyDetectorRegistry._key_map, f"Expected {key2} to be registered in AnomalyDetectorRegistry."
 
+    # the legacy backend is v0 only — no longer doubly registered under v1
+    legacy_v1 = AnomalyDetectorRegistry._generate_key("anomalib", "patchcore", "anomalydetection", "v1")
+    assert legacy_v1 not in AnomalyDetectorRegistry._key_map
+
 
 def test_get_version_inference():
     assert AnomalyDetectorRegistry._get_version({"version": "v2"}, "anomalib") == "v2"  # explicit wins
     assert AnomalyDetectorRegistry._get_version({}, "anomalib0") == "v0"
     assert AnomalyDetectorRegistry._get_version({}, "anomalib2") == "v2"
     assert AnomalyDetectorRegistry._get_version({}, "anomalib12") == "v12"
-    assert AnomalyDetectorRegistry._get_version({}, "anomalib") == "v1"
+    assert AnomalyDetectorRegistry._get_version({}, "anomalib") == "v0"  # bare legacy name maps to the v0 backend
 
 
 def test_get_version_warns_on_non_standard_framework(caplog):

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
@@ -16,7 +16,7 @@ def test_backends_table_covers_known_detectors():
         ("anomalib0", "padim", "anomalydetection", "v0"),
     ]
     for key in known_keys:
-        key2 = AnomalyDetectorRegistry._generate_key(*key, info={})
+        key2 = AnomalyDetectorRegistry._generate_key(*key)
         assert key2 in AnomalyDetectorRegistry._key_map, f"Expected {key2} to be registered in AnomalyDetectorRegistry."
 
 

--- a/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_anomaly_detector_registry.py
@@ -5,16 +5,10 @@ from anomaly_detectors.ad_core.anomaly_detector_registry import AnomalyDetectorR
 logger = logging.getLogger(__name__)
 
 
-def test_auto_register_models():
-    """
-    Test that all anomaly detectors are automatically registered.
-    """
-    AnomalyDetectorRegistry.auto_register_models()
+def test_backends_table_covers_known_detectors():
+    """The BACKENDS table expands to the known lookup keys — no backend imports needed."""
+    assert len(AnomalyDetectorRegistry._key_map) > 0, "AnomalyDetectorRegistry should have registered keys."
 
-    # Check if the registry is populated
-    assert len(AnomalyDetectorRegistry._registry) > 0, "AnomalyDetectorRegistry should have registered classes."
-
-    # Check if specific known detectors are registered
     known_keys = [
         ("anomalib2", "patchcore", "anomalydetection", "v2"),
         ("anomalib1", "patchcore", "anomalydetection", "v1"),
@@ -23,7 +17,7 @@ def test_auto_register_models():
     ]
     for key in known_keys:
         key2 = AnomalyDetectorRegistry._generate_key(*key, info={})
-        assert key2 in AnomalyDetectorRegistry._registry.keys(), f"Expected {key2} to be registered in AnomalyDetectorRegistry."
+        assert key2 in AnomalyDetectorRegistry._key_map, f"Expected {key2} to be registered in AnomalyDetectorRegistry."
 
 
 def test_get_version_inference():

--- a/tests/classifiers/ultralytics_cls/test_registry.py
+++ b/tests/classifiers/ultralytics_cls/test_registry.py
@@ -5,13 +5,9 @@ from classifiers.cls_core.classifier_registry import ClassifierRegistry
 logger = logging.getLogger(__name__)
 
 
-def test_auto_registration():
-    """
-    Test that the auto-registration of classifiers works correctly.
-    This will check if the classifiers are registered in the ClassifierRegistry.
-    """
-    ClassifierRegistry.auto_register_models()
-    assert len(ClassifierRegistry._registry) > 0, "ClassifierRegistry should have registered classifiers."
+def test_backends_table_covers_known_classifiers():
+    """The BACKENDS table expands to the known lookup keys — no backend imports needed."""
+    assert len(ClassifierRegistry._key_map) > 0, "ClassifierRegistry should have registered keys."
 
     to_be_tested_keys = [
         ("ultralytics", "yolo", "classification", "v1"),
@@ -19,4 +15,4 @@ def test_auto_registration():
 
     for key in to_be_tested_keys:
         key2 = ClassifierRegistry._generate_key(*key, info={})
-        assert key2 in ClassifierRegistry._registry, f"Model {key} should be registered."
+        assert key2 in ClassifierRegistry._key_map, f"Model {key} should be registered."

--- a/tests/classifiers/ultralytics_cls/test_registry.py
+++ b/tests/classifiers/ultralytics_cls/test_registry.py
@@ -14,5 +14,5 @@ def test_backends_table_covers_known_classifiers():
     ]
 
     for key in to_be_tested_keys:
-        key2 = ClassifierRegistry._generate_key(*key, info={})
+        key2 = ClassifierRegistry._generate_key(*key)
         assert key2 in ClassifierRegistry._key_map, f"Model {key} should be registered."

--- a/tests/lmi_common/test_model_registry.py
+++ b/tests/lmi_common/test_model_registry.py
@@ -74,7 +74,7 @@ def test_subclass_with_backends_is_fine():
 
 def test_expand_single_combination():
     registry = make_registry(entry())
-    key = registry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    key = registry._generate_key("fw_a", "model_x", "detect", "v1")
     assert registry._key_map == {key: f"{FAKE_MODULE}:DummyModel"}
 
 
@@ -82,13 +82,7 @@ def test_expand_multiple_frameworks_and_tasks():
     registry = make_registry(entry(frameworks=["fw_a", "fw_b"], tasks=["detect", "segment"]))
     for fw in ("fw_a", "fw_b"):
         for task in ("detect", "segment"):
-            assert registry._generate_key(fw, "model_x", task, "v1", {}) in registry._key_map
-
-
-def test_expand_with_info_field():
-    registry = make_registry(entry(info={"extra": "value"}))
-    key = registry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
-    assert key in registry._key_map
+            assert registry._generate_key(fw, "model_x", task, "v1") in registry._key_map
 
 
 # ---------------------------------------------------------------------------
@@ -154,20 +148,14 @@ def test_overlapping_entries_collide_on_shared_combination():
 
 
 def test_generate_key_is_case_insensitive():
-    key1 = ModelRegistry._generate_key("FW_A", "MODEL_X", "DETECT", "v1", {})
-    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    key1 = ModelRegistry._generate_key("FW_A", "MODEL_X", "DETECT", "v1")
+    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1")
     assert key1 == key2
 
 
 def test_generate_key_differs_by_version():
-    key1 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v2", {})
-    assert key1 != key2
-
-
-def test_generate_key_differs_by_info():
-    key1 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
+    key1 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1")
+    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v2")
     assert key1 != key2
 
 

--- a/tests/lmi_common/test_model_registry.py
+++ b/tests/lmi_common/test_model_registry.py
@@ -1,41 +1,53 @@
-import logging
+import sys
+import types
 
 import pytest
 
 import lmi_common.model_registry as model_registry_module
 from lmi_common.model_registry import DuplicateRegistrationError, ModelRegistry
 
-logger = logging.getLogger(__name__)
-
-
 # ---------------------------------------------------------------------------
-# Concrete registry subclass used across all tests
+# Fixtures: an importable fake backend module and a registry factory
 # ---------------------------------------------------------------------------
 
-
-class FakeRegistry(ModelRegistry):
-    PACKAGES = {}
-    _registry = {}
+FAKE_MODULE = "fake_backend_module_for_registry_tests"
 
 
-# ---------------------------------------------------------------------------
-# Helper: fresh registry state per test
-# ---------------------------------------------------------------------------
+class DummyModel:
+    pass
+
+
+class OtherModel:
+    pass
 
 
 @pytest.fixture(autouse=True)
-def clear_registry():
-    """Reset FakeRegistry between tests so registrations don't bleed over."""
-
-    def reset():
-        FakeRegistry._registry.clear()
-        FakeRegistry._failed_imports.clear()
-        FakeRegistry._attempted_imports.clear()
-        FakeRegistry._discovered = False
-
-    reset()
+def fake_backend_module():
+    """Install an importable fake module exposing DummyModel / OtherModel."""
+    module = types.ModuleType(FAKE_MODULE)
+    module.DummyModel = DummyModel
+    module.OtherModel = OtherModel
+    sys.modules[FAKE_MODULE] = module
     yield
-    reset()
+    sys.modules.pop(FAKE_MODULE, None)
+
+
+def make_registry(*entries):
+    """Define a fresh ModelRegistry subclass with the given BACKENDS entries."""
+    return type("TestRegistry", (ModelRegistry,), {"BACKENDS": list(entries)})
+
+
+def entry(**overrides):
+    """A valid BACKENDS entry, with fields overridable per test."""
+    base = {
+        "frameworks": ["fw_a"],
+        "model_names": ["model_x"],
+        "tasks": ["detect"],
+        "versions": ["v1"],
+        "class_path": f"{FAKE_MODULE}:DummyModel",
+    }
+    base.update(overrides)
+    return base
 
 
 # ---------------------------------------------------------------------------
@@ -43,168 +55,97 @@ def clear_registry():
 # ---------------------------------------------------------------------------
 
 
-def test_subclass_missing_all_required_attributes_raises():
+def test_subclass_missing_backends_raises():
     with pytest.raises(TypeError, match="must define"):
 
         class BadRegistry(ModelRegistry):
-            pass  # missing PACKAGES, _registry
+            pass  # missing BACKENDS
 
 
-def test_subclass_missing_one_required_attribute_raises():
-    with pytest.raises(TypeError, match="must define"):
-
-        class PartialRegistry(ModelRegistry):
-            PACKAGES = {}
-            # missing _registry
-
-
-def test_subclass_with_all_required_attributes_is_fine():
-    class GoodRegistry(ModelRegistry):
-        PACKAGES = {}
-        _registry = {}
-
-    assert hasattr(GoodRegistry, "_registry")
+def test_subclass_with_backends_is_fine():
+    registry = make_registry()
+    assert registry._key_map == {}
 
 
 # ---------------------------------------------------------------------------
-# register() — valid metadata
+# BACKENDS expansion — valid entries
 # ---------------------------------------------------------------------------
 
 
-def test_register_single_combination():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
-    key = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    assert key in FakeRegistry._registry
-    assert FakeRegistry._registry[key] is DummyModel
+def test_expand_single_combination():
+    registry = make_registry(entry())
+    key = registry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    assert registry._key_map == {key: f"{FAKE_MODULE}:DummyModel"}
 
 
-def test_register_multiple_frameworks_and_tasks():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a", "fw_b"],
-            model_names=["model_x"],
-            tasks=["detect", "segment"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
+def test_expand_multiple_frameworks_and_tasks():
+    registry = make_registry(entry(frameworks=["fw_a", "fw_b"], tasks=["detect", "segment"]))
     for fw in ("fw_a", "fw_b"):
         for task in ("detect", "segment"):
-            key = FakeRegistry._generate_key(fw, "model_x", task, "v1", {})
-            assert key in FakeRegistry._registry
+            assert registry._generate_key(fw, "model_x", task, "v1", {}) in registry._key_map
 
 
-def test_register_with_info_field():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-            info={"extra": "value"},
-        )
-    )
-    class DummyModel:
-        pass
-
-    key = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
-    assert key in FakeRegistry._registry
+def test_expand_with_info_field():
+    registry = make_registry(entry(info={"extra": "value"}))
+    key = registry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
+    assert key in registry._key_map
 
 
 # ---------------------------------------------------------------------------
-# register() — invalid metadata
+# BACKENDS expansion — invalid entries
 # ---------------------------------------------------------------------------
 
 
-def test_register_missing_frameworks_raises():
+def test_entry_missing_frameworks_raises():
+    bad = entry()
+    del bad["frameworks"]
     with pytest.raises((TypeError, ValueError)):
-
-        @FakeRegistry.register(
-            metadata=dict(
-                model_names=["model_x"],
-                tasks=["detect"],
-                versions=["v1"],
-            )
-        )
-        class DummyModel:
-            pass
+        make_registry(bad)
 
 
-def test_register_non_list_field_raises():
+def test_entry_non_list_field_raises():
     with pytest.raises(TypeError):
-
-        @FakeRegistry.register(
-            metadata=dict(
-                frameworks="fw_a",  # should be a list
-                model_names=["model_x"],
-                tasks=["detect"],
-                versions=["v1"],
-            )
-        )
-        class DummyModel:
-            pass
+        make_registry(entry(frameworks="fw_a"))  # should be a list
 
 
-def test_register_empty_list_field_raises():
+def test_entry_empty_list_field_raises():
     with pytest.raises(ValueError):
+        make_registry(entry(frameworks=[]))
 
-        @FakeRegistry.register(
-            metadata=dict(
-                frameworks=[],  # empty list not allowed
-                model_names=["model_x"],
-                tasks=["detect"],
-                versions=["v1"],
-            )
-        )
-        class DummyModel:
-            pass
+
+def test_entry_missing_class_path_raises():
+    bad = entry()
+    del bad["class_path"]
+    with pytest.raises(ValueError, match="class_path"):
+        make_registry(bad)
+
+
+def test_entry_class_path_without_class_name_raises():
+    with pytest.raises(ValueError, match="class_path"):
+        make_registry(entry(class_path="just.a.module"))
 
 
 # ---------------------------------------------------------------------------
-# register() — duplicate key (should raise)
+# BACKENDS expansion — duplicate keys (should raise at class definition)
 # ---------------------------------------------------------------------------
 
 
-def test_register_duplicate_key_raises():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-        )
-    )
-    class FirstModel:
-        pass
-
+def test_duplicate_key_across_entries_raises():
     with pytest.raises(DuplicateRegistrationError, match="already registered"):
+        make_registry(entry(), entry(class_path=f"{FAKE_MODULE}:OtherModel"))
 
-        @FakeRegistry.register(
-            metadata=dict(
-                frameworks=["fw_a"],
-                model_names=["model_x"],
-                tasks=["detect"],
-                versions=["v1"],
-            )
+
+def test_duplicate_key_with_same_class_path_still_raises():
+    with pytest.raises(DuplicateRegistrationError, match="already registered"):
+        make_registry(entry(), entry())
+
+
+def test_overlapping_entries_collide_on_shared_combination():
+    with pytest.raises(DuplicateRegistrationError, match="already registered"):
+        make_registry(
+            entry(tasks=["detect", "segment"]),
+            entry(tasks=["segment"], class_path=f"{FAKE_MODULE}:OtherModel"),
         )
-        class SecondModel:
-            pass
-
-    # First registration stays in place
-    key = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    assert FakeRegistry._registry[key] is FirstModel
 
 
 # ---------------------------------------------------------------------------
@@ -213,20 +154,20 @@ def test_register_duplicate_key_raises():
 
 
 def test_generate_key_is_case_insensitive():
-    key1 = FakeRegistry._generate_key("FW_A", "MODEL_X", "DETECT", "v1", {})
-    key2 = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    key1 = ModelRegistry._generate_key("FW_A", "MODEL_X", "DETECT", "v1", {})
+    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
     assert key1 == key2
 
 
 def test_generate_key_differs_by_version():
-    key1 = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    key2 = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v2", {})
+    key1 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v2", {})
     assert key1 != key2
 
 
 def test_generate_key_differs_by_info():
-    key1 = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
-    key2 = FakeRegistry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
+    key1 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {})
+    key2 = ModelRegistry._generate_key("fw_a", "model_x", "detect", "v1", {"extra": "value"})
     assert key1 != key2
 
 
@@ -236,86 +177,52 @@ def test_generate_key_differs_by_info():
 
 
 def test_get_class_returns_registered_class():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
-    cls = FakeRegistry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect", "version": "v1"})
+    registry = make_registry(entry())
+    cls = registry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect", "version": "v1"})
     assert cls is DummyModel
 
 
 def test_get_class_is_case_insensitive():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
-    cls = FakeRegistry.get_class({"framework": "FW_A", "model_name": "MODEL_X", "task": "DETECT", "version": "v1"})
+    registry = make_registry(entry())
+    cls = registry.get_class({"framework": "FW_A", "model_name": "MODEL_X", "task": "DETECT", "version": "v1"})
     assert cls is DummyModel
 
 
 def test_get_class_uses_package_and_algorithm_aliases():
     """'package' and 'algorithm' are accepted as aliases for 'framework' and 'model_name'."""
-
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_b"],
-            model_names=["model_y"],
-            tasks=["classify"],
-            versions=["v1"],
-        )
-    )
-    class AliasModel:
-        pass
-
-    cls = FakeRegistry.get_class({"package": "fw_b", "algorithm": "model_y", "task": "classify", "version": "v1"})
-    assert cls is AliasModel
+    registry = make_registry(entry(frameworks=["fw_b"], model_names=["model_y"], tasks=["classify"]))
+    cls = registry.get_class({"package": "fw_b", "algorithm": "model_y", "task": "classify", "version": "v1"})
+    assert cls is DummyModel
 
 
 def test_get_class_uses_model_type_alias_for_task():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["seg"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
-    cls = FakeRegistry.get_class({"framework": "fw_a", "model_name": "model_x", "model_type": "seg", "version": "v1"})
+    registry = make_registry(entry(tasks=["seg"]))
+    cls = registry.get_class({"framework": "fw_a", "model_name": "model_x", "model_type": "seg", "version": "v1"})
     assert cls is DummyModel
 
 
 def test_get_class_defaults_version_to_v1():
-    @FakeRegistry.register(
-        metadata=dict(
-            frameworks=["fw_a"],
-            model_names=["model_x"],
-            tasks=["detect"],
-            versions=["v1"],
-        )
-    )
-    class DummyModel:
-        pass
-
+    registry = make_registry(entry())
     # no "version" key — should default to "v1"
-    cls = FakeRegistry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect"})
+    cls = registry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect"})
     assert cls is DummyModel
+
+
+def test_get_class_imports_backend_module_once(monkeypatch):
+    registry = make_registry(entry())
+    imported = []
+    original = model_registry_module.importlib.import_module
+
+    def counting_import(name):
+        imported.append(name)
+        return original(name)
+
+    monkeypatch.setattr(model_registry_module.importlib, "import_module", counting_import)
+
+    lookup = {"framework": "fw_a", "model_name": "model_x", "task": "detect"}
+    assert registry.get_class(lookup) is DummyModel
+    assert registry.get_class(lookup) is DummyModel
+    assert imported == [FAKE_MODULE], "The backend module should be imported once and the class cached"
 
 
 # ---------------------------------------------------------------------------
@@ -324,144 +231,31 @@ def test_get_class_defaults_version_to_v1():
 
 
 def test_get_class_missing_framework_raises():
+    registry = make_registry(entry())
     with pytest.raises(ValueError, match="framework"):
-        FakeRegistry.get_class({"model_name": "model_x", "task": "detect"})
+        registry.get_class({"model_name": "model_x", "task": "detect"})
 
 
 def test_get_class_missing_task_raises():
+    registry = make_registry(entry())
     with pytest.raises(ValueError):
-        FakeRegistry.get_class({"framework": "fw_a", "model_name": "model_x"})
+        registry.get_class({"framework": "fw_a", "model_name": "model_x"})
 
 
-def test_get_class_unknown_combination_raises():
-    with pytest.raises(ValueError, match="No class found"):
-        FakeRegistry.get_class({"framework": "nonexistent", "model_name": "ghost", "task": "detect", "version": "v1"})
+def test_get_class_unknown_combination_raises_and_lists_available_keys():
+    registry = make_registry(entry())
+    with pytest.raises(ValueError, match="No backend registered") as exc_info:
+        registry.get_class({"framework": "nonexistent", "model_name": "ghost", "task": "detect", "version": "v1"})
+    assert "fw_a" in str(exc_info.value), "Available keys should be listed in the error"
 
 
-# ---------------------------------------------------------------------------
-# auto_register_models() — empty / invalid packages
-# ---------------------------------------------------------------------------
+def test_get_class_import_failure_raises_with_module_name():
+    registry = make_registry(entry(class_path="this.module.does.not.exist:Ghost"))
+    with pytest.raises(ImportError, match="this.module.does.not.exist"):
+        registry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect"})
 
 
-def test_auto_register_models_empty_packages_is_noop():
-    FakeRegistry.auto_register_models()
-    assert len(FakeRegistry._registry) == 0
-
-
-def test_auto_register_models_bad_module_logs_warning(caplog):
-    class RegistryWithBadModule(ModelRegistry):
-        PACKAGES = {"fw": ["this.module.does.not.exist"]}
-        _registry = {}
-
-    with caplog.at_level(logging.WARNING):
-        RegistryWithBadModule.auto_register_models()
-
-    assert any("this.module.does.not.exist" in record.message for record in caplog.records)
-    assert len(RegistryWithBadModule._registry) == 0
-
-
-# ---------------------------------------------------------------------------
-# Lazy discovery and failed-import reporting
-# ---------------------------------------------------------------------------
-
-
-def test_get_class_unknown_framework_triggers_full_discovery_once(monkeypatch):
-    class LazyRegistry(ModelRegistry):
-        PACKAGES = {}
-        _registry = {}
-
-    calls = []
-    original = LazyRegistry.auto_register_models
-
-    def spy():
-        calls.append(1)
-        original()
-
-    monkeypatch.setattr(LazyRegistry, "auto_register_models", spy)
-
-    @LazyRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
-    class Dummy:
-        pass
-
-    LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    LazyRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    assert len(calls) == 1, "Full discovery should run once, on the first lookup"
-
-
-def test_get_class_imports_only_requested_framework(monkeypatch):
-    class TargetedRegistry(ModelRegistry):
-        PACKAGES = {"fw_a": ["fake.module_a"], "fw_b": ["fake.module_b"]}
-        _registry = {}
-
-    imported = []
-
-    def fake_import(name):
-        imported.append(name)
-        if name == "fake.module_a":
-
-            @TargetedRegistry.register(metadata=dict(frameworks=["fw_a"], model_names=["m"], tasks=["t"], versions=["v1"]))
-            class BackendA:
-                pass
-
-    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
-
-    cls = TargetedRegistry.get_class({"framework": "fw_a", "model_name": "m", "task": "t"})
-    assert cls.__name__ == "BackendA"
-    assert imported == ["fake.module_a"], "Only the requested framework's module should be imported"
-
-
-def test_get_class_miss_falls_back_to_full_discovery(monkeypatch):
-    """An incomplete PACKAGES entry self-heals: a miss after the targeted import triggers full discovery."""
-
-    class IncompleteRegistry(ModelRegistry):
-        PACKAGES = {"fw_a": ["fake.module_a"], "fw_b": ["fake.module_b"]}
-        _registry = {}
-
-    imported = []
-
-    def fake_import(name):
-        imported.append(name)
-        if name == "fake.module_b":
-            # fw_a's backend actually lives in fw_b's module — missing from the fw_a map entry
-            @IncompleteRegistry.register(metadata=dict(frameworks=["fw_a"], model_names=["m"], tasks=["t"], versions=["v1"]))
-            class BackendA:
-                pass
-
-    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
-
-    cls = IncompleteRegistry.get_class({"framework": "fw_a", "model_name": "m", "task": "t"})
-    assert cls.__name__ == "BackendA"
-    assert imported == ["fake.module_a", "fake.module_b"]
-
-
-def test_duplicate_registration_during_import_propagates(monkeypatch):
-    """A duplicate key is a code bug: it must not be downgraded to a recorded import failure."""
-
-    class CollidingRegistry(ModelRegistry):
-        PACKAGES = {"fw": ["fake.colliding_module"]}
-        _registry = {}
-
-    def fake_import(name):
-        @CollidingRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
-        class First:
-            pass
-
-        @CollidingRegistry.register(metadata=dict(frameworks=["fw"], model_names=["m"], tasks=["t"], versions=["v1"]))
-        class Second:
-            pass
-
-    monkeypatch.setattr(model_registry_module.importlib, "import_module", fake_import)
-
-    with pytest.raises(DuplicateRegistrationError, match="already registered"):
-        CollidingRegistry.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    assert "fake.colliding_module" not in CollidingRegistry._failed_imports
-
-
-def test_failed_import_is_recorded_and_surfaced_in_lookup_error():
-    class RegistryWithBadModule(ModelRegistry):
-        PACKAGES = {"fw": ["this.module.does.not.exist"]}
-        _registry = {}
-
-    with pytest.raises(ValueError, match="failed to import"):
-        RegistryWithBadModule.get_class({"framework": "fw", "model_name": "m", "task": "t"})
-    assert "this.module.does.not.exist" in RegistryWithBadModule._failed_imports
+def test_get_class_bad_class_name_raises():
+    registry = make_registry(entry(class_path=f"{FAKE_MODULE}:DoesNotExist"))
+    with pytest.raises(ImportError, match="no attribute"):
+        registry.get_class({"framework": "fw_a", "model_name": "model_x", "task": "detect"})

--- a/tests/object_detectors/od_core/test_registry.py
+++ b/tests/object_detectors/od_core/test_registry.py
@@ -23,3 +23,15 @@ def test_backends_table_covers_known_models():
     for key in to_be_tested_keys:
         key2 = ObjectDetectorRegistry._generate_key(*key)
         assert key2 in ObjectDetectorRegistry._key_map, f"Model {key} should be registered."
+
+
+def test_get_version_inference():
+    assert ObjectDetectorRegistry._get_version({"version": "v2"}, "detectron2") == "v2"  # explicit wins
+    # legacy backends resolve to v0 without version metadata
+    assert ObjectDetectorRegistry._get_version({}, "detectron2") == "v0"
+    assert ObjectDetectorRegistry._get_version({"model_name": "yolov5"}, "ultralytics") == "v0"
+    assert ObjectDetectorRegistry._get_version({"algorithm": "YOLOv5"}, "ultralytics") == "v0"
+    # everything else defaults to v1; trailing digits in OD framework names are not versions
+    assert ObjectDetectorRegistry._get_version({"model_name": "yolo"}, "ultralytics") == "v1"
+    assert ObjectDetectorRegistry._get_version({"model_name": "yolov8"}, "ultralytics8") == "v1"
+    assert ObjectDetectorRegistry._get_version({}, "rfdetr") == "v1"

--- a/tests/object_detectors/od_core/test_registry.py
+++ b/tests/object_detectors/od_core/test_registry.py
@@ -5,13 +5,9 @@ from object_detectors.od_core.object_detector_registry import ObjectDetectorRegi
 logger = logging.getLogger(__name__)
 
 
-def test_auto_registration():
-    """
-    Test that the auto-registration of object detector models works correctly.
-    This will check if the models are registered in the ObjectDetectorRegistry.
-    """
-    ObjectDetectorRegistry.auto_register_models()
-    assert len(ObjectDetectorRegistry._registry) > 0, "ObjectDetectorRegistry should have registered models."
+def test_backends_table_covers_known_models():
+    """The BACKENDS table expands to the known lookup keys — no backend imports needed."""
+    assert len(ObjectDetectorRegistry._key_map) > 0, "ObjectDetectorRegistry should have registered keys."
 
     to_be_tested_keys = [
         ("detectron2", "mask_rcnn", "objectdetection", "v0"),
@@ -26,4 +22,4 @@ def test_auto_registration():
 
     for key in to_be_tested_keys:
         key2 = ObjectDetectorRegistry._generate_key(*key, info={})
-        assert key2 in ObjectDetectorRegistry._registry, f"Model {key} should be registered."
+        assert key2 in ObjectDetectorRegistry._key_map, f"Model {key} should be registered."

--- a/tests/object_detectors/od_core/test_registry.py
+++ b/tests/object_detectors/od_core/test_registry.py
@@ -21,5 +21,5 @@ def test_backends_table_covers_known_models():
     ]
 
     for key in to_be_tested_keys:
-        key2 = ObjectDetectorRegistry._generate_key(*key, info={})
+        key2 = ObjectDetectorRegistry._generate_key(*key)
         assert key2 in ObjectDetectorRegistry._key_map, f"Model {key} should be registered."


### PR DESCRIPTION
Replace the PACKAGES dict + @register decorator with a per-registry BACKENDS table mapping metadata to module:ClassName import strings.

- Tables are expanded and validated at class definition time, so duplicate lookup keys raise DuplicateRegistrationError on registry import — without importing any backend. Collisions between backends that cannot share an environment (anomalib v1 vs v2) are now detectable everywhere.
- get_class imports only the single module that provides the requested backend and caches the resolved class; a backend whose dependencies are missing now fails the lookup with an ImportError naming the module and cause, instead of being silently skipped.
- Remove @register decorators and registry imports from all backend modules; adding a backend is now a single table entry.
- Per-registry tests validate the expanded tables without the backends' heavy dependencies.

<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->


## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
