### PR TITLE
fix(bbox): lossless rotated-box conversion

### DIFF
--- a/lmi_utils/dataset_utils/ops/dataset_pad.py
+++ b/lmi_utils/dataset_utils/ops/dataset_pad.py
@@ -143,7 +143,7 @@ def clip_shapes(shapes, W, H, crop_warning_level=logging.DEBUG):
             elif status == "clip":
                 logger.log(crop_warning_level, f"Rotated box {shape.id} was clipped to image dimensions [{W}, {H}]")
                 is_warning = True
-                shape.value = Polygon(points=np.array(list(zip(new_X, new_Y))).astype(int).tolist()).to_rbox()
+                shape.value = Polygon(points=np.array(list(zip(new_X, new_Y))).tolist()).to_rbox()
 
         elif shape.type == AnnotationType.BOX:
             box = shape.value.to_numpy()[:-1]

--- a/lmi_utils/dataset_utils/representations.py
+++ b/lmi_utils/dataset_utils/representations.py
@@ -42,6 +42,11 @@ def _require_hw(kwargs):
     return h, w
 
 
+def _pixel_points(points) -> np.ndarray:
+    """Round points to the pixel grid for OpenCV rasterization, which only accepts integer coordinates."""
+    return np.round(np.asarray(points, dtype=float)).astype(np.int32)
+
+
 class AnnotationType(enum.Enum):
     BOX = "Box"
     POLYGON = "Polygon"
@@ -281,8 +286,7 @@ class Box(Base):
         h, w = _require_hw(kwargs)
         mask = np.zeros((h, w), dtype=np.uint8)
         if self.angle != 0:
-            pts = self._rotated_corners(**kwargs)
-            cv2.fillPoly(mask, [pts], 1)
+            cv2.fillPoly(mask, [_pixel_points(self._rotated_corners(**kwargs))], 1)
         else:
             mask[int(self.y_min) : int(self.y_max), int(self.x_min) : int(self.x_max)] = 1
         return Mask(mask=mask)
@@ -368,8 +372,7 @@ class Polygon(Base):
     def to_mask(self, **kwargs):
         h, w = _require_hw(kwargs)
         mask = np.zeros((h, w), dtype=np.uint8)
-        pts = self.to_numpy().astype(np.int32)
-        cv2.fillPoly(mask, [pts], 1)
+        cv2.fillPoly(mask, [_pixel_points(self.to_numpy())], 1)
         return Mask(mask=mask)
 
     def to_box(self, **kwargs):
@@ -381,7 +384,7 @@ class Polygon(Base):
         return Box(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max)
 
     def to_rbox(self, **kwargs):
-        x1, y1, w, h, angle = get_rotated_bbox(self.to_numpy().astype(int))
+        x1, y1, w, h, angle = get_rotated_bbox(self.to_numpy())
         return Box(x_min=x1, y_min=y1, x_max=x1 + w, y_max=y1 + h, angle=angle)
 
 

--- a/lmi_utils/dataset_utils/representations.py
+++ b/lmi_utils/dataset_utils/representations.py
@@ -60,8 +60,10 @@ class Base:
 
     def save(self, path: str):
         """Save the dataclass as a JSON file."""
-        # create directory if it doesn't exist
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # create directory if it doesn't exist; a bare filename has none
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
         with open(path, "w") as f:
             f.write(self.to_json())
 

