### PR TITLE
fix(yolo): correctly infer the imgsz from weights files

### DIFF
--- a/lmi_common/yolo_core.py
+++ b/lmi_common/yolo_core.py
@@ -34,14 +34,26 @@ class YoloCore:
             self.model.model.fuse()
         self.model.eval()
 
-        # set image size
+        self._resolve_image_size(image_size)
+
+        # class map < id: class name >
+        self.names = self.model.names
+
+    def _resolve_image_size(self, image_size):
+        """Set self.image_size from the caller's request, reporting where the model contradicts it."""
         trained = self._infer_image_size()
+        long_side = self._infer_long_side()
         if image_size is not None:
             self.image_size = [int(image_size[0]), int(image_size[1])]
             if trained is not None and self.image_size != trained:
                 self.logger.warning(
                     f"Provided image_size {self.image_size} != model's trained imgsz {trained}; "
                     "inference may be less accurate and differ from how the model was trained."
+                )
+            elif long_side is not None and max(self.image_size) != long_side:
+                self.logger.warning(
+                    f"Provided image_size {self.image_size} does not have the long side {long_side} this model "
+                    "was trained at with rectangular batches; objects will be scaled differently than in training."
                 )
         elif trained is not None:
             self.image_size = trained
@@ -50,18 +62,33 @@ class YoloCore:
             self.image_size = [640, 640]
             self.logger.warning("image_size not specified and trained imgsz unavailable; using [640, 640]")
 
-        # class map < id: class name >
-        self.names = self.model.names
+    def _training_arg(self, name):
+        args = getattr(getattr(self.model, "model", None), "args", None)
+        return args.get(name) if isinstance(args, dict) else getattr(args, name, None)
 
     def _infer_image_size(self):
-        """Return the model's trained imgsz as [h, w], or None if it can't be read (e.g. engine/onnx)."""
-        args = getattr(getattr(self.model, "model", None), "args", None)
-        imgsz = args.get("imgsz") if isinstance(args, dict) else getattr(args, "imgsz", None)
+        """Return the model's input size as [h, w], or None when the model cannot express one.
+
+        An exported model records the real pair in its metadata. A .pt has only its training args, where a
+        rectangular run stores just the long side -- a scalar that is not a shape and must not be read as a
+        square.
+        """
+        metadata = getattr(self.model, "metadata", None)
+        imgsz = metadata.get("imgsz") if isinstance(metadata, dict) else None
+        if isinstance(imgsz, (list, tuple)) and len(imgsz) >= 2:
+            return [int(imgsz[0]), int(imgsz[1])]
+
+        imgsz = self._training_arg("imgsz")
         if isinstance(imgsz, (list, tuple)):
             return [int(imgsz[0]), int(imgsz[1])] if len(imgsz) >= 2 else [int(imgsz[0]), int(imgsz[0])]
         if isinstance(imgsz, int):
-            return [imgsz, imgsz]
+            return None if self._training_arg("rect") else [imgsz, imgsz]
         return None
+
+    def _infer_long_side(self):
+        """Return the long side a rectangular .pt was trained at -- the only size such a model records."""
+        imgsz = self._training_arg("imgsz")
+        return int(imgsz) if isinstance(imgsz, int) and self._training_arg("rect") else None
 
     @smart_inference_mode()
     def from_numpy(self, x: np.ndarray) -> torch.Tensor:

--- a/tests/lmi_common/test_yolo_core.py
+++ b/tests/lmi_common/test_yolo_core.py
@@ -1,0 +1,148 @@
+"""How YoloCore decides the input size a model runs at.
+
+Ultralytics records that size differently per format. An exported model carries the real [h, w] in its
+metadata. A .pt carries only its training args, and a run with rect=True stores just the long side there --
+a scalar that is not a shape, because rect fits each batch to its own aspect ratio. Reading that scalar as
+a square is wrong in both directions: it invents a shape the model never saw, and it hides the one check
+such a model can support.
+"""
+
+import logging
+
+import pytest
+
+from lmi_common.yolo_core import YoloCore
+
+
+def core(metadata=None, args=None):
+    """A YoloCore with only the loaded-model state the size helpers read; __init__ wants a real file."""
+    instance = YoloCore.__new__(YoloCore)
+    backend = type("Backend", (), {})()
+    backend.metadata = metadata
+    backend.model = type("Weights", (), {"args": args})() if args is not None else None
+    instance.model = backend
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# _infer_image_size
+# ---------------------------------------------------------------------------
+
+
+def test_exported_metadata_gives_the_real_pair():
+    """The exporter writes the [h, w] it built the graph at; nothing else knows it as exactly."""
+    assert core(metadata={"imgsz": [480, 640]})._infer_image_size() == [480, 640]
+
+
+def test_metadata_wins_over_training_args():
+    """An exported rectangle must not be overridden by the square long side left in the training args."""
+    assert core(metadata={"imgsz": [384, 640]}, args={"imgsz": 640, "rect": True})._infer_image_size() == [384, 640]
+
+
+def test_square_checkpoint_reports_its_square():
+    """Without rect every image is letterboxed to imgsz, so the scalar really is the shape."""
+    assert core(metadata={"imgsz": None}, args={"imgsz": 640, "rect": False})._infer_image_size() == [640, 640]
+
+
+def test_rect_checkpoint_reports_nothing():
+    """rect stores only the long side, so there is no shape to report and none may be invented."""
+    assert core(metadata={"imgsz": None}, args={"imgsz": 640, "rect": True})._infer_image_size() is None
+
+
+@pytest.mark.parametrize(
+    "imgsz, expected",
+    [([480, 640], [480, 640]), ((480, 640), [480, 640]), ([640], [640, 640])],
+)
+def test_a_pair_in_the_training_args_is_taken_as_written(imgsz, expected):
+    assert core(args={"imgsz": imgsz, "rect": True})._infer_image_size() == expected
+
+
+@pytest.mark.parametrize("metadata, args", [(None, None), ({}, None), ({"imgsz": None}, {})])
+def test_a_model_that_records_no_size_reports_nothing(metadata, args):
+    assert core(metadata=metadata, args=args)._infer_image_size() is None
+
+
+def test_training_args_may_be_an_object_rather_than_a_dict():
+    """AutoBackend hands back a namespace for some formats and a dict for others."""
+    args = type("Args", (), {"imgsz": 640, "rect": False})()
+    assert core(args=args)._infer_image_size() == [640, 640]
+
+
+# ---------------------------------------------------------------------------
+# _infer_long_side
+# ---------------------------------------------------------------------------
+
+
+def test_a_rect_checkpoint_still_knows_its_long_side():
+    """The one fact rect does record, and the only check such a model can support."""
+    assert core(args={"imgsz": 640, "rect": True})._infer_long_side() == 640
+
+
+@pytest.mark.parametrize("args", [{"imgsz": 640, "rect": False}, {"imgsz": [480, 640], "rect": True}, {}, None])
+def test_no_long_side_when_the_shape_is_already_known(args):
+    """Anything that yields a full shape is checked against that shape instead."""
+    assert core(args=args)._infer_long_side() is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_image_size
+# ---------------------------------------------------------------------------
+
+
+def test_the_caller_wins_over_the_model(caplog):
+    """The caller is the only party that can know a rect model's shape, so it is never overridden."""
+    instance = core(metadata={"imgsz": [480, 640]})
+    with caplog.at_level(logging.WARNING):
+        instance._resolve_image_size([640, 640])
+    assert instance.image_size == [640, 640]
+    assert "!= model's trained imgsz [480, 640]" in caplog.text
+
+
+def test_a_size_matching_the_exported_graph_is_silent(caplog):
+    instance = core(metadata={"imgsz": [480, 640]})
+    with caplog.at_level(logging.INFO):
+        instance._resolve_image_size([480, 640])
+    assert instance.image_size == [480, 640]
+    assert caplog.text == ""
+
+
+def test_a_rect_model_at_the_trained_scale_is_silent(caplog):
+    """[480, 640] and [640, 640] both letterbox a 640 long side at the training scale."""
+    instance = core(args={"imgsz": 640, "rect": True})
+    with caplog.at_level(logging.INFO):
+        instance._resolve_image_size([480, 640])
+    assert instance.image_size == [480, 640]
+    assert caplog.text == ""
+
+
+def test_a_rect_model_at_the_wrong_scale_is_reported(caplog):
+    """A shorter long side shrinks every object relative to training, which no padding can undo."""
+    instance = core(args={"imgsz": 640, "rect": True})
+    with caplog.at_level(logging.WARNING):
+        instance._resolve_image_size([320, 480])
+    assert instance.image_size == [320, 480]
+    assert "long side 640" in caplog.text
+
+
+def test_an_unspecified_size_adopts_the_exported_shape(caplog):
+    with caplog.at_level(logging.INFO):
+        instance = core(metadata={"imgsz": [480, 640]})
+        instance._resolve_image_size(None)
+    assert instance.image_size == [480, 640]
+    assert "using model's trained imgsz" in caplog.text
+
+
+def test_an_unspecified_size_falls_back_when_the_model_cannot_say(caplog):
+    """A rect .pt with no caller-supplied size leaves nothing to go on; say so rather than guess quietly."""
+    instance = core(args={"imgsz": 640, "rect": True})
+    with caplog.at_level(logging.WARNING):
+        instance._resolve_image_size(None)
+    assert instance.image_size == [640, 640]
+    assert "trained imgsz unavailable" in caplog.text
+
+
+def test_a_requested_size_is_coerced_to_ints():
+    """Sizes arrive from CLI parsing and config files, not always as ints."""
+    instance = core()
+    instance._resolve_image_size(["480", "640"])
+    assert instance.image_size == [480, 640]

