### PR TITLE
fix(OD): handle masks differently for yolo and rfdetr

### DIFF
--- a/lmi_utils/dataset_utils/representations.py
+++ b/lmi_utils/dataset_utils/representations.py
@@ -197,6 +197,29 @@ class Box(Base):
             unit=angle_unit,
         )
 
+    def _corners(self, **kwargs) -> np.ndarray:
+        """The box's four corners, rotated when it carries an angle."""
+        if self.angle != 0:
+            return self._rotated_corners(**kwargs).astype(float)
+        return np.array(
+            [
+                [self.x_min, self.y_min],
+                [self.x_max, self.y_min],
+                [self.x_max, self.y_max],
+                [self.x_min, self.y_max],
+            ],
+            dtype=float,
+        )
+
+    def _enclosing_bounds(self, **kwargs) -> tuple:
+        """The axis-aligned extent enclosing the box, its rotation included.
+
+        A rotated box's own x_min..x_max is the extent it had before rotating, which is not where the
+        object is, so any axis-aligned consumer has to measure the rotated corners instead.
+        """
+        pts = self._corners(**kwargs)
+        return pts[:, 0].min(), pts[:, 1].min(), pts[:, 0].max(), pts[:, 1].max()
+
     def flip(self, **kwargs):
         flipx = kwargs.get("flipx", False)
         flipy = kwargs.get("flipy", False)
@@ -245,42 +268,23 @@ class Box(Base):
         return (self.x_max - self.x_min) * (self.y_max - self.y_min)
 
     def to_coco(self, **kwargs):
-        """Convert to COCO format (x_min, y_min, width, height)."""
-        return self.to_xywh().tolist()[:4]  # Exclude angle for COCO format
+        """Convert to COCO format (x_min, y_min, width, height); a COCO bbox is axis-aligned."""
+        x_min, y_min, x_max, y_max = self._enclosing_bounds(**kwargs)
+        return [float(x_min), float(y_min), float(x_max - x_min), float(y_max - y_min)]
 
     def to_yolo(self, h, w, **kwargs):
-        use_obb = kwargs.get("use_obb", False)
-
-        cx = (self.x_min + self.x_max) / 2
-        cy = (self.y_min + self.y_max) / 2
-        if self.angle != 0 and use_obb:
-            rotated_coords = self._rotated_corners(**kwargs).astype(float)
+        if kwargs.get("use_obb", False):
+            corners = self._corners(**kwargs)
             # Rotation may move valid edge boxes slightly outside the image; Ultralytics expects clipped normalized corners.
-            rotated_coords[:, 0] = np.clip(rotated_coords[:, 0], 0, w)
-            rotated_coords[:, 1] = np.clip(rotated_coords[:, 1], 0, h)
-            return [[pt[0] / w, pt[1] / h] for pt in rotated_coords]
-        else:
-            if use_obb:
-                logger.debug(f"Use_obb is True but angle is {self.angle}; returning obb formatted bounding box.")
-                corners = np.array(
-                    [
-                        [self.x_min, self.y_min],
-                        [self.x_max, self.y_min],
-                        [self.x_max, self.y_max],
-                        [self.x_min, self.y_max],
-                    ]
-                )
-                return [[pt[0] / w, pt[1] / h] for pt in corners]
-            else:
-                # convert to center_x, center_y, width, height
-                return [
-                    [
-                        cx / w,
-                        cy / h,
-                        (self.x_max - self.x_min) / w,
-                        (self.y_max - self.y_min) / h,
-                    ]
-                ]
+            corners[:, 0] = np.clip(corners[:, 0], 0, w)
+            corners[:, 1] = np.clip(corners[:, 1], 0, h)
+            return [[x / w, y / h] for x, y in corners]
+
+        # center_x, center_y, width, height of the axis-aligned extent
+        x_min, y_min, x_max, y_max = self._enclosing_bounds(**kwargs)
+        x_min, x_max = np.clip([x_min, x_max], 0, w)
+        y_min, y_max = np.clip([y_min, y_max], 0, h)
+        return [[(x_min + x_max) / 2 / w, (y_min + y_max) / 2 / h, (x_max - x_min) / w, (y_max - y_min) / h]]
 
     def to_mask(self, **kwargs):
         h, w = _require_hw(kwargs)
@@ -292,16 +296,7 @@ class Box(Base):
         return Mask(mask=mask)
 
     def to_polygon(self, **kwargs):