--- a/lmi_utils/label_utils/COCO_dataset.py
+++ b/lmi_utils/label_utils/COCO_dataset.py
@@ -181,7 +181,7 @@ class COCO_Dataset:
             fname(str): the file name
         """
         img = cv2.imread(annot.path)
-        pts = rotate(*annot.bbox)
+        pts = np.round(rotate(*annot.bbox)).astype(int)
         cv2.drawContours(img, [pts], 0, (0, 255, 0), 3, cv2.LINE_AA)
         if len(annot.segmentation):
             segs = np.array(annot.segmentation).astype(int)

--- a/lmi_utils/label_utils/bbox_utils.py
+++ b/lmi_utils/label_utils/bbox_utils.py
@@ -47,7 +47,7 @@ def rotate(x, y, w, h, angle=0.0, rot_center="up_left", unit="degree"):
         unit(str): the current unit, either 'degree' or 'radian'. defalt unit is 'degree'
 
     Returns:
-        np.ndarray: 4x2
+        np.ndarray: 4x2 of floats. Callers that rasterize the corners must round them to int themselves.
     """
     if unit == "degree":
         ANGLE = np.deg2rad(angle)
@@ -70,7 +70,7 @@ def rotate(x, y, w, h, angle=0.0, rot_center="up_left", unit="degree"):
             ]
             for px, py in points
         ]
-    ).astype(int)
+    )
 
 
 def get_rotated_bbox(pts: np.ndarray) -> list:
@@ -92,7 +92,7 @@ def get_rotated_bbox(pts: np.ndarray) -> list:
 
     # the pivot is the topmost corner (minimum y, then minimum x if tied)
     idx = np.lexsort((box_points[:, 0], box_points[:, 1]))[0]
-    x, y = box_points[idx]
+    x, y = (float(v) for v in box_points[idx])
 
     # Of the two edges meeting at the pivot, the width axis is the one the height axis follows under a
     # quarter turn in the direction `rotate` turns, which is the positive cross product in image coordinates

--- a/lmi_utils/label_utils/bbox_utils.py
+++ b/lmi_utils/label_utils/bbox_utils.py
@@ -76,6 +76,11 @@ def rotate(x, y, w, h, angle=0.0, rot_center="up_left", unit="degree"):
 def get_rotated_bbox(pts: np.ndarray) -> list:
     """Get the rotated bbox from polygon points.
 
+    The result is what ``rotate`` consumes: the pivot is the corner ``rotate`` turns the box about, and
+    ``angle`` measures the box's own width axis from that pivot. Both are read off the corners rather than
+    from ``minAreaRect``'s angle, whose range OpenCV has redefined between releases (4.5 and 4.13 disagree on
+    its sign); a pivot chosen for one convention places the box on the wrong side of itself under the other.
+
     Args:
         pts (np.ndarray): Polygon points in shape [N, 2]
 
@@ -83,19 +88,22 @@ def get_rotated_bbox(pts: np.ndarray) -> list:
         list: [x, y, w, h, angle], where (x,y) is the pivot of the rotated bbox
     """
     bbox = np.array(pts, dtype=np.float32)
-    (cx, cy), (w, h), angle = cv2.minAreaRect(bbox)
+    box_points = cv2.boxPoints(cv2.minAreaRect(bbox))
 
-    # Get the 4 corners of the rotated rectangle
-    rect = ((cx, cy), (w, h), angle)
-    box_points = cv2.boxPoints(rect)
-
-    # Find pivot
-    if angle != 90:
-        # the top-left corner (minimum y, then minimum x if tied)
-        idx = np.lexsort((box_points[:, 0], box_points[:, 1]))[0]
-    else:
-        # the top-right corner (minimum y, then maximum x if tied)
-        idx = np.lexsort((-box_points[:, 0], box_points[:, 1]))[0]
+    # the pivot is the topmost corner (minimum y, then minimum x if tied)
+    idx = np.lexsort((box_points[:, 0], box_points[:, 1]))[0]
     x, y = box_points[idx]
+
+    # Of the two edges meeting at the pivot, the width axis is the one the height axis follows under a
+    # quarter turn in the direction `rotate` turns, which is the positive cross product in image coordinates
+    width_axis = box_points[(idx + 1) % 4] - box_points[idx]
+    height_axis = box_points[idx - 1] - box_points[idx]
+    cross = width_axis[0] * height_axis[1] - width_axis[1] * height_axis[0]
+    if cross < 0:
+        width_axis, height_axis = height_axis, width_axis
+
+    w = float(np.linalg.norm(width_axis))
+    h = float(np.linalg.norm(height_axis))
+    angle = float(np.degrees(np.arctan2(width_axis[1], width_axis[0])))
 
     return [x, y, w, h, angle]

