### PR TITLE
fix: deterministic model resource teardown in pipeline clean_up

### DIFF
--- a/anomaly_detectors/ad_core/ad_base.py
+++ b/anomaly_detectors/ad_core/ad_base.py
@@ -60,6 +60,9 @@ class ADBase(ABC):
     def warmup(self, *args, **kwargs) -> None:
         pass
 
+    def release(self) -> None:  # noqa: B027 — intentional no-op default, not abstract
+        """Free resources that need deterministic teardown (e.g. TRT engine/context). Default no-op."""
+
     @abstractmethod
     def preprocess(self, images: List[ImageLike]) -> torch.Tensor:
         """Convert a list of HWC uint8 images to a batched [N,C,H,W] float tensor."""

--- a/anomaly_detectors/anomalib_lmi/base.py
+++ b/anomaly_detectors/anomalib_lmi/base.py
@@ -218,6 +218,9 @@ class _AnomalibEngine(Anomalib_Base):
     def forward(self, input_batch: torch.Tensor) -> torch.Tensor:
         return self.engine.infer(input_batch)[self._anomaly_output_idx]
 
+    def release(self) -> None:
+        self.engine.release()
+
 
 class AnomalibTRT(_AnomalibEngine):
     """TensorRT engine backend."""

--- a/classifiers/cls_core/cls_base.py
+++ b/classifiers/cls_core/cls_base.py
@@ -16,6 +16,9 @@ class ClassifierBase(abc.ABC):
     def warmup(self, *args, **kwargs):
         pass
 
+    def release(self) -> None:  # noqa: B027 — intentional no-op default, not abstract
+        """Free resources that need deterministic teardown (e.g. TRT engine/context). Default no-op."""
+
     @abc.abstractmethod
     def preprocess(self, images: List, *args, **kwargs):
         pass

--- a/lmi_common/onnx_engine.py
+++ b/lmi_common/onnx_engine.py
@@ -199,6 +199,15 @@ class ONNXEngine:
         """List of output buffers in engine output order. Mirrors ``TRTEngine._output_buffers``."""
         return [self._outputs[n].buffer for n in self._output_names]
 
+    def release(self) -> None:
+        """Release the ORT session and drop I/O buffers. Mirrors ``TRTEngine.release()``.
+
+        Safe to call more than once. The engine must not be used afterwards.
+        """
+        self._io_binding = None
+        self._session = None
+        self._outputs = {}
+
     def infer(self, *inputs: torch.Tensor, copy: bool = True) -> List[torch.Tensor]:
         """Run synchronous inference.
 

--- a/lmi_common/trt_engine.py
+++ b/lmi_common/trt_engine.py
@@ -128,6 +128,18 @@ class TRTEngine:
         self.fp16: bool = first_input_buf.dtype == torch.float16
         self.is_dynamic: bool = is_dynamic
 
+    def release(self) -> None:
+        """Release TensorRT resources deterministically (context before engine) and drop CUDA I/O buffers.
+
+        Safe to call more than once. The engine must not be used afterwards.
+        """
+        # Drop in dependency order: TRT requires the execution context to be destroyed before the engine.
+        self.context = None
+        self._engine = None
+        self._input_buffers = {}
+        self._output_buffers = []
+        self._bindings = []
+
     def infer(self, *inputs: torch.Tensor, copy: bool = True) -> List[torch.Tensor]:
         """Run synchronous inference.
 

--- a/lmi_utils/pipeline_base/pipeline_base.py
+++ b/lmi_utils/pipeline_base/pipeline_base.py
@@ -1,5 +1,6 @@
 import collections
 import functools
+import gc
 import json
 import logging
 import re
@@ -8,6 +9,8 @@ from abc import ABCMeta, abstractmethod
 from logging import Logger
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+import torch
 
 from anomaly_detectors.ad_core.ad_base import ADBase
 from anomaly_detectors.ad_core.anomaly_detector import AnomalyDetector