-        if self.angle != 0:
-            pts = self._rotated_corners(**kwargs)
-        else:
-            pts = [
-                [self.x_min, self.y_min],
-                [self.x_max, self.y_min],
-                [self.x_max, self.y_max],
-                [self.x_min, self.y_max],
-            ]
-        return Polygon(points=pts)
+        return Polygon(points=self._corners(**kwargs).tolist())
 
     def point_in_box(self, x: int, y: int):
         return self.x_min <= x <= self.x_max and self.y_min <= y <= self.y_max
@@ -367,7 +362,14 @@ class Polygon(Base):
         return [np.array(self.points).ravel().tolist()]
 
     def to_yolo(self, h, w, **kwargs):
+        if kwargs.get("use_obb", False):
+            # an obb row is exactly four corners, so an arbitrary outline has to become its rotated box
+            return self.to_rbox(**kwargs).to_yolo(h, w, **kwargs)
         return [[point[0] / w, point[1] / h] for point in self.points]
+
+    def encloses_area(self, **kwargs) -> bool:
+        """Whether the outline encloses at least one pixel; a point, a line, or collinear points do not."""
+        return cv2.contourArea(self.to_numpy().astype(np.float32).reshape(-1, 2)) >= 1
 
     def to_mask(self, **kwargs):
         h, w = _require_hw(kwargs)
@@ -440,12 +442,17 @@ class Mask(Base):
         ys, xs = np.nonzero(mask == 1)
         return xs.tolist(), ys.tolist()
 
