### PR TITLE
Fixing create blend mask bug

### DIFF
--- a/lmi_utils/image_utils/tiler.py
+++ b/lmi_utils/image_utils/tiler.py
@@ -79,14 +79,17 @@ def create_blend_mask(
     y_coords = torch.arange(tile_h, device=device).float()
     x_coords = torch.arange(tile_w, device=device).float()
 
-    # Calculate distance from edges
-    y_dist_from_top = y_coords
-    y_dist_from_bottom = tile_h - 1 - y_coords
-    x_dist_from_left = x_coords
-    x_dist_from_right = tile_w - 1 - x_coords
-
     # create 2D grids
     y_grid, x_grid = torch.meshgrid(y_coords, x_coords, indexing="ij")
+
+    # Calculate distance from edges as 2D grids (not 1D vectors):
+    # torch.minimum(y_blend, x_blend) below combines per-axis blends
+    # elementwise over the full (tile_h, tile_w) surface, which only works
+    # if both operands already have that shape.
+    y_dist_from_top = y_grid
+    y_dist_from_bottom = tile_h - 1 - y_grid
+    x_dist_from_left = x_grid
+    x_dist_from_right = tile_w - 1 - x_grid
 
     # calculate minimum distance to any edge
     y_edge_dist = torch.minimum(y_dist_from_top, y_dist_from_bottom)


### PR DESCRIPTION
The bug: create_blend_mask's LINEAR/COSINE branches computed the per-axis edge distances as 1D vectors (y_edge_dist shape (tile_h,), x_edge_dist shape (tile_w,)) instead of full 2D grids, then combined them with torch.minimum(y_blend, x_blend). Since the two vectors are indexed along different axes, this only avoided a shape error when tile_h == tile_w (coincidentally equal lengths), and even then it paired row i's vertical distance with column i's horizontal distance — a meaningless diagonal slice — instead of a real 2D blend surface. For non-square tiles it crashed outright.

The fix: build y_edge_dist/x_edge_dist from the existing 2D y_grid/x_grid (from torch.meshgrid) instead of the 1D y_coords/x_coords, so both are already shape (tile_h, tile_w) before the minimum. This mirrors what the Gaussian branch already did correctly, and makes mask[i,j] = min(vertical-edge blend at row i, horizontal-edge blend at column j) — the intended per-pixel blend — for any tile shape, square or not.