@@ -524,10 +527,18 @@ class PipelineBase(metaclass=ABCMeta):
 
     def clean_up(self) -> None:
         """
-        clean up the pipeline in REVERSED order, i.e., the last models get destroyed first
+        clean up the pipeline in REVERSED order, i.e., the last models get destroyed first.
+        Calls each model's ``release()`` (if defined) for deterministic resource teardown,
+        then returns freed CUDA memory to the driver.
         """
         while self.models:
             model_name, model = self.models.popitem(last=True)
+            try:
+                release = getattr(model, "release", None)
+                if callable(release):
+                    release()
+            except Exception:
+                self.logger.exception(f"Failed to release '{model_name}'; continuing clean-up")
             del model
             self.logger.info(f"{model_name} has been cleaned up")
         self.logger.info("pipeline is cleaned up")
@@ -535,6 +546,10 @@ class PipelineBase(metaclass=ABCMeta):
         self.init_results()
         self._preprocessing.clear()
         self.logger.info("preprocessing is cleaned up")
+
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def update_results(self, key: str, value: Any, sub_key: Optional[str] = None, **kwargs: Any) -> None:
         """

--- a/object_detectors/detectron2_lmi/model.py
+++ b/object_detectors/detectron2_lmi/model.py
@@ -204,6 +204,9 @@ class Detectron2TRT(Detectron2Base):
         """
         return self.trt.infer(inputs)
 
+    def release(self) -> None:
+        self.trt.release()
+
     def postprocess(self, predictions, **kwargs) -> List[Results]:
         """Post-process the predictions from the TRT object detection model.
 

--- a/object_detectors/od_core/od_base.py
+++ b/object_detectors/od_core/od_base.py
@@ -40,6 +40,9 @@ class ODBase(abc.ABC):
     def warmup(self, *args, **kwargs):
         pass
 
+    def release(self) -> None:  # noqa: B027 — intentional no-op default, not abstract
+        """Free resources that need deterministic teardown (e.g. TRT engine/context). Default no-op."""
+
     @abc.abstractmethod
     def preprocess(self, *args, **kwargs):
         pass

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -230,6 +230,9 @@ class RfdetrTRT(RfdetrBase):
         """
         return self.trt.infer(image)
 
+    def release(self) -> None:
+        self.trt.release()
+
 
 @RfdetrModel.register("ts")
 @RfdetrModel.register("pt")

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -322,3 +322,41 @@ def test_version_1_error():
     model_roles = {"mock-model": {"model_role": "mock-model"}}
     with pytest.raises(ValueError, match="Gadget version 1 is no longer supported"):
         pipeline.load(model_roles, {})
+
+
+def test_clean_up_calls_release():
+    pipeline = PipelineOD(version="3")
+    released = []
+
+    class DummyModel:
+        def release(self):
+            released.append("dummy")
+
+    pipeline.models["dummy"] = DummyModel()
+    pipeline.clean_up()
+
+    assert released == ["dummy"]
+    assert len(pipeline.models) == 0
+
+
+def test_clean_up_continues_when_release_fails(caplog):
+    pipeline = PipelineOD(version="3")
+    released = []
+
+    class BadModel:
+        def release(self):
+            raise RuntimeError("boom")
+
+    class GoodModel:
+        def release(self):
+            released.append("good")
+
+    pipeline.models["good"] = GoodModel()
+    pipeline.models["bad"] = BadModel()
+
+    with caplog.at_level(logging.ERROR):
+        pipeline.clean_up()
+
+    assert released == ["good"], "Remaining models must still be released after one release() fails"
+    assert len(pipeline.models) == 0
+    assert any("Failed to release 'bad'" in r.message for r in caplog.records)

--- a/tests/lmi_utils/pipeline_base/test_pipeline_base.py
+++ b/tests/lmi_utils/pipeline_base/test_pipeline_base.py
@@ -339,6 +339,89 @@ def test_clean_up_calls_release():
     assert len(pipeline.models) == 0
 
 