-    def to_polygon(self, **kwargs) -> List[Polygon]:
+    def to_polygons(self, **kwargs) -> List[Polygon]:
+        """One outline per connected region, skipping any that encloses no area.
+
+        Plural because a mask may hold several disconnected regions; a Box, which is always one connected
+        shape, has the singular `to_polygon`.
+        """
         h, w = _require_hw(kwargs)
         mask_array = self.to_numpy(h=h, w=w)
         contours, _ = cv2.findContours(mask_array, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        polygons = [contour.reshape(-1, 2) for contour in contours]
-        return [Polygon([[x, y] for x, y in polygon]) for polygon in polygons]
+        polygons = [Polygon([[x, y] for x, y in contour.reshape(-1, 2)]) for contour in contours]
+        return [polygon for polygon in polygons if polygon.encloses_area(**kwargs)]
 
     def to_coco(self, **kwargs):
         """Convert the mask to COCO format."""
@@ -458,39 +465,39 @@ class Mask(Base):
 
     def to_yolo(self, h, w, **kwargs):
         instances = []
-        for polygon in self.to_polygon(h=h, w=w):
+        for polygon in self.to_polygons(h=h, w=w):
             instances.append(polygon.to_yolo(h, w, **kwargs))
         return instances
 
     def area(self, **kwargs):
-        polygons = self.to_polygon(**kwargs)
+        polygons = self.to_polygons(**kwargs)
         area = 0
         for polygon in polygons:
             area += polygon.area(**kwargs)
         return area
 
     def to_box(self, **kwargs):
+        """The single box enclosing the whole mask, disconnected regions included.
+
+        This is what an axis-aligned consumer of one instance wants: a COCO annotation holds its regions
+        together under one bbox. Formats that cannot express a disconnected instance want `to_boxes`.
+        """
         h, w = _require_hw(kwargs)
-        merge_boxes = kwargs.get("merge_boxes", False)
         mask_array = self.to_numpy(h=h, w=w)
         boxes = masks_to_boxes(torch.from_numpy(mask_array).unsqueeze(0))
-        if merge_boxes:
-            if boxes is not None:
-                x_min = boxes[:, 0].min().item()
-                y_min = boxes[:, 1].min().item()
-                x_max = boxes[:, 2].max().item()
-                y_max = boxes[:, 3].max().item()
-            else:
-                raise ValueError("No boxes found in the mask for merging.")
-            return Box(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max, angle=0)
-        else:
-            if boxes is None or boxes.numel() == 0:
-                raise ValueError("No boxes found in the mask.")
-            bboxes = []
-            for box in boxes:
-                x_min, y_min, x_max, y_max = box.tolist()
-                bboxes.append(Box(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max, angle=0))
-            return bboxes if len(bboxes) > 1 else bboxes[0]  # Return a list if multiple boxes, otherwise a single box
+        if boxes is None or boxes.numel() == 0:
+            raise ValueError("No boxes found in the mask.")
+        return Box(
+            x_min=boxes[:, 0].min().item(),
+            y_min=boxes[:, 1].min().item(),
+            x_max=boxes[:, 2].max().item(),
+            y_max=boxes[:, 3].max().item(),
+            angle=0,
+        )
+
+    def to_boxes(self, **kwargs) -> List[Box]:
+        """One box per connected region, for formats where an instance is a single connected shape."""
+        return [polygon.to_box(**kwargs) for polygon in self.to_polygons(**kwargs)]
 
 
 @dataclass
@@ -598,6 +605,17 @@ class PolygonAnnotation(Annotation):
     @classmethod
     def from_dict(cls, data: dict) -> "PolygonAnnotation":
         return cls(**cls._base_fields(data), value=Polygon.from_dict(data["value"]))
+
+
+def _annotation_encloses_area(annotation: Annotation, h: int, w: int) -> bool:
+    """Whether an annotation covers any pixels; geometry that covers none cannot be trained on."""
+    if annotation.type == AnnotationType.MASK:
+        return bool(annotation.value.to_polygons(h=h, w=w))
+    if annotation.type == AnnotationType.POLYGON:
+        return annotation.value.encloses_area(h=h, w=w)
+    if annotation.type == AnnotationType.BOX:
+        return annotation.value.to_polygon().encloses_area(h=h, w=w)
+    return True
 
 
 @dataclass
@@ -716,13 +734,18 @@ class FileAnnotations(Base):
             if len(target_classes) > 0 and annotation.label_id not in target_classes:
                 continue
 
+            if not _annotation_encloses_area(annotation, h, w):
+                logger.warning(f"Skipping {annotation.type.value} annotation {annotation.id}, which encloses no area")
+                continue
+
             # Conversion steps:
             if annotation.type == AnnotationType.BOX and to_segmentation:
                 logger.debug(f"Converting box {annotation.id} to YOLO format with mask_type=AnnotationType.MASK")
                 updated_annotations.append(annotation.value.to_mask(h=h, w=w))
             elif annotation.type == AnnotationType.MASK and to_object_detection:
                 logger.debug(f"Converting mask {annotation.id} to YOLO format with mask_type=AnnotationType.MASK")
-                updated_annotations.append(annotation.value.to_box(h=h, w=w, merge_boxes=merge_boxes))
+                # a YOLO instance is one connected shape, so each region becomes its own box
+                updated_annotations.extend([annotation.value.to_box(h=h, w=w)] if merge_boxes else annotation.value.to_boxes(h=h, w=w))
             elif annotation.type == AnnotationType.POLYGON and to_object_detection:
                 logger.debug(f"Converting polygon {annotation.id} to YOLO format with mask_type=AnnotationType.POLYGON")
                 updated_annotations.append(annotation.value.to_box(h=h, w=w))

--- a/lmi_utils/label_utils/json_to_coco.py
+++ b/lmi_utils/label_utils/json_to_coco.py
@@ -19,28 +19,35 @@ def get_args():
     ap.add_argument("--path_val_imgs", "-vi", required=False, help="the output path for val images")
     ap.add_argument("--target_classes", default="all", help="[optional] the comma separated target classes, default=all")
     ap.add_argument("--bg", action="store_true", help="keep images with no labels in the output, where models treat them as background")
-    ap.add_argument("--merge_box", action="store_true", help="merge multiple instances of same class boxes into one. Brush labels only!")
+    ap.add_argument("--split_regions", action="store_true", help="give each disconnected region of a mask its own annotation")
     ap.add_argument("--idx0", action="store_true", help="start index from 0 instead of 1")
 
     args = vars(ap.parse_args())
     return args
 
 
-def get_coco_annotation(annotation, **kwargs):
-    """Convert a dataset annotation to COCO format. Returns (segmentation, bbox, area)."""
+def _outline_entry(polygon, **kwargs):
+    """The COCO entry for a single outline."""
+    return polygon.to_coco(**kwargs), polygon.to_box(**kwargs).to_coco(**kwargs), polygon.area(**kwargs)
+
+
+def get_coco_annotations(annotation, **kwargs):
+    """Convert a dataset annotation to COCO entries, each a (segmentation, bbox, area) triple.
+
+    A mask holding disconnected regions stays one entry under one box, the way COCO expresses a single
+    occluded instance. split_regions gives each region its own entry instead, for consumers that read
+    only the box and would otherwise train on one that is mostly background.
+    """
     if isinstance(annotation, MaskAnnotation):
+        if kwargs.get("split_regions", False):
+            return [_outline_entry(region, **kwargs) for region in annotation.value.to_polygons(**kwargs)]
         bbox = annotation.value.to_box(**kwargs)
-        area = annotation.value.area(**kwargs)
-        return annotation.value.to_coco(**kwargs), bbox.to_coco(**kwargs), area
+        return [(annotation.value.to_coco(**kwargs), bbox.to_coco(**kwargs), annotation.value.area(**kwargs))]
     elif isinstance(annotation, PolygonAnnotation):
-        bbox = annotation.value.to_box(**kwargs)
-        area = annotation.value.area(**kwargs)
-        return annotation.value.to_coco(**kwargs), bbox.to_coco(**kwargs), area
+        return [_outline_entry(annotation.value, **kwargs)]
     elif isinstance(annotation, BoxAnnotation):
         poly = annotation.value.to_polygon(**kwargs)
-        segm = poly.to_coco(**kwargs)
-        area = poly.area(**kwargs)
-        return segm, annotation.value.to_coco(**kwargs), area
+        return [(poly.to_coco(**kwargs), annotation.value.to_coco(**kwargs), poly.area(**kwargs))]
     else:
         raise ValueError(f"Unsupported annotation type: {type(annotation)}")
 
@@ -57,7 +64,7 @@ def create_coco_dataset(
         target_classes (list): List of class IDs to include. If None, all classes are used.
         background (bool): Keep images without valid annotations for the target classes as
             background images (a COCO image entry with no annotations). Default False (skip them).
-        **kwargs: Additional options (e.g. merge_boxes, idx0).
+        **kwargs: Additional options (e.g. split_regions, idx0).
 
     Returns:
         Tuple of (Dataset, CocoDataset, Set[str], Dict[str, str]):
@@ -108,7 +115,11 @@ def create_coco_dataset(
         for annotation in filtered_annotations:
             try:
                 # both segmentation and bbox are required for COCO format
-                segmentation, bbox, area = get_coco_annotation(annotation, h=file.height, w=file.width, **kwargs)
+                entries = get_coco_annotations(annotation, h=file.height, w=file.width, **kwargs)
+            except Exception as e:
+                logger.error(f"Error processing  (annotation could be invalid) {annotation.id} for file {file.path}: {e}")
+                continue
+            for segmentation, bbox, area in entries:
                 if bbox[2] <= 0 or bbox[3] <= 0:
                     logger.warning(f"Skipping annotation {annotation.id} for file {file.path} as bbox is invalid: {bbox}")
                     continue
@@ -125,9 +136,6 @@ def create_coco_dataset(
                     )
                 )
                 added_annotations += 1
-            except Exception as e:
-                logger.error(f"Error processing  (annotation could be invalid) {annotation.id} for file {file.path}: {e}")
-                continue
         if added_annotations > 0 or background:
             fnames.add(os.path.basename(file.path))
         else:
@@ -155,7 +163,7 @@ def convert_to_json(args):
     path_val_json = args["path_val_json"] if args["path_val_json"] != "labels.json" else os.path.join(path_val_imgs, args["path_val_json"])
     path_out = args["path_out"]
     background = args.get("bg", False)
-    merge_box = args.get("merge_box", False)
+    split_regions = args.get("split_regions", False)
 
     if not os.path.exists(path_train_json):
         raise FileNotFoundError(f"Train annotations file {path_train_json} does not exist")
@@ -196,7 +204,7 @@ def convert_to_json(args):
         is_crowd=False,
         target_classes=target_classes,
         background=background,
-        merge_boxes=merge_box,
+        split_regions=split_regions,
         idx0=args.get("idx0", False),
     )
     if use_train_for_val:
@@ -212,7 +220,7 @@ def convert_to_json(args):
             is_crowd=False,
             target_classes=target_classes,
             background=background,
-            merge_boxes=merge_box,
+            split_regions=split_regions,
             idx0=args.get("idx0", False),
         )
 