--- a/tests/lmi_utils/dataset_utils/test_representations.py
+++ b/tests/lmi_utils/dataset_utils/test_representations.py
@@ -593,9 +593,13 @@ def test_box_flip():
         Box(10, 20, 50, 80, 0).flip(flipx=True, w=0)
 
 
-def get_flip_expected_coords(x, y, w, h, angle, flip_w, flip_h, flip_x=False, flip_y=False):
+def get_flip_expected_corners(x, y, w, h, angle, flip_w, flip_h, flip_x=False, flip_y=False):
     """
-    Helper to calculate ground truth for the test.
+    Helper to calculate ground truth for the test: the flipped box's four corners.
+
+    The corners are the box itself. Which of them the flipped box reports as its pivot, and the angle that
+    goes with it, is a choice of representation -- a box lying flat is equally the corner on its left at 0
+    degrees or the corner on its right at 90 -- so the test compares the geometry rather than the choice.
     """
     # 1. Get exact corners of the input box
     angle_rad = np.deg2rad(angle)
@@ -619,12 +623,7 @@ def get_flip_expected_coords(x, y, w, h, angle, flip_w, flip_h, flip_x=False, fl
     if flip_y:
         pts[:, 1] = flip_h - pts[:, 1]
 
-    # 3. Find the pivot
-    if angle != 90:
-        ind = np.lexsort((pts[:, 0], pts[:, 1]))
-    else:
-        ind = np.lexsort((-pts[:, 0], pts[:, 1]))
-    return pts[ind[0]]
+    return pts[np.lexsort((pts[:, 0], pts[:, 1]))]
 
 
 @pytest.mark.parametrize(
@@ -652,10 +651,11 @@ def test_flip_rotated_robust(box_in, flip_kwargs):
     flip_x = flip_kwargs.get("flipx", False)
     flip_y = flip_kwargs.get("flipy", False)
 
-    expected_pt = get_flip_expected_coords(x1, y1, w_box, h_box, a, flip_w, flip_h, flip_x, flip_y)
+    expected = get_flip_expected_corners(x1, y1, w_box, h_box, a, flip_w, flip_h, flip_x, flip_y)
 
-    assert box.x_min == pytest.approx(expected_pt[0], abs=1.0)
-    assert box.y_min == pytest.approx(expected_pt[1], abs=1.0)
+    corners = np.array(box._rotated_corners(), dtype=float)
+    corners = corners[np.lexsort((corners[:, 0], corners[:, 1]))]
+    assert corners == pytest.approx(expected, abs=1.0)
 
     # verify the width and height
     old_dims = sorted([x2 - x1, y2 - y1])

--- a/tests/lmi_utils/dataset_utils/test_representations.py
+++ b/tests/lmi_utils/dataset_utils/test_representations.py
@@ -109,7 +109,7 @@ def test_box_to_mask():
     assert isinstance(m, Mask)
     mask = np.zeros((100, 100), dtype=np.uint8)
     pts = rotate(10, 20, 50 - 10, 80 - 20, 30)
-    cv2.fillPoly(mask, [pts], 1)
+    cv2.fillPoly(mask, [np.round(pts).astype(np.int32)], 1)
     assert np.allclose(m.to_numpy(h=100, w=100), mask)
     poly = b.to_polygon()
     assert np.allclose(poly.to_numpy(), pts)
@@ -160,6 +160,24 @@ def test_polygon_to_mask():
     mask = np.zeros((100, 100), dtype=np.uint8)
     cv2.fillPoly(mask, [np.array(poly.points).astype(np.int32)], 1)
     assert np.allclose(m.to_numpy(h=100, w=100), mask)
+
+
+@pytest.mark.parametrize("angle", [0, 7, 30, 45, 89, -15, -70])
+def test_polygon_to_rbox_round_trips_exactly(angle):
+    """
+    A rotated rectangle survives polygon -> rbox -> polygon.
+
+    Neither direction may round to the pixel grid: a box is stored in image coordinates and only rasterized
+    at the point it is drawn, and a rounding of each corner compounds over an operation chain.
+    """
+    corners = cv2.boxPoints(((123.4, 210.7), (81.3, 46.9), angle))
+
+    round_tripped = np.array(Polygon(points=corners.tolist()).to_rbox().to_polygon().points)
+
+    def sorted_corners(pts):
+        return pts[np.lexsort((pts[:, 0], pts[:, 1]))]
+
+    assert sorted_corners(round_tripped) == pytest.approx(sorted_corners(corners), abs=1e-3)
 
 
 def test_mask_from_dict_and_to_yolo():

--- a/tests/lmi_utils/label_utils/test_bbox_utils.py
+++ b/tests/lmi_utils/label_utils/test_bbox_utils.py
@@ -31,7 +31,7 @@ def test_geometric_consistency(angle, size):
 
     # sort the corners
     recon_corners = np.array(sorted(recon_corners, key=lambda p: (p[0], p[1])))
-    gt_corners = np.array(sorted(gt_corners.astype(int), key=lambda p: (p[0], p[1])))
+    gt_corners = np.array(sorted(gt_corners, key=lambda p: (p[0], p[1])))
 
     assert np.allclose(recon_corners, gt_corners), "Reconstructed corners do not match ground truth corners."
 

--- a/tests/lmi_utils/label_utils/test_bbox_utils.py
+++ b/tests/lmi_utils/label_utils/test_bbox_utils.py
@@ -38,15 +38,40 @@ def test_geometric_consistency(angle, size):
 
 def test_pivot_logic():
     """
-    Verifies that the returned point is the 'Top-right' and angle is 90 degrees when the box is horizontal.
+    Verifies that a horizontal box is returned unrotated, from its top-left corner.
     """
     # Create a box where the "top" is flat (0 degrees)
     pts = create_rotated_rect_points((100, 100), (40, 20), 0)
 
     x, y, w, h, angle = get_rotated_bbox(pts)
-    assert angle == 90
-    assert x == 120
-    assert y == 90
+    assert (x, y, w, h, angle) == pytest.approx((80, 90, 40, 20, 0))
+
+
+def _restated(rect):
+    """The same rectangle, stated in the angle range the other OpenCV releases use."""
+    (cx, cy), (w, h), angle = rect
+    return (cx, cy), (h, w), angle + (-90 if angle > 0 else 90)
+
+
+@pytest.mark.parametrize("angle", [0, 1, 30, 45, 89, 90, -15, -89])
+def test_reconstruction_is_independent_of_the_minarearect_angle_range(angle, monkeypatch):
+    """
+    The reconstruction must survive whichever angle range the installed OpenCV reports.
+
+    OpenCV has redefined minAreaRect's range across releases -- 4.5 through 4.12 return (0, 90], 4.13
+    returns [-90, 0) -- and the same rectangle is describable in either. Reading the corners as if they came
+    from the other range picks the wrong pivot, which reflects the box across itself.
+    """
+    pts = create_rotated_rect_points((200, 200), (100, 50), angle)
+
+    def corners():
+        return np.array(sorted(rotate(*get_rotated_bbox(pts)), key=lambda p: (p[0], p[1])))
+
+    as_reported = corners()
+    real_min_area_rect = cv2.minAreaRect
+    monkeypatch.setattr(cv2, "minAreaRect", lambda points: _restated(real_min_area_rect(points)))
+
+    assert np.allclose(corners(), as_reported)
 
 
 def test_diamond_shape_top_vertex():


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
keep rotated corners in float, round only when rasterizing

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