+def test_clean_up_releases_interleaved_models_in_reversed_order():
+    """clean_up pops last-in-first-out, so insertion order onnx2, trt2, onnx1, trt1
+    must release as trt1, onnx1, trt2, onnx2 — interleaving engine types."""
+    pipeline = PipelineOD(version="3")
+    order = []
+
+    class FakeEngine:
+        def __init__(self, name):
+            self.name = name
+
+        def release(self):
+            order.append(self.name)
+
+    for name in ["onnx2", "trt2", "onnx1", "trt1"]:
+        pipeline.models[name] = FakeEngine(name)
+
+    pipeline.clean_up()
+
+    assert order == ["trt1", "onnx1", "trt2", "onnx2"]
+    assert len(pipeline.models) == 0
+
+
+def test_clean_up_interleaved_trt_and_onnx_engines(tmp_path):
+    """Real engines: clean_up must tear down TRT, ONNX, TRT, ONNX interleaved without
+    CUDA errors, clearing each engine's resources and leaving the device usable."""
+    pytest.importorskip("tensorrt")
+    ort = pytest.importorskip("onnxruntime")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if "CUDAExecutionProvider" not in ort.get_available_providers():
+        pytest.skip("onnxruntime-gpu / CUDAExecutionProvider not available")
+
+    from lmi_common.onnx_engine import ONNXEngine
+    from lmi_common.trt_engine import TRTEngine
+    from tests.lmi_common.test_trt_engine import _build_engine, _export_onnx
+
+    onnx_path = str(tmp_path / "tiny.onnx")
+    engine_path = str(tmp_path / "tiny.engine")
+    _export_onnx(onnx_path, dynamic=True)
+    _build_engine(onnx_path, engine_path, min_b=1, opt_b=2, max_b=4, static=False)
+
+    pipeline = PipelineOD(version="3")
+    order = []
+
+    def tracked(name, model):
+        orig = model.release
+
+        def wrapped():
+            order.append(name)
+            orig()
+
+        model.release = wrapped
+        return model
+
+    # Insert in reverse so LIFO clean_up releases trt1, onnx1, trt2, onnx2.
+    for name in ["onnx2", "trt2", "onnx1", "trt1"]:
+        if name.startswith("trt"):
+            model = TRTEngine(engine_path, device="cuda")
+        else:
+            model = ONNXEngine(onnx_path, device="cuda", dynamic_max_batch=4)
+        pipeline.models[name] = tracked(name, model)
+
+    # Exercise every engine so contexts and buffers are live before teardown.
+    engines = dict(pipeline.models)
+    x = torch.randn(2, 3, 32, 32, dtype=torch.float32, device="cuda")
+    for model in engines.values():
+        assert model.infer(x)[0].shape == (2, 4)
+
+    pipeline.clean_up()
+
+    assert order == ["trt1", "onnx1", "trt2", "onnx2"]
+    assert len(pipeline.models) == 0
+    for name, model in engines.items():
+        if name.startswith("trt"):
+            assert model.context is None and model._engine is None, f"{name} not released"
+        else:
+            assert model._session is None and model._io_binding is None, f"{name} not released"
+
+    # The device must remain usable after interleaved teardown.
+    torch.cuda.synchronize()
+    assert torch.ones(4, device="cuda").sum().item() == 4.0
+
+
 def test_clean_up_continues_when_release_fails(caplog):
     pipeline = PipelineOD(version="3")
     released = []


### PR DESCRIPTION
- Add a release() protocol: no-op default on ODBase/ADBase/ClassifierBase, implemented by TRTEngine (context-before-engine teardown, buffer drop) and ONNXEngine (session/io-binding drop).
- Wire release() through the engine-holding backends: RfdetrTRT, Detectron2TRT, and the Anomalib TRT/ONNX engine base.
- PipelineBase.clean_up now calls each model's release() (per-model try/except so one failure doesn't block the rest), then gc.collect() and torch.cuda.empty_cache() to return freed memory to the driver.

<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->


## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