--- a/lmi_utils/label_utils/json_to_yolo.py
+++ b/lmi_utils/label_utils/json_to_yolo.py
@@ -38,17 +38,8 @@ def get_args():
         default="all",
         help="[optional] the comma separated target classes, default=all",
     )
-    ap.add_argument("--obb", action="store_true", help="support for oriented bounding box support")
-    ap.add_argument(
-        "--seg",
-        action="store_true",
-        help='convert label formats: mask-to-bbox if "--convert" is enabled, otherwise bbox-to-mask',
-    )
-    ap.add_argument(
-        "--convert",
-        action="store_true",
-        help='convert label formats: bbox-to-mask if "--seg" is enabled, otherwise mask-to-bbox',
-    )
+    ap.add_argument("--obb", action="store_true", help="emit oriented bounding boxes")
+    ap.add_argument("--seg", action="store_true", help="emit segmentation outlines")
     ap.add_argument(
         "--bg",
         action="store_true",
@@ -57,7 +48,7 @@ def get_args():
     ap.add_argument(
         "--merge_box",
         action="store_true",
-        help="merge multiple instances of same class boxes into one. Brush labels only!",
+        help="keep a mask's disconnected regions as one instance under a single box",
     )
     args = vars(ap.parse_args())
     return args
@@ -142,10 +133,11 @@ def convert_to_yolo(args):
     path_val_json = args["path_val_json"] if args["path_val_json"] != "labels.json" else os.path.join(path_val_imgs, args["path_val_json"])
     path_out = args["path_out"]
     merge_box = args.get("merge_box", False)
-    bbox_to_mask = True if args.get("convert", False) and args.get("seg", False) else False
-    mask_to_od = True if args.get("convert", False) and not args.get("seg", False) else False
     target_classes = args["target_classes"].split(",")
     use_obb = args.get("obb", False)
+    # The target format decides the conversion: a detect label file holds boxes, a segment one outlines
+    bbox_to_mask = args.get("seg", False)
+    mask_to_od = not bbox_to_mask and not use_obb
     path_class_yaml = args.get("path_dataset_yaml", None)
 
     # check if the dataset path exists

--- a/tests/lmi_utils/dataset_utils/test_representations.py
+++ b/tests/lmi_utils/dataset_utils/test_representations.py
@@ -806,3 +806,144 @@ def test_dataset_json_format_preserved():
     assert loaded_anns_by_id["ann_kp"].value.visibility == 1
     assert loaded.labels[0].keypoints == ["label_kp"]
     assert len(loaded_anns_by_id["ann_poly"].value.points) == 4
+
+
+# =====================================================
+#  Target-format Shape Conversion Tests
+# =====================================================
+#
+# Every row a YOLO label file receives must already be in the target format's shape. Ultralytics will
+# reinterpret rows it considers malformed -- a detect row of more than six fields is read as a segment and
+# reduced to its bounding box -- so a row of the wrong width trains without complaint. These tests pin the
+# width at the source rather than relying on that.
+
+_TASK_FLAGS = {
+    "detect": dict(to_segmentation=False, to_object_detection=True, use_obb=False),
+    "segment": dict(to_segmentation=True, to_object_detection=False, use_obb=False),
+    "obb": dict(to_segmentation=False, to_object_detection=False, use_obb=True),
+}
+
+
+def _two_blob_mask():
+    mask = np.zeros((100, 100), np.uint8)
+    mask[10:30, 10:30] = 1
+    mask[60:80, 65:85] = 1
+    return mask
+
+
+def _export(annotation, task, **overrides):
+    """The YOLO rows one annotation produces for a target format."""
+    flags = dict(_TASK_FLAGS[task], merge_boxes=False, target_classes=[], label_id_idx={"label1": 0})
+    flags.update(overrides)
+    rows, _ = FileAnnotations("f", "image.png", 100, 100, [annotation]).to_yolo(**flags)
+    return rows
+
+
+def _annotation(annotation_type):
+    if annotation_type == "box":
+        return BoxAnnotation("a", "label1", Box(10, 10, 30, 30))
+    if annotation_type == "rotated box":
+        return BoxAnnotation("a", "label1", Box(10, 10, 40, 30, angle=30))
+    if annotation_type == "quad polygon":
+        return PolygonAnnotation("a", "label1", Polygon(points=[[10, 10], [30, 12], [28, 30], [12, 28]]))
+    if annotation_type == "hexagon polygon":
+        return PolygonAnnotation("a", "label1", Polygon(points=[[10, 20], [20, 10], [40, 10], [50, 20], [40, 30], [20, 30]]))
+    mask = np.zeros((100, 100), np.uint8)
+    mask[10:30, 10:30] = 1
+    return MaskAnnotation("a", "label1", Mask(mask))
+
+
+@pytest.mark.parametrize("annotation_type", ["box", "rotated box", "quad polygon", "hexagon polygon", "mask"])
+def test_detect_rows_are_always_five_fields(annotation_type):
+    rows = _export(_annotation(annotation_type), "detect")
+    assert [len(row) for row in rows] == [5]  # class + cx cy w h
+
+
+@pytest.mark.parametrize("annotation_type", ["box", "rotated box", "quad polygon", "hexagon polygon", "mask"])
+def test_obb_rows_are_always_nine_fields(annotation_type):
+    rows = _export(_annotation(annotation_type), "obb")
+    assert [len(row) for row in rows] == [9]  # class + four corners
+
+
+@pytest.mark.parametrize("annotation_type", ["box", "rotated box", "quad polygon", "hexagon polygon", "mask"])
+def test_segment_rows_are_a_class_and_point_pairs(annotation_type):
+    rows = _export(_annotation(annotation_type), "segment")
+    assert rows and all(len(row) >= 7 and (len(row) - 1) % 2 == 0 for row in rows)
+
+
+@pytest.mark.parametrize("task,expected_width", [("detect", 5), ("obb", 9)])
+def test_disconnected_mask_becomes_one_instance_per_region(task, expected_width):
+    """A YOLO instance is one connected shape, so two blobs cannot share a row."""
+    rows = _export(MaskAnnotation("a", "label1", Mask(_two_blob_mask())), task)
+    assert [len(row) for row in rows] == [expected_width, expected_width]
+
+
+def test_merge_boxes_keeps_a_disconnected_mask_as_one_box():
+    rows = _export(MaskAnnotation("a", "label1", Mask(_two_blob_mask())), "detect", merge_boxes=True)
+    assert len(rows) == 1
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        PolygonAnnotation("a", "label1", Polygon(points=[[5, 5], [20, 20]])),
+        PolygonAnnotation("a", "label1", Polygon(points=[[5, 5], [10, 5], [20, 5]])),
+        MaskAnnotation("a", "label1", Mask(np.zeros((100, 100), np.uint8))),
+        BoxAnnotation("a", "label1", Box(10, 10, 10, 40)),
+    ],
+    ids=["line", "collinear points", "empty mask", "zero-width box"],
+)
+@pytest.mark.parametrize("task", ["detect", "segment", "obb"])
+def test_geometry_enclosing_no_area_is_not_exported(annotation, task):
+    assert _export(annotation, task) == []
+
+
+def test_detect_box_encloses_the_rotated_object():
+    """A rotated box's own x_min..x_max is where it sat before rotating, not where the object is."""
+    box = Box(20, 40, 80, 60, angle=45)
+    corners = box.to_polygon().to_numpy()
+
+    ((cx, cy, width, height),) = box.to_yolo(100, 100)
+    x_min, x_max = (cx - width / 2) * 100, (cx + width / 2) * 100
+    y_min, y_max = (cy - height / 2) * 100, (cy + height / 2) * 100
+
+    assert x_min <= corners[:, 0].min() and x_max >= corners[:, 0].max()
+    assert y_min <= corners[:, 1].min() and y_max >= corners[:, 1].max()
+
+
+def test_coco_box_encloses_the_rotated_object():
+    box = Box(20, 40, 80, 60, angle=45)
+    corners = box.to_polygon().to_numpy()
+
+    x, y, width, height = box.to_coco()
+
+    assert x <= corners[:, 0].min() and x + width >= corners[:, 0].max()
+    assert y <= corners[:, 1].min() and y + height >= corners[:, 1].max()
+
+
+def test_mask_to_box_merges_and_to_boxes_splits():
+    mask = Mask(_two_blob_mask())
+
+    merged = mask.to_box(h=100, w=100)
+    split = mask.to_boxes(h=100, w=100)
+
+    assert len(split) == 2
+    assert merged.x_min <= min(b.x_min for b in split) and merged.x_max >= max(b.x_max for b in split)
+
+
+def test_mask_to_polygons_skips_regions_enclosing_no_area():
+    mask = np.zeros((100, 100), np.uint8)
+    mask[10:30, 10:30] = 1
+    mask[50, 60:70] = 1  # a one-pixel-tall line
+
+    assert len(Mask(mask).to_polygons(h=100, w=100)) == 1
+
+
+def test_polygon_obb_output_is_its_rotated_box():
+    polygon = Polygon(points=[[10, 20], [20, 10], [40, 10], [50, 20], [40, 30], [20, 30]])
+
+    corners = np.array(polygon.to_yolo(100, 100, use_obb=True))
+    expected = np.array(polygon.to_rbox().to_yolo(100, 100, use_obb=True))
+
+    assert corners.shape == (4, 2)
+    assert corners == pytest.approx(expected)