--- a/tests/lmi_common/test_yolo_core_contract.py
+++ b/tests/lmi_common/test_yolo_core_contract.py
@@ -1,0 +1,109 @@
+"""What ultralytics itself records about a model's input size.
+
+The unit tests in test_yolo_core.py hand YoloCore a stub, so they pin our reading of a given input and stay
+green no matter what ultralytics emits. These run the real thing instead: they fail if a future ultralytics
+drops the export metadata, stops collapsing a configured pair to the long side, or starts recording a rect
+run's size as a pair. Each of those silently changes which branch of _infer_image_size a real model takes.
+"""
+
+import numpy as np
+import pytest
+import torch
+from ultralytics import YOLO
+from ultralytics.nn.autobackend import AutoBackend
+from ultralytics.utils.checks import check_imgsz
+
+from lmi_common.yolo_core import YoloCore
+
+ASSET_MODEL = "tests/assets/models/od/ultralytics/yolo11n.pt"
+LONG_SIDE = 640
+DEPLOY_SHAPE = [480, 640]  # deliberately non-square: a square hides every ordering mistake
+
+
+@pytest.fixture(scope="module")
+def rect_dataset(tmp_path_factory):
+    """A two-image dataset written to disk, the minimum a rect training run needs."""
+    cv2 = pytest.importorskip("cv2")
+    yaml = pytest.importorskip("yaml")
+    root = tmp_path_factory.mktemp("rect_data")
+    for split in ("train", "val"):
+        (root / "images" / split).mkdir(parents=True)
+        (root / "labels" / split).mkdir(parents=True)
+        for i in range(2):
+            cv2.imwrite(str(root / "images" / split / f"{i}.jpg"), np.zeros((1080, 1920, 3), np.uint8))
+            (root / "labels" / split / f"{i}.txt").write_text("0 0.5 0.5 0.2 0.2\n")
+    data = root / "data.yaml"
+    data.write_text(yaml.safe_dump({"path": str(root), "train": "images/train", "val": "images/val", "names": {0: "a"}}))
+    return str(data)
+
+
+@pytest.fixture(scope="module")
+def rect_checkpoint(rect_dataset, tmp_path_factory):
+    """A checkpoint from a real rect run, configured with a rectangle to prove the rectangle is dropped."""
+    out = tmp_path_factory.mktemp("rect_run")
+    model = YOLO("yolo11n.yaml", task="detect")
+    model.train(
+        data=rect_dataset,
+        imgsz=[LONG_SIDE, 480],
+        rect=True,
+        epochs=1,
+        batch=2,
+        device="cpu",
+        workers=0,
+        project=str(out),
+        name="run",
+        exist_ok=True,
+        plots=False,
+        val=False,
+        verbose=False,
+    )
+    return out / "run" / "weights" / "last.pt"
+
+
+@pytest.fixture(scope="module")
+def exported_onnx(tmp_path_factory):
+    """A stock checkpoint exported at a non-square size, as the trainer exports a deployable model."""
+    pytest.importorskip("onnx")
+    source = tmp_path_factory.mktemp("export") / "model.pt"
+    source.write_bytes(open(ASSET_MODEL, "rb").read())
+    return YOLO(str(source), task="detect").export(format="onnx", imgsz=DEPLOY_SHAPE, simplify=False, verbose=False)
+
+
+def test_training_still_collapses_a_configured_pair_to_the_long_side():
+    """If this stops holding, a rect checkpoint's imgsz becomes a shape and the scalar branch is wrong."""
+    assert check_imgsz([LONG_SIDE, 480], max_dim=1) == LONG_SIDE
+
+
+def test_a_rect_run_records_a_scalar_and_its_rect_flag(rect_checkpoint):
+    """The scalar plus the flag are exactly what _infer_image_size needs to refuse to invent a shape."""
+    train_args = torch.load(rect_checkpoint, map_location="cpu", weights_only=False)["train_args"]
+    assert train_args["rect"] is True
+    assert isinstance(train_args["imgsz"], int), "a pair here would mean the shape is knowable after all"
+    assert train_args["imgsz"] == LONG_SIDE
+
+
+def test_a_rect_checkpoint_yields_no_shape_but_keeps_its_long_side(rect_checkpoint):
+    """The end the unit tests assert with a stub, reached from a real file."""
+    core = YoloCore(str(rect_checkpoint), device="cpu", image_size=DEPLOY_SHAPE)
+    assert core._infer_image_size() is None
+    assert core._infer_long_side() == LONG_SIDE
+    assert core.image_size == DEPLOY_SHAPE
+
+
+def test_export_still_writes_the_pair_into_the_model_metadata(exported_onnx):
+    """Losing this silently removes the only size check an onnx or engine model has."""
+    backend = AutoBackend(str(exported_onnx), torch.device("cpu"), fuse=False)
+    assert backend.metadata.get("imgsz") == DEPLOY_SHAPE
+
+
+def test_the_metadata_pair_is_height_first(exported_onnx):
+    """Proven against the graph rather than assumed, since a transposed pair still looks well-formed."""
+    ort = pytest.importorskip("onnxruntime")
+    session = ort.InferenceSession(str(exported_onnx), providers=["CPUExecutionProvider"])
+    assert list(session.get_inputs()[0].shape[2:]) == DEPLOY_SHAPE  # NCHW
+
+
+def test_an_exported_model_reports_the_shape_it_was_built_at(exported_onnx):
+    core = YoloCore(str(exported_onnx), device="cpu", image_size=None)
+    assert core._infer_image_size() == DEPLOY_SHAPE
+    assert core.image_size == DEPLOY_SHAPE


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary


## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