--- a/tests/lmi_utils/label_utils/test_json_to_coco.py
+++ b/tests/lmi_utils/label_utils/test_json_to_coco.py
@@ -3,7 +3,15 @@ import os
 import cv2
 import numpy as np
 
-from lmi_utils.dataset_utils.representations import Box, BoxAnnotation, Dataset, FileAnnotations, Label
+from lmi_utils.dataset_utils.representations import (
+    Box,
+    BoxAnnotation,
+    Dataset,
+    FileAnnotations,
+    Label,
+    Mask,
+    MaskAnnotation,
+)
 from lmi_utils.label_utils.json_to_coco import convert_to_json, create_coco_dataset
 
 
@@ -75,3 +83,51 @@ def test_convert_to_json_bg_copies_background_images(tmp_path):
     for split in ("train", "valid"):
         copied = {f for f in os.listdir(out_dir / split) if f.endswith(".png")}
         assert copied == {"id0_img0.png", "id1_img1.png", "id2_img2.png"}
+
+
+def build_mask_dataset(blobs):
+    """One file holding one mask annotation, with a filled rectangle per (y0, y1, x0, x1) blob."""
+    mask = np.zeros((100, 200), dtype=np.uint8)
+    for y0, y1, x0, x1 in blobs:
+        mask[y0:y1, x0:x1] = 1
+    file = FileAnnotations(
+        id="0",
+        path="img0.png",
+        height=100,
+        width=200,
+        annotations=[MaskAnnotation(id="a0", label_id="defect", confidence=1.0, value=Mask(mask=mask))],
+        predictions=[],
+    )
+    return Dataset(labels=[Label(id="defect")], files=[file])
+
+
+def test_disconnected_mask_is_one_annotation_by_default():
+    _, coco, _, _ = create_coco_dataset(build_mask_dataset([(10, 30, 10, 30), (60, 80, 65, 85)]))
+    assert len(coco.annotations) == 1
+    # the union of both regions, so the box covers the gap between them
+    assert [round(v) for v in coco.annotations[0].bbox] == [10, 10, 74, 69]
+
+
+def test_split_regions_gives_each_region_its_own_annotation():
+    _, coco, _, _ = create_coco_dataset(build_mask_dataset([(10, 30, 10, 30), (60, 80, 65, 85)]), split_regions=True)
+    assert len(coco.annotations) == 2
+    boxes = sorted([round(v) for v in ann.bbox] for ann in coco.annotations)
+    assert boxes == [[10, 10, 19, 19], [65, 60, 19, 19]]
+
+
+def test_connected_mask_is_one_annotation_either_way():
+    for split_regions in (False, True):
+        _, coco, _, _ = create_coco_dataset(build_mask_dataset([(10, 30, 10, 30)]), split_regions=split_regions)
+        assert len(coco.annotations) == 1
+        assert [round(v) for v in coco.annotations[0].bbox] == [10, 10, 19, 19]
+
+
+def test_split_regions_carry_their_own_segmentation():
+    _, coco, _, _ = create_coco_dataset(build_mask_dataset([(10, 30, 10, 30), (60, 80, 65, 85)]), split_regions=True)
+    for annotation in coco.annotations:
+        xs = annotation.segmentation[0][0::2]
+        ys = annotation.segmentation[0][1::2]
+        # each outline stays inside its own box rather than spanning both regions
+        assert min(xs) == annotation.bbox[0] and min(ys) == annotation.bbox[1]
+        assert max(xs) - min(xs) == annotation.bbox[2]
+        assert max(ys) - min(ys) == annotation.bbox[3]


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary


## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
