### PR TITLE
feat(anomalib): Implement tiler changes and max training sample estimation for AnomalibV2

### DIFF
--- a/anomaly_detectors/anomalib_lmi/_cli.py
+++ b/anomaly_detectors/anomalib_lmi/_cli.py
@@ -29,17 +29,22 @@ def run_cli(model_cls):
         "--scale_mode", default="padding", choices=["padding", "interpolation"], help="tile scaling mode: padding or interpolation"
     )
     test_ap.add_argument("--limit", type=int, default=None, help="process only the first N images")
+    test_ap.add_argument("-is", "--image_size", type=int, nargs=2, default=None)
 
     convert_ap = subs.add_parser("convert", help="convert model to trt engine")
     convert_ap.add_argument("-i", "--model_path", default="/app/model/model.pt", help="Input model file path.")
     convert_ap.add_argument("-o", "--export_dir", default="/app/export")
     convert_ap.add_argument("-c", "--convert_type", default="trt", choices=["trt", "onnx"], help="convert type: trt or onnx")
     convert_ap.add_argument("--fp32", action="store_true", help="disable fp16 and use fp32 for TRT conversion")
+    convert_ap.add_argument("-is", "--image_size", type=int, nargs=2, default=None)
     args = vars(ap.parse_args())
 
     action = args["action"]
     model_path = args["model_path"]
-    ad = model_cls(model_path)
+    kwargs = {}
+    if args["image_size"] is not None:
+        kwargs["image_size"] = args["image_size"]
+    ad = model_cls(model_path, **kwargs)
 
     if action == "convert":
         export_dir = args["export_dir"]

--- a/anomaly_detectors/anomalib_lmi/gofactory_AD.py
+++ b/anomaly_detectors/anomalib_lmi/gofactory_AD.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 
 from anomaly_detectors.anomalib_lmi.v1.model import AnomalyModel as AnomalyModelV1
+from anomaly_detectors.anomalib_lmi.v2.model import AnomalyModel as AnomalyModelV2
 
 MAX_UINT16 = 65535
 IMG_FORMATS = [".png", ".jpg"]
@@ -27,6 +28,7 @@ def predict(
     resize=False,
     overlap_mode="average",
     annotate=False,
+    version=1,
 ):
     """generating anomaly maps for a set of images
 
@@ -36,6 +38,7 @@ def predict(
         image_size (list): the size of the input images (h,w)
         out_path (str): the output path to save the anomaly maps and summary.json
         recursive (bool, optional): whether to search images recursively. Defaults to True.
+        version (int): Anomalib major version, either 1 or 2. Defaults to 1.
     """
 
     directory_path = Path(images_path)
@@ -49,8 +52,9 @@ def predict(
     if not images:
         return
 
-    logger.info(f"Loading model: {model_path}.")
-    model = AnomalyModelV1(
+    model_class = AnomalyModelV1 if version == 1 else AnomalyModelV2
+    logger.info(f"Loading Anomalib v{version} model: {model_path}.")
+    model = model_class(
         model_path,
         image_size=image_size,
         tile=tile,
@@ -72,14 +76,7 @@ def predict(
         t0 = time.time()
         # predict() returns a list of per-image anomaly maps; this loop runs one
         # image at a time, so take the single result.
-        anom_map = model.predict(
-            img,
-            **{
-                "tiling_settings": {
-                    "overlap_mode": overlap_mode,
-                }
-            },
-        )[0].astype(np.float32)
+        anom_map = model.predict(img)[0].astype(np.float32)
         logger.debug(f"anom_map shape {anom_map.shape}")
 
         proctime.append(time.time() - t0)
@@ -170,6 +167,7 @@ if __name__ == "__main__":
     ap.add_argument("-o", "--output", type=str, required=True, help="path to the output folder")
     ap.add_argument("--height", type=int, required=False, help="input height", default=224)
     ap.add_argument("--width", type=int, required=False, help="image width", default=224)
+    ap.add_argument("--version", type=int, choices=[1, 2], default=1, help="Anomalib model version (default: 1)")
     ap.add_argument("--recursive", action="store_true", help="search images recursively")
     ap.add_argument(
         "--tile",
@@ -223,4 +221,5 @@ if __name__ == "__main__":
         args.resize,
         args.overlap_mode,
         args.annotate,
+        args.version,
     )

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/__init__.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/__init__.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import torch
+
+from .base import BaseAnomalibMemoryEstimator
+from .common import (
+    FeatureProfile,
+    MemoryBudget,
+    MemoryEstimate,
+    TileConfig,
+    dtype_from_precision,
+)
+from .padim import PadimMemoryEstimate, PadimMemoryEstimator
+from .patchcore import PatchCoreMemoryEstimate, PatchCoreMemoryEstimator
+
+__all__ = [
+    "BaseAnomalibMemoryEstimator",
+    "FeatureProfile",
+    "MemoryBudget",
+    "MemoryEstimate",
+    "TileConfig",
+    "dtype_from_precision",
+    "PadimMemoryEstimate",
+    "PadimMemoryEstimator",
+    "PatchCoreMemoryEstimate",
+    "PatchCoreMemoryEstimator",
+    "make_memory_estimator",
+]
+
+
+def make_memory_estimator(
+    model,
+    tile_config: TileConfig,
+    *,
+    precision: str | torch.dtype = "float32",
+    profiling_device: str = "cuda",
+    profiling_dtype: torch.dtype | None = None,
+    stats_dtype: torch.dtype = torch.float32,
+) -> BaseAnomalibMemoryEstimator:
+    """Build the memory estimator matching the anomalib model type."""
+    name = type(model).__name__.lower()
+
+    if "patchcore" in name:
+        return PatchCoreMemoryEstimator(
+            model=model,
+            tile_config=tile_config,
+            precision=precision,
+            profiling_device=profiling_device,
+            profiling_dtype=profiling_dtype,
+        )
+
+    if "padim" in name:
+        return PadimMemoryEstimator(
+            model=model,
+            tile_config=tile_config,
+            precision=precision,
+            profiling_device=profiling_device,
+            profiling_dtype=profiling_dtype,
+            stats_dtype=stats_dtype,
+        )
+
+    raise NotImplementedError(f"No memory estimator for model type: {type(model).__name__}. Supported: patchcore and padim.")

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/base.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/base.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
+
+from .common import (
+    FeatureProfile,
+    MemoryBudget,
+    MemoryEstimate,
+    TileConfig,
+    bytes_to_mib,
+    dtype_from_precision,
+    dtype_nbytes,
+)
+
+_MISSING = object()
+
+
+class BaseAnomalibMemoryEstimator(ABC):
+    """Base estimator for anomalib training memory.
+
+    Anomalib models fall into distinct training-memory categories:
+
+    - memory-bank (peak scales with the number of training images): PatchCore,
+      PaDiM. ``max_train_images`` is the meaningful output.
+    - gradient-trained / deep (peak driven by params + optimizer state + batch
+      activations, independent of dataset size): EfficientAd, Dinomaly, Ganomaly,
+      AnomalyDino. Image count does not constrain storage; see
+      ``GradientTrainedMemoryEstimator``.
+    """
+
+    model_type: str = "base"
+
+    def __init__(
+        self,
+        model,
+        tile_config: TileConfig,
+        *,
+        precision: str | torch.dtype = "float32",
+        profiling_device: str = "cuda",
+        profiling_dtype: torch.dtype | None = None,
+    ):
+        self.model = model
+        self.tile_config = tile_config
+        self.profiling_device = profiling_device
+
+        self.activation_dtype = dtype_from_precision(precision)
+        self.profiling_dtype = profiling_dtype or self.activation_dtype
+        self.activation_dtype_bytes = self.dtype_nbytes(self.activation_dtype)
+
+    dtype_nbytes = staticmethod(dtype_nbytes)
+
+    @staticmethod
+    def dtype_from_string(
+        dtype_str: str,
+        fallback: torch.dtype = torch.float32,
+    ) -> torch.dtype:
+        return dtype_from_precision(dtype_str, fallback=fallback)
+
+    def unwrap_inner_model(self):
+        return getattr(self.model, "model", self.model)
+
+    def _infer_hparam(self, name: str, default, cast=None) -> Any:
+        """Walk model / model.model / hparams candidates for an hparam value."""
+        candidates = [
+            self.model,
+            getattr(self.model, "model", None),
+            getattr(self.model, "hparams", None),
+            getattr(getattr(self.model, "model", None), "hparams", None),
+        ]
+
+        for obj in candidates:
+            if obj is None:
+                continue
+
+            value = getattr(obj, name, _MISSING)
+            if value is _MISSING and hasattr(obj, "get"):
+                value = obj.get(name, _MISSING)
+
+            if value is not _MISSING and value is not None:
+                return cast(value) if cast is not None else value
+
+        return cast(default) if cast is not None else default
+
+    def get_feature_extractor(self):
+        inner = self.unwrap_inner_model()
+
+        if hasattr(inner, "feature_extractor"):
+            return inner.feature_extractor
+
+        if hasattr(self.model, "feature_extractor"):
+            return self.model.feature_extractor
+
+        raise AttributeError(f"Could not find feature_extractor on {type(self.model)}")
+
+    def profile_features(self) -> FeatureProfile:
+        cfg = self.tile_config
+        inner = self.unwrap_inner_model()
+        extractor = self.get_feature_extractor().to(self.profiling_device).eval()
+
+        Th, Tw = cfg.effective_tile_size
+
+        dummy = torch.zeros(
+            1,
+            cfg.channels,
+            Th,
+            Tw,
+            device=self.profiling_device,
+            dtype=self.profiling_dtype,
+        )
+
+        use_autocast = self.profiling_device.startswith("cuda") and self.profiling_dtype in {torch.float16, torch.bfloat16}
+
+        with torch.inference_mode():
+            with torch.autocast(
+                device_type="cuda",
+                dtype=self.profiling_dtype,
+                enabled=use_autocast,
+            ):
+                out = extractor(dummy)
+
+                if isinstance(out, dict):
+                    features = out
+                elif isinstance(out, (list, tuple)):
+                    features = {f"layer_{i}": x for i, x in enumerate(out)}
+                else:
+                    features = {"features": out}
+
+                feature_shapes = {name: tuple(feat.shape) for name, feat in features.items()}
+
+                feature_dtypes = {name: str(feat.dtype) for name, feat in features.items()}
+
+                embedding = None
+                if hasattr(inner, "generate_embedding"):
+                    try:
+                        embedding = inner.generate_embedding(features)
+                    except Exception:
+                        embedding = None
+
+        if embedding is not None:
+            embedding_shape = tuple(embedding.shape)
+            embedding_dtype = str(embedding.dtype)
+        else:
+            max_h = max(shape[-2] for shape in feature_shapes.values())
+            max_w = max(shape[-1] for shape in feature_shapes.values())
+            total_c = sum(shape[1] for shape in feature_shapes.values())
+
+            embedding_shape = (1, total_c, max_h, max_w)
+            embedding_dtype = next(iter(feature_dtypes.values()))
+
+        _, emb_c, emb_h, emb_w = embedding_shape
+        H, W = cfg.image_size
+
+        stitched_h = int(round(H * emb_h / Th))
+        stitched_w = int(round(W * emb_w / Tw))
+
+        return FeatureProfile(
+            feature_shapes=feature_shapes,
+            feature_dtypes=feature_dtypes,
+            embedding_shape_per_tile=embedding_shape,
+            embedding_dtype=embedding_dtype,
+            stitched_embedding_shape=(
+                cfg.batch_size,
+                emb_c,
+                stitched_h,
+                stitched_w,
+            ),
+        )
+
+    def input_tile_batch_mib(self) -> float:
+        cfg = self.tile_config
+        Th, Tw = cfg.effective_tile_size
+
+        n_bytes = cfg.effective_tile_batch * cfg.channels * Th * Tw * self.activation_dtype_bytes
+
+        return bytes_to_mib(n_bytes)
+
+    def feature_batch_mib(self, profile: FeatureProfile) -> float:
+        cfg = self.tile_config
+        total_bytes = 0
+
+        for shape in profile.feature_shapes.values():
+            _, C, H, W = shape
+            total_bytes += cfg.effective_tile_batch * C * H * W * self.activation_dtype_bytes
+
+        return bytes_to_mib(total_bytes)
+
+    def embedding_batch_mib(self, profile: FeatureProfile) -> float:
+        cfg = self.tile_config
+        _, C, H, W = profile.embedding_shape_per_tile
+
+        n_bytes = cfg.effective_tile_batch * C * H * W * self.activation_dtype_bytes
+
+        return bytes_to_mib(n_bytes)
+
+    def activation_peak_mib(self, profile: FeatureProfile) -> float:
+        return self.input_tile_batch_mib() + self.feature_batch_mib(profile) + self.embedding_batch_mib(profile)
+
+    def gross_available_mib(
+        self,
+        memory_budget: MemoryBudget,
+        activation_mib: float,
+        extra_fixed_mib: float = 0.0,
+    ) -> float:
+        return (
+            memory_budget.memory_limit_mib - memory_budget.reserve_mib - memory_budget.fixed_overhead_mib - activation_mib - extra_fixed_mib
+        )
+
+    def effective_budget_mib(
+        self,
+        memory_budget: MemoryBudget,
+        activation_mib: float,
+        extra_fixed_mib: float = 0.0,
+    ) -> float:
+        return max(
+            0.0,
+            self.gross_available_mib(memory_budget, activation_mib, extra_fixed_mib) * memory_budget.safety_fraction,
+        )
+
+    def common_budget_dict(
+        self,
+        memory_budget: MemoryBudget,
+        *,
+        activation_mib: float,
+        effective_budget_mib: float,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        budget = {
+            "memory_limit_mib": memory_budget.memory_limit_mib,
+            "safety_fraction": memory_budget.safety_fraction,
+            "reserve_mib": memory_budget.reserve_mib,
+            "fixed_overhead_mib": memory_budget.fixed_overhead_mib,
+            "activation_peak_mib": activation_mib,
+            "usable_mib": memory_budget.usable_mib,
+            "effective_budget_mib": effective_budget_mib,
+        }
+        if extra:
+            budget.update(extra)
+        return budget
+
+    def common_tiling_dict(self, profile: FeatureProfile) -> dict[str, Any]:
+        return {
+            "image_size": self.tile_config.image_size,
+            "uses_tiling": self.tile_config.uses_tiling,
+            "tile_size": self.tile_config.tile_size,
+            "stride": self.tile_config.stride,
+            "effective_tile_size": self.tile_config.effective_tile_size,
+            "effective_stride": self.tile_config.effective_stride,
+            "batch_size": self.tile_config.batch_size,
+            "n_tiles_h": self.tile_config.n_tiles_h,
+            "n_tiles_w": self.tile_config.n_tiles_w,
+            "tiles_per_image": self.tile_config.tiles_per_image,
+            "effective_tile_batch": self.tile_config.effective_tile_batch,
+            "input_tile_batch_mib": self.input_tile_batch_mib(),
+            "feature_batch_mib": self.feature_batch_mib(profile),
+            "embedding_batch_mib": self.embedding_batch_mib(profile),
+        }
+
+    def common_model_dtype_dict(self, profile: FeatureProfile) -> dict[str, Any]:
+        return {
+            "activation_dtype": str(self.activation_dtype),
+            "activation_dtype_bytes": self.activation_dtype_bytes,
+            "profiling_dtype": str(self.profiling_dtype),
+            "profile_embedding_dtype": profile.embedding_dtype,
+            "profile_feature_dtypes": profile.feature_dtypes,
+        }
+
+    def estimate(self, *, memory_budget: MemoryBudget, **kwargs) -> MemoryEstimate:
+        profile = kwargs.pop("profile", None)
+        if profile is None:
+            profile = self.profile_features()
+
+        return self.estimate_from_profile(
+            profile=profile,
+            memory_budget=memory_budget,
+            **kwargs,
+        )
+
+    @abstractmethod
+    def estimate_from_profile(
+        self,
+        *,
+        profile: FeatureProfile,
+        memory_budget: MemoryBudget,
+        **kwargs,
+    ) -> MemoryEstimate:
+        raise NotImplementedError
+
+    def calibrate_workspace_factor(
+        self,
+        *,
+        observed_peak_mib: float,
+        n_train_images: int,
+        profile: FeatureProfile | None = None,
+        fixed_overhead_mib: float = 0.0,
+    ) -> float:
+        """Recover this estimator's workspace factor from an observed training peak.
+
+        Memory-bank estimators (PatchCore, PaDiM) override this to solve for their
+        per-image workspace overhead. For estimators whose peak does not scale with
+        the training set (e.g. gradient-trained models) calibration is a no-op and
+        returns ``0.0`` so generic calibration pipelines can run unconditionally.
+        """
+        return 0.0

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/common.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/common.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+
+
+def bytes_to_mib(x: float) -> float:
+    return x / 1024**2
+
+
+def mib_to_bytes(x: float) -> int:
+    return int(x * 1024**2)
+
+
+def dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def dtype_from_precision(precision, fallback: torch.dtype = torch.float32) -> torch.dtype:
+    """Resolve a torch dtype from a precision tag, dtype, or finalized dtype string.
+
+    Accepts Lightning-style tags ("16-mixed", "bf16"), plain names ("float16"),
+    and already-finalized ``str(dtype)`` values ("torch.float16").
+    """
+    if isinstance(precision, torch.dtype):
+        return precision
+
+    p = str(precision).lower().removeprefix("torch.")
+
+    if p in {"16", "16-mixed", "fp16", "float16", "half"}:
+        return torch.float16
+
+    if p in {"bf16", "bf16-mixed", "bfloat16"}:
+        return torch.bfloat16
+
+    if p in {"32", "32-true", "fp32", "float32", "full"}:
+        return torch.float32
+
+    return fallback
+
+
+@dataclass
+class MemoryBudget:
+    memory_limit_mib: float
+    fixed_overhead_mib: float = 0.0
+    safety_fraction: float = 1.0
+    reserve_mib: float = 0.0
+
+    @property
+    def usable_mib(self) -> float:
+        return self.memory_limit_mib * self.safety_fraction - self.reserve_mib
+
+    @property
+    def variable_budget_mib(self) -> float:
+        return self.usable_mib - self.fixed_overhead_mib
+
+
+@dataclass
+class TileConfig:
+    image_size: tuple[int, int]
+    batch_size: int
+    tile_size: tuple[int, int] | None = None
+    stride: tuple[int, int] | None = None
+    channels: int = 3
+
+    @property
+    def uses_tiling(self) -> bool:
+        return self.tile_size is not None
+
+    @property
+    def effective_tile_size(self) -> tuple[int, int]:
+        return self.tile_size or self.image_size
+
+    @property
+    def effective_stride(self) -> tuple[int, int]:
+        return self.stride or self.effective_tile_size
+
+    @property
+    def n_tiles_h(self) -> int:
+        if not self.uses_tiling:
+            return 1
+
+        H, _ = self.image_size
+        Th, _ = self.effective_tile_size
+        Sh, _ = self.effective_stride
+
+        return max(1, math.ceil((H - Th) / Sh) + 1)
+
+    @property
+    def n_tiles_w(self) -> int:
+        if not self.uses_tiling:
+            return 1
+
+        _, W = self.image_size
+        _, Tw = self.effective_tile_size
+        _, Sw = self.effective_stride
+
+        return max(1, math.ceil((W - Tw) / Sw) + 1)
+
+    @property
+    def tiles_per_image(self) -> int:
+        return self.n_tiles_h * self.n_tiles_w
+
+    @property
+    def effective_tile_batch(self) -> int:
+        return self.batch_size * self.tiles_per_image
+
+
+@dataclass
+class FeatureProfile:
+    feature_shapes: dict[str, tuple[int, int, int, int]]
+    feature_dtypes: dict[str, str]
+    embedding_shape_per_tile: tuple[int, int, int, int]
+    embedding_dtype: str
+    stitched_embedding_shape: tuple[int, int, int, int]
+
+    @property
+    def embedding_dim(self) -> int:
+        return self.embedding_shape_per_tile[1]
+
+    @property
+    def stitched_h(self) -> int:
+        return self.stitched_embedding_shape[-2]
+
+    @property
+    def stitched_w(self) -> int:
+        return self.stitched_embedding_shape[-1]
+
+    @property
+    def patches_per_image(self) -> int:
+        return self.stitched_h * self.stitched_w
+
+
+@dataclass
+class MemoryEstimate:
+    max_train_images: int | None
+    requested_train_images: int | None = None
+    fits_requested_train_images: bool | None = None
+    budget: dict[str, Any] = field(default_factory=dict)
+    per_image: dict[str, Any] = field(default_factory=dict)
+    requested: dict[str, Any] = field(default_factory=dict)
+    model: dict[str, Any] = field(default_factory=dict)
+    tiling: dict[str, Any] = field(default_factory=dict)
+    feature_profile: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def budget_mib_after_fixed(self) -> float | None:
+        return self.budget.get("effective_budget_mib")
+
+    @property
+    def per_image_peak_mib(self) -> float | None:
+        return self.per_image.get("peak_bank_per_image_mib")
+
+    @property
+    def details(self) -> dict[str, Any]:
+        return {
+            "budget": self.budget,
+            "per_image": self.per_image,
+            "requested": self.requested,
+            "model": self.model,
+            "tiling": self.tiling,
+            "feature_profile": self.feature_profile,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/estimate.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/estimate.py
@@ -1,0 +1,181 @@
+import logging
+
+import torch
+
+from anomaly_detectors.anomalib_lmi.v2.train import build_model, load_config
+
+from . import make_memory_estimator
+from .common import MemoryBudget, TileConfig
+from .patchcore import PatchCoreMemoryEstimator
+
+logger = logging.getLogger(__name__)
+
+# VRAM headroom left free for the CUDA/cuDNN context, allocator fragmentation,
+# framework overhead and other processes. This is memory the estimator's peak
+# model does NOT account for: the CUDA context (~0.6-1 GiB), cuDNN convolution
+# workspaces, backbone forward activations beyond the profiled feature peak, and
+# non-PyTorch allocations. The observed unmodeled floor during PatchCore
+# validation on an 8 GiB card is ~3.5 GiB. Overridable via `memory.reserve_mib`.
+DEFAULT_RESERVE_MIB = 3_000
+# Fallback device memory limit when CUDA is unavailable (e.g. CPU-only hosts).
+FALLBACK_MEMORY_LIMIT_MIB = 24_000
+
+
+def device_memory_limit_mib(device: str = "cuda") -> float:
+    """Total VRAM (MiB) of the given CUDA device, or a fallback when unavailable."""
+    if device.startswith("cuda") and torch.cuda.is_available():
+        index = torch.cuda.current_device()
+        total_bytes = torch.cuda.get_device_properties(index).total_memory
+        return total_bytes / 1024**2
+    return FALLBACK_MEMORY_LIMIT_MIB
+
+
+def estimate_max(train_config, num_samples=0, calibrate=None, reserve_mib=None):
+    if isinstance(train_config, str):
+        train_config = load_config(train_config)
+    model_params = train_config["model"]["params"]
+    precision = model_params.get("precision", "float32").lower()
+
+    # Optional per-run memory tuning. `reserve_mib` is headroom the peak model does
+    # not cover (CUDA context, cuDNN, fragmentation). `inference_chunk_size` controls
+    # the runtime's nearest-neighbour chunk behaviour: unset/None auto-detects from
+    # the installed anomalib, a positive int pins it, and 0 forces the conservative
+    # un-chunked estimate (useful if the training runtime differs from this host).
+    # An explicit `reserve_mib` argument overrides the config value.
+    memory_cfg = train_config.get("memory") or {}
+    if reserve_mib is None:
+        reserve_mib = memory_cfg.get("reserve_mib", DEFAULT_RESERVE_MIB)
+    inference_chunk_size = memory_cfg.get("inference_chunk_size")
+
+    tile_size = model_params.get("tile_size")
+    stride = model_params.get("stride")
+    if isinstance(tile_size, int):
+        tile_size = (tile_size, tile_size)
+    if isinstance(stride, int):
+        stride = (stride, stride)
+    tile_config = TileConfig(
+        image_size=model_params["image_size"],
+        tile_size=tile_size,
+        stride=stride,
+        batch_size=train_config["data"]["train_batch_size"],
+    )
+
+    # build_model mutates model_params (pops image_size/tile_size/stride), so read
+    # everything we need from the config before building the model.
+    coreset_sampling_ratio = model_params.get("coreset_sampling_ratio")
+
+    estimator = make_memory_estimator(
+        model=build_model(train_config["model"]),
+        tile_config=tile_config,
+        precision=precision,
+        profiling_device="cuda",
+    )
+
+    profile = estimator.profile_features()
+
+    if isinstance(calibrate, (list, tuple)):
+        n_train, peak = calibrate
+        factor = estimator.calibrate_workspace_factor(
+            observed_peak_mib=peak,
+            n_train_images=n_train,
+            profile=profile,
+            fixed_overhead_mib=0.0,
+        )
+        return round(factor, 4)
+
+    memory_budget = MemoryBudget(
+        memory_limit_mib=device_memory_limit_mib("cuda"),
+        fixed_overhead_mib=0,
+        safety_fraction=1.00,
+        reserve_mib=reserve_mib,
+    )
+
+    # Only memory-bank estimators constrain the dataset size; each accepts a
+    # different set of kwargs, so build them per model type.
+    extra_kwargs = {}
+    if isinstance(estimator, PatchCoreMemoryEstimator):
+        extra_kwargs = {
+            "coreset_sampling_ratio": coreset_sampling_ratio,
+            "dataset_workspace_factor": 1.0515,
+            # TODO: Add select factor based on image_size, (1.1641) based on 348x348
+            "inference_chunk_size": inference_chunk_size,
+        }
+
+    estimate = estimator.estimate(
+        memory_budget=memory_budget,
+        n_train_images=num_samples,
+        profile=profile,
+        **extra_kwargs,
+    )
+
+    max_images = estimate.max_train_images
+
+    # Report the peak for the dataset size actually used: the requested count when
+    # given, otherwise the resolved cap (training reduces the dataset to it). At 0
+    # images the peak is just activations and misrepresents the real run.
+    peak_reference = num_samples or max_images
+    if peak_reference and peak_reference != num_samples:
+        del estimate
+        estimate = estimator.estimate(
+            memory_budget=memory_budget,
+            n_train_images=peak_reference,
+            profile=profile,
+            **extra_kwargs,
+        )
+
+    peak_mib = estimated_peak_mib(estimate)
+    del estimate
+    return max_images, peak_mib
+
+
+def estimated_peak_mib(estimate):
+    """Estimated peak training memory (MiB), independent of model family.
+
+    For memory-bank models with a requested image count this is the modelled peak
+    at that count; otherwise it falls back to the fixed footprint (activations +
+    params/optimizer/stats), which is the meaningful figure for gradient-trained
+    models where memory does not scale with dataset size.
+    """
+    requested_peak = estimate.requested.get("requested_total_peak_mib")
+    if requested_peak is not None:
+        return requested_peak
+
+    budget = estimate.budget
+    return (
+        budget.get("fixed_overhead_mib", 0.0)
+        + budget.get("activation_peak_mib", 0.0)
+        + budget.get("params_total_mib", 0.0)
+        + budget.get("padim_stats_peak_mib", 0.0)
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-i", "--config", type=str, help="Config yaml path")
+    ap.add_argument("-n", "--num_samples", type=int)
+    ap.add_argument("-c", "--calibrate", type=int, nargs=2, help="(N, peak_mib)")
+    ap.add_argument(
+        "-r",
+        "--reserve_mib",
+        type=int,
+        default=None,
+        help="VRAM headroom (MiB) left free for CUDA/cuDNN context and allocator overhead; overrides the config's memory.reserve_mib.",
+    )
+    args = ap.parse_args()
+
+    out = estimate_max(
+        args.config,
+        args.num_samples,
+        calibrate=args.calibrate,
+        reserve_mib=args.reserve_mib,
+    )
+
+    # Calibration returns a single factor; estimation returns (max_images, peak_mib).
+    if isinstance(out, tuple):
+        max_images, peak_mib = out
+        print(f"max_train_images={max_images}")
+        print(f"estimated_peak_mib={peak_mib:.2f}")
+    else:
+        print(out)

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/padim.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/padim.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+
+from .base import BaseAnomalibMemoryEstimator
+from .common import FeatureProfile, MemoryBudget, MemoryEstimate, bytes_to_mib
+
+
+@dataclass
+class PadimMemoryEstimate(MemoryEstimate):
+    model_type: str = field(default="padim", init=False)
+
+
+class PadimMemoryEstimator(BaseAnomalibMemoryEstimator):
+    model_type = "padim"
+
+    def __init__(
+        self,
+        model,
+        tile_config,
+        *,
+        precision: str | torch.dtype = "float32",
+        profiling_device: str = "cuda",
+        profiling_dtype: torch.dtype | None = None,
+        stats_dtype: torch.dtype = torch.float32,
+    ):
+        super().__init__(
+            model=model,
+            tile_config=tile_config,
+            precision=precision,
+            profiling_device=profiling_device,
+            profiling_dtype=profiling_dtype,
+        )
+
+        # PaDiM covariance / inverse-covariance stats run through torch.linalg.inv,
+        # which uses float32 even when feature extraction runs fp16.
+        self.stats_dtype = stats_dtype
+        self.stats_dtype_bytes = self.dtype_nbytes(stats_dtype)
+
+    def infer_n_features(self, default: int) -> int:
+        return self._infer_hparam("n_features", default, cast=int)
+
+    def resolve_train_embedding_dtype(self, profile: FeatureProfile) -> torch.dtype:
+        """PaDiM training embeddings follow the extracted feature dtype."""
+        if getattr(profile, "feature_dtypes", None):
+            first_feature_dtype = next(iter(profile.feature_dtypes.values()))
+            return self.dtype_from_string(
+                first_feature_dtype,
+                fallback=self.activation_dtype,
+            )
+
+        return self.activation_dtype
+
+    def per_image_embedding_mib(
+        self,
+        profile: FeatureProfile,
+        *,
+        padim_workspace_factor: float = 0.25,
+    ) -> dict[str, Any]:
+        """Per-image cost of the accumulated training memory bank.
+
+        PaDiM appends every batch embedding to ``memory_bank`` and ``torch.vstack``-es
+        them in ``fit()``, so the bank scales with the number of training images.
+        ``padim_workspace_factor`` covers the transient ``vstack`` copy and the
+        gaussian-fit overlap on top of the raw per-image embedding.
+        """
+        raw_D = profile.embedding_dim
+        d = self.infer_n_features(default=raw_D)
+
+        train_embedding_dtype = self.resolve_train_embedding_dtype(profile)
+        train_embedding_dtype_bytes = self.dtype_nbytes(train_embedding_dtype)
+
+        train_embedding_bytes = profile.patches_per_image * d * train_embedding_dtype_bytes
+
+        workspace_bytes = train_embedding_bytes * padim_workspace_factor
+        peak_bytes = train_embedding_bytes + workspace_bytes
+
+        return {
+            "train_embedding_dtype": str(train_embedding_dtype),
+            "train_embedding_dtype_bytes": train_embedding_dtype_bytes,
+            "train_embedding_per_image_mib": bytes_to_mib(train_embedding_bytes),
+            "workspace_per_image_mib": bytes_to_mib(workspace_bytes),
+            "peak_per_image_mib": bytes_to_mib(peak_bytes),
+            "padim_workspace_factor": padim_workspace_factor,
+        }
+
+    def stats_mib(self, profile: FeatureProfile) -> dict[str, Any]:
+        """Fixed-size gaussian stats, independent of the training image count.
+
+        During ``MultiVariateGaussian.fit`` PaDiM holds, simultaneously:
+          - mean:           (d, P)        -> d * P
+          - covariance:     (d, d, P)     -> d * d * P  (transient workspace)
+          - inv_covariance: (P, d, d)     -> P * d * d  (persistent buffer)
+          - identity:       (d, d)        -> d * d
+        so the peak fixed cost is ~2 * P * d * d, not a single term.
+        """
+        raw_D = profile.embedding_dim
+        d = self.infer_n_features(default=raw_D)
+        P = profile.patches_per_image
+        b = self.stats_dtype_bytes
+
+        mean_bytes = P * d * b
+        covariance_bytes = P * d * d * b  # transient (d, d, P) workspace
+        inv_covariance_bytes = P * d * d * b  # persistent (P, d, d) buffer
+        identity_bytes = d * d * b
+
+        persistent_bytes = mean_bytes + inv_covariance_bytes
+        peak_bytes = mean_bytes + covariance_bytes + inv_covariance_bytes + identity_bytes
+
+        return {
+            "stats_dtype": str(self.stats_dtype),
+            "stats_dtype_bytes": b,
+            "padim_mean_mib": bytes_to_mib(mean_bytes),
+            "padim_covariance_mib": bytes_to_mib(covariance_bytes),
+            "padim_inv_covariance_mib": bytes_to_mib(inv_covariance_bytes),
+            "padim_identity_mib": bytes_to_mib(identity_bytes),
+            "padim_stats_persistent_mib": bytes_to_mib(persistent_bytes),
+            "padim_stats_peak_mib": bytes_to_mib(peak_bytes),
+            # Retained for backward compatibility: total stats peak.
+            "padim_stats_mib": bytes_to_mib(peak_bytes),
+        }
+
+    def calibrate_workspace_factor(
+        self,
+        *,
+        observed_peak_mib: float,
+        n_train_images: int,
+        profile: FeatureProfile | None = None,
+        fixed_overhead_mib: float = 0.0,
+    ) -> float:
+        """Recover ``padim_workspace_factor`` from an observed training peak."""
+        if profile is None:
+            profile = self.profile_features()
+
+        per_raw = self.per_image_embedding_mib(profile, padim_workspace_factor=0.0)
+        raw_per_image_mib = per_raw["train_embedding_per_image_mib"]
+
+        activation_mib = self.activation_peak_mib(profile)
+        stats_peak_mib = self.stats_mib(profile)["padim_stats_peak_mib"]
+
+        bank_mib = observed_peak_mib - activation_mib - stats_peak_mib - fixed_overhead_mib
+
+        if n_train_images <= 0 or raw_per_image_mib <= 0:
+            return 0.0
+
+        observed_total_factor = bank_mib / (n_train_images * raw_per_image_mib)
+
+        # Peak model: raw * (1 + workspace_factor)
+        return max(0.0, observed_total_factor - 1.0)
+
+    def estimate_from_profile(
+        self,
+        *,
+        profile: FeatureProfile,
+        memory_budget: MemoryBudget,
+        padim_workspace_factor: float = 0.25,
+        n_train_images: int | None = None,
+        **kwargs,
+    ) -> PadimMemoryEstimate:
+        raw_D = profile.embedding_dim
+        d = self.infer_n_features(default=raw_D)
+
+        per = self.per_image_embedding_mib(
+            profile,
+            padim_workspace_factor=padim_workspace_factor,
+        )
+
+        stats = self.stats_mib(profile)
+        stats_peak_mib = stats["padim_stats_peak_mib"]
+
+        activation_mib = self.activation_peak_mib(profile)
+
+        gross_available_mib = self.gross_available_mib(
+            memory_budget,
+            activation_mib,
+            extra_fixed_mib=stats_peak_mib,
+        )
+        effective_budget_mib = self.effective_budget_mib(
+            memory_budget,
+            activation_mib,
+            extra_fixed_mib=stats_peak_mib,
+        )
+
+        per_image_peak_mib = per["peak_per_image_mib"]
+
+        if effective_budget_mib <= 0 or per_image_peak_mib <= 0:
+            max_images = 0
+        else:
+            max_images = int(effective_budget_mib // per_image_peak_mib)
+
+        fits_requested = None
+        requested: dict[str, Any] = {}
+
+        if n_train_images is not None:
+            fits_requested = n_train_images <= max_images
+
+            requested = {
+                "requested_train_images": n_train_images,
+                "requested_train_embeddings_mib": (n_train_images * per["train_embedding_per_image_mib"]),
+                "requested_workspace_mib": (n_train_images * per["workspace_per_image_mib"]),
+                "requested_variable_peak_mib": (n_train_images * per["peak_per_image_mib"]),
+                "requested_total_peak_mib": (
+                    memory_budget.fixed_overhead_mib + activation_mib + stats_peak_mib + n_train_images * per["peak_per_image_mib"]
+                ),
+            }
+
+        budget = self.common_budget_dict(
+            memory_budget,
+            activation_mib=activation_mib,
+            effective_budget_mib=effective_budget_mib,
+            extra={
+                "padim_stats_peak_mib": stats_peak_mib,
+                "padim_stats_persistent_mib": stats["padim_stats_persistent_mib"],
+                "gross_available_mib_after_activation_and_stats": gross_available_mib,
+            },
+        )
+
+        return PadimMemoryEstimate(
+            max_train_images=max_images,
+            requested_train_images=n_train_images,
+            fits_requested_train_images=fits_requested,
+            budget=budget,
+            per_image=per,
+            requested=requested,
+            model={
+                "raw_embedding_dim": raw_D,
+                "padim_dim_used": d,
+                "patches_per_image": profile.patches_per_image,
+                "padim_workspace_factor": padim_workspace_factor,
+                **self.common_model_dtype_dict(profile),
+                **stats,
+            },
+            tiling=self.common_tiling_dict(profile),
+            feature_profile=asdict(profile),
+        )

--- a/anomaly_detectors/anomalib_lmi/v2/memory_estimation/patchcore.py
+++ b/anomaly_detectors/anomalib_lmi/v2/memory_estimation/patchcore.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+
+from .base import BaseAnomalibMemoryEstimator
+from .common import FeatureProfile, MemoryBudget, MemoryEstimate, bytes_to_mib
+
+# anomalib's PatchcoreModel.nearest_neighbors query chunk size (DEFAULT_CHUNK_SIZE).
+ANOMALIB_QUERY_CHUNK_SIZE = 1024
+# First anomalib release that chunks the nearest-neighbour query AND rewrote
+# euclidean_dist to be fully in-place. Earlier versions (e.g. 2.2.0) compute the
+# full (n_query, M) distance matrix at once with out-of-place arithmetic, the real
+# training-time OOM driver during validation.
+ANOMALIB_CHUNKING_MIN_VERSION = (2, 3)
+# Transient peak of euclidean_dist as a multiple of a single (n_query, M) tensor.
+# < 2.3 builds `x_norm - 2 * matmul(x, y.T) + y_norm.T` out-of-place, keeping the
+# matmul output and the arithmetic result alive at once (~2x). >= 2.3 does the
+# arithmetic in-place (mul_/add_/clamp_min_/sqrt_) on the matmul output (~1x).
+EUCLIDEAN_DIST_UNCHUNKED_FACTOR = 2.0
+EUCLIDEAN_DIST_CHUNKED_FACTOR = 1.0
+
+
+def euclidean_dist_transient_factor(inference_chunk_size: int | None) -> float:
+    """Transient multiplier for the euclidean_dist peak given the runtime's chunk mode.
+
+    A truthy chunk size implies anomalib >= 2.3, whose euclidean_dist is in-place
+    (factor 1); an un-chunked runtime uses the older out-of-place form (factor 2).
+    """
+    return EUCLIDEAN_DIST_CHUNKED_FACTOR if inference_chunk_size else EUCLIDEAN_DIST_UNCHUNKED_FACTOR
+
+
+def detect_inference_chunk_size() -> int | None:
+    """Query chunk size anomalib uses for nearest-neighbour search.
+
+    Returns ``ANOMALIB_QUERY_CHUNK_SIZE`` when the installed anomalib chunks the
+    query, otherwise ``None`` (the full distance matrix is materialised at once).
+    Falls back to ``None`` (the conservative, larger estimate) if the version
+    cannot be determined.
+    """
+    try:
+        from importlib.metadata import version
+
+        parts = version("anomalib").split(".")
+        major, minor = int(parts[0]), int(parts[1])
+    except Exception:
+        return None
+
+    if (major, minor) >= ANOMALIB_CHUNKING_MIN_VERSION:
+        return ANOMALIB_QUERY_CHUNK_SIZE
+    return None
+
+
+@dataclass
+class PatchCoreMemoryEstimate(MemoryEstimate):
+    model_type: str = field(default="patchcore", init=False)
+
+
+class PatchCoreMemoryEstimator(BaseAnomalibMemoryEstimator):
+    model_type = "patchcore"
+
+    def infer_coreset_sampling_ratio(self, default: float = 0.1) -> float:
+        return self._infer_hparam("coreset_sampling_ratio", default, cast=float)
+
+    def get_existing_memory_bank_dtype(self) -> torch.dtype | None:
+        inner = self.unwrap_inner_model()
+
+        bank = getattr(inner, "memory_bank", None)
+        if isinstance(bank, torch.Tensor) and torch.is_floating_point(bank):
+            return bank.dtype
+
+        if isinstance(inner, torch.nn.Module):
+            for _, module in inner.named_modules():
+                bank = getattr(module, "memory_bank", None)
+                if isinstance(bank, torch.Tensor) and torch.is_floating_point(bank):
+                    return bank.dtype
+
+        return None
+
+    def resolve_bank_dtype(self, profile: FeatureProfile) -> torch.dtype:
+        existing_dtype = self.get_existing_memory_bank_dtype()
+        if existing_dtype is not None:
+            return existing_dtype
+
+        if getattr(profile, "feature_dtypes", None):
+            first_feature_dtype = next(iter(profile.feature_dtypes.values()))
+            return self.dtype_from_string(
+                first_feature_dtype,
+                fallback=self.activation_dtype,
+            )
+
+        return self.activation_dtype
+
+    def per_image_bank_mib(
+        self,
+        profile: FeatureProfile,
+        *,
+        coreset_sampling_ratio: float | None = None,
+        dataset_workspace_factor: float = 0.0,
+        include_coreset_in_peak: bool = False,
+    ) -> dict[str, Any]:
+        if coreset_sampling_ratio is None:
+            coreset_sampling_ratio = self.infer_coreset_sampling_ratio()
+
+        bank_dtype = self.resolve_bank_dtype(profile)
+        bank_dtype_bytes = self.dtype_nbytes(bank_dtype)
+
+        raw_bytes = profile.patches_per_image * profile.embedding_dim * bank_dtype_bytes
+
+        coreset_bytes = raw_bytes * coreset_sampling_ratio
+        dataset_workspace_bytes = raw_bytes * dataset_workspace_factor
+
+        raw_phase_bytes = raw_bytes + dataset_workspace_bytes
+        coreset_phase_bytes = coreset_bytes
+
+        if include_coreset_in_peak:
+            peak_bytes = raw_bytes + dataset_workspace_bytes + coreset_bytes
+        else:
+            peak_bytes = max(raw_phase_bytes, coreset_phase_bytes)
+
+        return {
+            "bank_dtype": str(bank_dtype),
+            "bank_dtype_bytes": bank_dtype_bytes,
+            "raw_bank_per_image_mib": bytes_to_mib(raw_bytes),
+            "coreset_bank_per_image_mib": bytes_to_mib(coreset_bytes),
+            "dataset_workspace_per_image_mib": bytes_to_mib(dataset_workspace_bytes),
+            "raw_phase_per_image_mib": bytes_to_mib(raw_phase_bytes),
+            "coreset_phase_per_image_mib": bytes_to_mib(coreset_phase_bytes),
+            "peak_bank_per_image_mib": bytes_to_mib(peak_bytes),
+            "coreset_sampling_ratio": coreset_sampling_ratio,
+            "dataset_workspace_factor": dataset_workspace_factor,
+            "include_coreset_in_peak": include_coreset_in_peak,
+        }
+
+    def query_patches(self, profile: FeatureProfile, *, inference_chunk_size: int | None) -> int:
+        """Number of query rows in the inference distance matrix.
+
+        anomalib scores a full eval batch of ``batch_size * patches_per_image``
+        patches at once; newer versions chunk this at ``inference_chunk_size``. A
+        non-positive/None chunk size leaves the query un-chunked (here the caller
+        has already resolved ``None`` to a concrete size).
+        """
+        n_query = self.tile_config.batch_size * profile.patches_per_image
+        if inference_chunk_size:
+            n_query = min(n_query, inference_chunk_size)
+        return n_query
+
+    def inference_distance_matrix_mib(
+        self,
+        profile: FeatureProfile,
+        *,
+        memory_bank_patches: float,
+        inference_chunk_size: int | None,
+    ) -> float:
+        """Peak of the ``euclidean_dist`` matrix during validation/inference.
+
+        ``euclidean_dist(x, y)`` materialises a ``(n_query, M)`` tensor where ``M``
+        is the coreset/memory-bank patch count. Older (un-chunked) anomalib keeps
+        two such tensors alive at once; >= 2.3 does the arithmetic in-place — see
+        ``euclidean_dist_transient_factor``. This is the dominant PatchCore peak on
+        un-chunked runtimes and drives training-time OOMs (the fit loop runs
+        validation). Cost scales with the memory-bank size, hence with #train images.
+        """
+        n_query = self.query_patches(profile, inference_chunk_size=inference_chunk_size)
+        bank_dtype = self.resolve_bank_dtype(profile)
+        n_bytes = n_query * memory_bank_patches * self.dtype_nbytes(bank_dtype)
+        factor = euclidean_dist_transient_factor(inference_chunk_size)
+        return bytes_to_mib(n_bytes) * factor
+
+    def memory_bank_patches(
+        self,
+        profile: FeatureProfile,
+        *,
+        n_train_images: float,
+        coreset_sampling_ratio: float,
+    ) -> float:
+        """Coreset/memory-bank patch count for a given number of training images."""
+        return n_train_images * profile.patches_per_image * coreset_sampling_ratio
+
+    def calibrate_workspace_factor(
+        self,
+        *,
+        observed_peak_mib: float,
+        n_train_images: int,
+        profile: FeatureProfile | None = None,
+        fixed_overhead_mib: float = 0.0,
+    ) -> float:
+        if profile is None:
+            profile = self.profile_features()
+
+        bank_dtype = self.resolve_bank_dtype(profile)
+        bank_dtype_bytes = self.dtype_nbytes(bank_dtype)
+
+        raw_bank_per_image_mib = bytes_to_mib(profile.patches_per_image * profile.embedding_dim * bank_dtype_bytes)
+
+        activation_mib = self.activation_peak_mib(profile)
+
+        dataset_mib = observed_peak_mib - activation_mib - fixed_overhead_mib
+
+        if n_train_images <= 0 or raw_bank_per_image_mib <= 0:
+            return 0.0
+
+        observed_total_factor = dataset_mib / (n_train_images * raw_bank_per_image_mib)
+
+        # Peak model: raw * (1 + workspace_factor)
+        return max(0.0, observed_total_factor - 1.0)
+
+    def estimate_from_profile(
+        self,
+        *,
+        profile: FeatureProfile,
+        memory_budget: MemoryBudget,
+        n_train_images: int | None = None,
+        coreset_sampling_ratio: float | None = None,
+        dataset_workspace_factor: float = 0.0,
+        include_coreset_in_peak: bool = False,
+        inference_chunk_size: int | None = None,
+    ) -> PatchCoreMemoryEstimate:
+        if coreset_sampling_ratio is None:
+            coreset_sampling_ratio = self.infer_coreset_sampling_ratio()
+
+        # None (the default) auto-detects the runtime's chunk size; a positive int
+        # pins it; 0 forces the conservative, un-chunked estimate.
+        chunk_size = detect_inference_chunk_size() if inference_chunk_size is None else inference_chunk_size
+
+        per = self.per_image_bank_mib(
+            profile,
+            coreset_sampling_ratio=coreset_sampling_ratio,
+            dataset_workspace_factor=dataset_workspace_factor,
+            include_coreset_in_peak=include_coreset_in_peak,
+        )
+
+        activation_mib = self.activation_peak_mib(profile)
+        effective_budget_mib = self.effective_budget_mib(
+            memory_budget,
+            activation_mib,
+        )
+
+        # Constraint 1: coreset/memory-bank storage (grows with #train images).
+        per_image_peak_mib = per["peak_bank_per_image_mib"]
+        max_images_bank = 0 if effective_budget_mib <= 0 else int(effective_budget_mib // per_image_peak_mib)
+
+        # Constraint 2: validation/inference peak. anomalib scores each eval batch
+        # against the whole coreset, so at that point the GPU holds BOTH the
+        # resident coreset (M x d) AND the distance matrix (n_query x M). Both grow
+        # with #train images (M = n_train * patches_per_image * coreset_ratio), so
+        # the per-image cost is the sum of the two.
+        n_query = self.query_patches(profile, inference_chunk_size=chunk_size)
+        bank_dtype_bytes = per["bank_dtype_bytes"]
+        patches_per_train_image = profile.patches_per_image * coreset_sampling_ratio
+        distance_transient_factor = euclidean_dist_transient_factor(chunk_size)
+        distance_mib_per_image = bytes_to_mib(n_query * patches_per_train_image * bank_dtype_bytes) * distance_transient_factor
+        resident_coreset_mib_per_image = per["coreset_bank_per_image_mib"]
+        inference_mib_per_image = distance_mib_per_image + resident_coreset_mib_per_image
+        max_images_distance = (
+            0 if effective_budget_mib <= 0 or inference_mib_per_image <= 0 else int(effective_budget_mib // inference_mib_per_image)
+        )
+
+        # The binding constraint is the smaller of the two.
+        max_images = min(max_images_bank, max_images_distance)
+        binding_constraint = "inference_distance_matrix" if max_images_distance <= max_images_bank else "memory_bank_storage"
+
+        fits_requested = None
+        requested = {}
+
+        if n_train_images is not None:
+            fits_requested = n_train_images <= max_images
+
+            bank_patches = self.memory_bank_patches(
+                profile,
+                n_train_images=n_train_images,
+                coreset_sampling_ratio=coreset_sampling_ratio,
+            )
+            distance_matrix_mib = self.inference_distance_matrix_mib(
+                profile,
+                memory_bank_patches=bank_patches,
+                inference_chunk_size=chunk_size,
+            )
+            bank_peak_mib = n_train_images * per["peak_bank_per_image_mib"]
+            resident_coreset_mib = n_train_images * per["coreset_bank_per_image_mib"]
+            # Validation peak: the coreset stays resident while the distance matrix
+            # is allocated, so they add up.
+            inference_peak_mib = distance_matrix_mib + resident_coreset_mib
+
+            requested = {
+                "requested_train_images": n_train_images,
+                "requested_raw_bank_mib": (n_train_images * per["raw_bank_per_image_mib"]),
+                "requested_coreset_bank_mib": resident_coreset_mib,
+                "requested_dataset_workspace_mib": (n_train_images * per["dataset_workspace_per_image_mib"]),
+                "requested_variable_peak_bank_mib": bank_peak_mib,
+                "requested_inference_distance_matrix_mib": distance_matrix_mib,
+                "requested_inference_peak_mib": inference_peak_mib,
+                "requested_total_peak_mib": (memory_budget.fixed_overhead_mib + activation_mib + max(bank_peak_mib, inference_peak_mib)),
+            }
+
+        return PatchCoreMemoryEstimate(
+            max_train_images=max_images,
+            requested_train_images=n_train_images,
+            fits_requested_train_images=fits_requested,
+            budget=self.common_budget_dict(
+                memory_budget,
+                activation_mib=activation_mib,
+                effective_budget_mib=effective_budget_mib,
+                extra={
+                    "max_train_images_bank_storage": max_images_bank,
+                    "max_train_images_inference_distance": max_images_distance,
+                    "binding_constraint": binding_constraint,
+                },
+            ),
+            per_image={
+                **per,
+                "inference_distance_matrix_per_image_mib": distance_mib_per_image,
+            },
+            requested=requested,
+            model={
+                "embedding_dim": profile.embedding_dim,
+                "patches_per_image": profile.patches_per_image,
+                "coreset_sampling_ratio": coreset_sampling_ratio,
+                "dataset_workspace_factor": dataset_workspace_factor,
+                "inference_chunk_size": chunk_size,
+                "inference_query_patches": n_query,
+                **self.common_model_dtype_dict(profile),
+                "resolved_bank_dtype": per["bank_dtype"],
+                "resolved_bank_dtype_bytes": per["bank_dtype_bytes"],
+            },
+            tiling=self.common_tiling_dict(profile),
+            feature_profile=asdict(profile),
+        )

--- a/anomaly_detectors/anomalib_lmi/v2/tiling.py
+++ b/anomaly_detectors/anomalib_lmi/v2/tiling.py
@@ -1,0 +1,100 @@
+"""Tiler configuration callback. from anomalib v2.3.3"""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import lightning.pytorch as pl
+from anomalib.callbacks.tiler_configuration import TilerConfigurationCallback
+from anomalib.data.utils.tiler import Tiler as BaseAnomalibTiler
+from anomalib.models.components import AnomalibModule
+from torch import Tensor
+
+from lmi_utils.image_utils.tiler import ScaleMode, Tiler
+
+logger = logging.getLogger(__name__)
+
+
+class AnomalibTiler(Tiler, BaseAnomalibTiler):
+    def __init__(self, *args, **kwargs):
+        BaseAnomalibTiler.__init__(self, *args, **kwargs)
+
+    @property
+    def scale_mode(self):
+        return self.mode
+
+    @property
+    def overlap_mode(self):
+        return None
+
+    def tile(self, *args, **kwargs) -> Tensor:
+        return BaseAnomalibTiler.tile(self, *args, **kwargs)
+
+    def untile(self, tiles, scale_mode=None, overlap_mode=None) -> Tensor:
+        orig_mode, self.mode = self.mode, scale_mode or self.mode
+        # overlap_mode unused
+        try:
+            result = BaseAnomalibTiler.untile(self, tiles)
+        finally:
+            self.mode = orig_mode
+        return result
+
+
+class CallbackTiler(Tiler):
+    def __init__(
+        self,
+        tile_size: int | Sequence,
+        stride: int | Sequence | None,
+        remove_border_count: int = 0,
+        mode: ScaleMode = ScaleMode.PADDING,
+        **kwargs,
+    ):
+        # Anomalib's Tiler allows stride=None -> stride=tile_size
+        # This behavior is included in this subclass instead of main
+        # repo Tiler, as stride is expected to always be present in
+        # main Tiler use case
+        tile_size = list(AnomalibTiler.validate_size_type(tile_size))
+        stride = stride or tile_size
+        super().__init__(tile_size, stride, scale_mode=mode)
+        self.remove_border_count = remove_border_count  # unused
+
+    @property
+    def mode(self):
+        return self.scale_mode
+
+
+class TilerConfigCallback(TilerConfigurationCallback):
+    """Callback for configuring image tiling operations"""
+
+    def __init__(
+        self,
+        enable: bool = False,
+        tile_size: int | Sequence = 224,
+        stride: int | Sequence | None = None,
+        remove_border_count: int = 0,
+        mode: ScaleMode = ScaleMode.PADDING,
+        tiler_class: Any = None,
+        **tiler_kwargs,
+    ) -> None:
+        """Initialize tiling configuration."""
+        self.enable = enable
+        self.tile_size = tile_size
+        self.stride = stride
+        self.remove_border_count = remove_border_count
+        self.mode = mode
+        tiler_class = globals()[tiler_class] if isinstance(tiler_class, str) else tiler_class
+        self.tiler_class = tiler_class or CallbackTiler
+        self.tiler_kwargs = tiler_kwargs
+
+    def setup(self, trainer: pl.Trainer, pl_module: pl.LightningModule, stage: str | None = None) -> None:
+        """Set Tiler object within Anomalib Model"""
+        del trainer, stage  # These variables are not used.
+
+        if not self.enable:
+            return
+
+        if isinstance(pl_module, AnomalibModule) and hasattr(pl_module.model, "tiler"):
+            pl_module.model.tiler = self.tiler_class(tile_size=self.tile_size, stride=self.stride, mode=self.mode, **self.tiler_kwargs)
+        else:
+            msg = "Model does not support tiling."
+            raise ValueError(msg)

--- a/anomaly_detectors/anomalib_lmi/v2/train.py
+++ b/anomaly_detectors/anomalib_lmi/v2/train.py
@@ -1,14 +1,22 @@
 import argparse
 import logging
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import anomalib.models as ad_models
+import torch
 import yaml
 from anomalib.data import Folder
 from anomalib.deploy import ExportType
 from anomalib.engine import Engine
+from anomalib.pre_processing import PreProcessor
+
+# import before anomalib to avoid partial-init circular import
 from torchvision.transforms import v2
+
+from .tiling import TilerConfigCallback
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +52,10 @@ def build_augmentations(aug_config: Optional[List[Dict]]) -> Optional[v2.Compose
         params = clean_params(params)
 
         try:
+            if not isinstance(name, str):
+                logger.warning("Transform class_name must be a string. Skipping.")
+                continue
+
             if not hasattr(v2, name):
                 logger.warning(f"Transform '{name}' not found in torchvision.transforms.v2. Skipping.")
                 continue
@@ -58,6 +70,12 @@ def build_augmentations(aug_config: Optional[List[Dict]]) -> Optional[v2.Compose
     return v2.Compose(transforms_list) if transforms_list else None
 
 
+def build_preprocessor(preprocessor_config: Optional[List[Dict]]) -> PreProcessor:
+    """Build an Anomalib preprocessor from torchvision v2 transform settings."""
+    transforms = build_augmentations(preprocessor_config)
+    return PreProcessor(transform=transforms)
+
+
 def build_model(model_config: Dict[str, Any]):
     """
     Dynamically builds the Anomalib model.
@@ -65,6 +83,8 @@ def build_model(model_config: Dict[str, Any]):
     """
     class_name = model_config.get("class_name")
     params = model_config.get("params", {}) or {}
+    for rm in ["tiler_type", "tile_size", "stride", "precision"]:
+        params.pop(rm, None)
 
     # Clean params (convert lists to tuples)
     params = clean_params(params)
@@ -80,11 +100,13 @@ def build_model(model_config: Dict[str, Any]):
     image_size = params.pop("image_size", None)
 
     # 3. Configure Pre-processor (if applicable) using the extracted image_size
-    if hasattr(model_class, "configure_pre_processor") and image_size is not None:
-        if "pre_processor" not in params:
+    if "pre_processor" not in params:
+        if hasattr(model_class, "configure_pre_processor") and image_size is not None:
             logger.info(f"Auto-configuring pre-processor for {class_name} with size {image_size}...")
             pre_processor = model_class.configure_pre_processor(image_size=image_size)
             params["pre_processor"] = pre_processor
+    else:
+        params["pre_processor"] = build_preprocessor(params["pre_processor"])
 
     # 4. Instantiate the model
     try:
@@ -114,15 +136,61 @@ def get_image_size(model) -> Optional[tuple]:
     return None
 
 
+def build_tiler(tile_size, stride, tiler_cls_name=None):
+    if tile_size is None:
+        return []
+    return [TilerConfigCallback(enable=True, tile_size=tile_size, stride=stride, tiler_class=tiler_cls_name)]
+
+
+def estimate_max_samples(config_path, num_samples=None):
+    # Run in a subprocess so the model/CUDA context built for profiling is fully
+    # released on process exit, leaving no lingering VRAM before engine.fit().
+    cmd = [
+        sys.executable,
+        "-m",
+        "anomaly_detectors.anomalib_lmi.v2.memory_estimation.estimate",
+        "-i",
+        config_path,
+    ]
+    if num_samples:
+        cmd.extend(["-n", str(num_samples)])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.warning(f"Could not estimate training memory:\n{result.stderr.strip()}")
+        return None, None
+
+    max_images, peak_mib = None, None
+    for line in result.stdout.strip().splitlines():
+        key, _, value = line.partition("=")
+        key, value = key.strip(), value.strip()
+        try:
+            if key == "max_train_images":
+                max_images = None if value == "None" else int(value)
+            elif key == "estimated_peak_mib":
+                peak_mib = float(value)
+        except ValueError:
+            continue
+
+    if max_images is None and peak_mib is None:
+        logger.warning(f"Unexpected estimate output:\n{result.stdout.strip()}")
+    return max_images, peak_mib
+
+
 def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Train Anomalib Model from YAML config")
     parser.add_argument("--config", type=str, default="config.yaml", help="Path to config file")
+    parser.add_argument("--skip-mem-estimate", action="store_true", help="Run memory estimation before training")
+    parser.add_argument("--ckpt-path", type=Path, help="Path to a Lightning checkpoint to resume")
     args = parser.parse_args()
 
     cfg = load_config(args.config)
 
     # --- Build Model Dynamically ---
+    model_params = cfg["model"]["params"]
+    tiler_cls_name = model_params.pop("tiler_type", None)
+    tiler_callbacks = build_tiler(model_params.pop("tile_size", None), model_params.pop("stride", None), tiler_cls_name=tiler_cls_name)
     model = build_model(cfg["model"])
 
     # --- Data Module Setup ---
@@ -134,20 +202,62 @@ def main():
     eng_cfg = cfg["engine"]
     engine = Engine(
         max_epochs=eng_cfg["max_epochs"],
-        accelerator=eng_cfg["accelerator"],
+        accelerator=eng_cfg.get("accelerator", "gpu"),
         devices=eng_cfg["devices"],
         default_root_dir=Path(eng_cfg["default_root_dir"]),
+        callbacks=tiler_callbacks,
     )
+
+    if not args.skip_mem_estimate:
+        max_dataset_size, estimated_peak_mib = estimate_max_samples(args.config)
+        logger.info(f"Approximated max dataset size: {max_dataset_size or 'Could not estimate max dataset size'}")
+        logger.info(
+            "Estimated training memory: %s",
+            f"{estimated_peak_mib:.2f} MiB" if estimated_peak_mib is not None else "Could not estimate training memory",
+        )
 
     # --- Train ---
     logger.info("Starting training...")
-    engine.fit(model=model, datamodule=datamodule)
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    engine.fit(model=model, datamodule=datamodule, ckpt_path=args.ckpt_path)
+    checkpoint_path = Path(eng_cfg["default_root_dir"]) / "model.ckpt"
+    engine.trainer.save_checkpoint(checkpoint_path)
+    logger.info(
+        "cuda max allocated MiB: %.2f",
+        torch.cuda.max_memory_allocated() / 1024**2,
+    )
+    logger.info(
+        "cuda max reserved MiB: %.2f",
+        torch.cuda.max_memory_reserved() / 1024**2,
+    )
+
+    inner = getattr(model, "model", model)
+
+    for name in ["memory_bank", "embedding", "embeddings"]:
+        if hasattr(inner, name):
+            value = getattr(inner, name)
+            if isinstance(value, torch.Tensor):
+                logger.info(f"{name}: shape={tuple(value.shape)}, dtype={value.dtype}, device={value.device}")
 
     # --- Export to Torch---
     engine.export(model=model, export_type=ExportType.TORCH)
 
     # --- Export to ONNX---
-    engine.export(model=model, export_type=ExportType.ONNX, input_size=get_image_size(model))
+    # Avoid unsupported data type (half precision) issues (ex. reflection_pad2d)
+    model = model.float()
+
+    def export_engine(external_data=False):
+        onnx_kwargs = {"external_data": external_data}
+        engine.export(model=model, export_type=ExportType.ONNX, input_size=get_image_size(model), onnx_kwargs=onnx_kwargs)
+
+    try:
+        export_engine()
+    except RuntimeError as e:
+        if "larger than 2GiB limit" in str(e):
+            # Retry export with external data
+            logger.info("2GiB onnx export limit exceeded, export will include additional files.")
+            export_engine(external_data=True)
 
 
 if __name__ == "__main__":

--- a/lmi_utils/image_utils/tiler.py
+++ b/lmi_utils/image_utils/tiler.py
@@ -4,6 +4,7 @@ from enum import Enum
 from itertools import product
 from math import ceil
 from pathlib import Path
+from typing import Union
 
 import torch
 from torch.nn import functional as F
@@ -179,12 +180,18 @@ def downscale_image(image: torch.Tensor, size: tuple, mode: ScaleMode = ScaleMod
     return image
 
 
+def as_int(x):
+    if isinstance(x, torch.Tensor):
+        return int(x.detach().cpu().item())
+    return int(x)
+
+
 class Tiler:
     logger = logging.getLogger("Tiler")
 
     EXPECTED_FIELDS = {"tile_size", "stride", "im_size", "scale_size", "batch_size", "num_channel", "n_tiles"}
 
-    def __init__(self, tile_size, stride):
+    def __init__(self, tile_size, stride, scale_mode="padding", overlap_mode="average"):
         """init tiler
 
         Args:
@@ -201,11 +208,13 @@ class Tiler:
         self.tile_size = tile_size
         self.stride = stride
         self.im_size: list = None
-        self.scale_size: list = None
+        self.scale_size: Union[list, tuple] = None
         self.batch_size: int = None
         self.num_channel: int = None
         self.n_tiles: list = None
         self._blend_mask_cache = {}  # Cache for blend masks by overlap mode
+        self.scale_mode: Union[str, ScaleMode] = scale_mode
+        self.overlap_mode: Union[str, OverlapMode] = overlap_mode
 
     @classmethod
     def validate_tile_and_stride(cls, tile_size, stride):
@@ -301,16 +310,17 @@ class Tiler:
             raise RuntimeError(f"Tiler state incomplete. Missing: {missing}. Call tile() first or ensure metadata contains all fields.")
 
     @torch.inference_mode()
-    def tile(self, im: torch.Tensor, mode="padding") -> torch.Tensor:
+    def tile(self, im: torch.Tensor, mode=None) -> torch.Tensor:
         """generate tiles from the image. Will resize images if necessary.
 
         Args:
             im (Tensor): input image in the format: [b,c,h,w]
-            mode (str | ScaleMode, optional): scale mode. Defaults to "padding".
+            mode (str | ScaleMode, optional): scale mode. Defaults to self.scale_mode.
 
         Returns:
             Tensor: resized tiles
         """
+        mode = mode or self.scale_mode
         if not isinstance(mode, (str, ScaleMode)):
             raise ValueError(f"mode must be str or ScaleMode enum. Got: {type(mode)}")
 
@@ -354,20 +364,22 @@ class Tiler:
     def untile(
         self,
         tiles,
-        scale_mode="padding",
-        overlap_mode="average",
+        scale_mode=None,
+        overlap_mode=None,
     ):
         """convert tiles into original image. Apply blending for smooth transitions.
 
         Args:
             tiles (Torch): the tiles tensor in the format: [n_tiles*batch, c, tile_h, tile_w]
-            scale_mode (str | ScaleMode, optional): scale mode. Defaults to "padding".
-            overlap_mode (str | OverlapMode, optional): overlap handling mode. Defaults to "average".
+            scale_mode (str | ScaleMode, optional): scale mode. Defaults to self.scale_mode.
+            overlap_mode (str | OverlapMode, optional): overlap handling mode. Defaults to self.overlap_mode.
 
         Returns:
             Tensor: the reconstructed image with smooth blending
         """
         self._validate_state()
+        scale_mode = scale_mode or self.scale_mode
+        overlap_mode = overlap_mode or self.overlap_mode
         if not isinstance(scale_mode, (str, ScaleMode)):
             raise ValueError(f"scale_mode must be str or ScaleMode enum. Got: {type(scale_mode)}")
         if not isinstance(overlap_mode, (str, OverlapMode)):
@@ -384,50 +396,70 @@ class Tiler:
         expected_n_tiles = self.n_tiles[0] * self.n_tiles[1] * self.batch_size
         if n_tiles_total != expected_n_tiles:
             raise ValueError(f"Expected {expected_n_tiles} tiles, got {n_tiles_total}")
-        if [tile_h, tile_w] != self.tile_size:
-            raise ValueError(f"Expected tile size {self.tile_size}, got [{tile_h}, {tile_w}]")
+
+        # Allow untiling for model feature maps
+        scale_h = int(tile_h) / self.tile_size[0]
+        scale_w = int(tile_w) / self.tile_size[1]
+
+        def scale_2d(size, scale_h, scale_w):
+            return [
+                int(round(as_int(size[0]) * scale_h)),
+                int(round(as_int(size[1]) * scale_w)),
+            ]
+
+        out_tile_size = [tile_h, tile_w]
+        out_stride = [max(1, d) for d in scale_2d(self.stride, scale_h, scale_w)]
+        out_scale_size = scale_2d(self.scale_size, scale_h, scale_w)
+        out_im_size = scale_2d(self.im_size, scale_h, scale_w)
+        # ----------------------------------------
 
         tiles = tiles.contiguous().view(-1, self.batch_size, num_channel, tile_h, tile_w)
         device = tiles.device
 
-        im = torch.zeros(self.batch_size, num_channel, *self.scale_size, device=device)
+        im = torch.zeros(self.batch_size, num_channel, *out_scale_size, device=device)
 
         if overlap_mode == OverlapMode.MAX:
             for tile, (i, j) in zip(
                 tiles,
                 product(
-                    range(0, self.scale_size[0] - self.tile_size[0] + 1, self.stride[0]),
-                    range(0, self.scale_size[1] - self.tile_size[1] + 1, self.stride[1]),
+                    range(0, out_scale_size[0] - out_tile_size[0] + 1, out_stride[0]),
+                    range(0, out_scale_size[1] - out_tile_size[1] + 1, out_stride[1]),
                 ),
             ):
                 # Take maximum between existing values and new tile
-                im[:, :, i : i + self.tile_size[0], j : j + self.tile_size[1]] = torch.maximum(
-                    im[:, :, i : i + self.tile_size[0], j : j + self.tile_size[1]],
+                im[:, :, i : i + out_tile_size[0], j : j + out_tile_size[1]] = torch.maximum(
+                    im[:, :, i : i + out_tile_size[0], j : j + out_tile_size[1]],
                     tile,
                 )
         else:
-            cache_key = (overlap_mode.value, device.type, device.index if device.index is not None else -1)
+            cache_key = (
+                overlap_mode.value,
+                tuple(out_tile_size),
+                tuple(out_stride),
+                device.type,
+                device.index if device.index is not None else -1,
+            )
             if cache_key not in self._blend_mask_cache:
-                self._blend_mask_cache[cache_key] = create_blend_mask(self.tile_size, self.stride, overlap_mode, device)
+                self._blend_mask_cache[cache_key] = create_blend_mask(out_tile_size, out_stride, overlap_mode, device)
 
             blend_mask = self._blend_mask_cache[cache_key]
-            weight_sum = torch.zeros(self.batch_size, num_channel, *self.scale_size, device=device)
+            weight_sum = torch.zeros(self.batch_size, num_channel, *out_scale_size, device=device)
 
             blend_mask_broadcast = blend_mask.unsqueeze(0).unsqueeze(0).expand(self.batch_size, num_channel, -1, -1)
 
             for tile, (i, j) in zip(
                 tiles,
                 product(
-                    range(0, self.scale_size[0] - self.tile_size[0] + 1, self.stride[0]),
-                    range(0, self.scale_size[1] - self.tile_size[1] + 1, self.stride[1]),
+                    range(0, out_scale_size[0] - out_tile_size[0] + 1, out_stride[0]),
+                    range(0, out_scale_size[1] - out_tile_size[1] + 1, out_stride[1]),
                 ),
             ):
                 weighted_tile = tile * blend_mask_broadcast
 
-                im[:, :, i : i + self.tile_size[0], j : j + self.tile_size[1]] += weighted_tile
-                weight_sum[:, :, i : i + self.tile_size[0], j : j + self.tile_size[1]] += blend_mask_broadcast
+                im[:, :, i : i + out_tile_size[0], j : j + out_tile_size[1]] += weighted_tile
+                weight_sum[:, :, i : i + out_tile_size[0], j : j + out_tile_size[1]] += blend_mask_broadcast
 
             eps = 1e-8
             im = torch.div(im, weight_sum + eps)
 
-        return downscale_image(im, self.im_size, scale_mode).to(tiles.dtype)
+        return downscale_image(im, out_im_size, scale_mode).to(tiles.dtype)

--- a/lmi_utils/image_utils/tiler.py
+++ b/lmi_utils/image_utils/tiler.py
@@ -409,7 +409,10 @@ class Tiler:
 
         out_tile_size = [tile_h, tile_w]
         out_stride = [max(1, d) for d in scale_2d(self.stride, scale_h, scale_w)]
-        out_scale_size = scale_2d(self.scale_size, scale_h, scale_w)
+        out_scale_size = [
+            out_tile_size[0] + (self.n_tiles[0] - 1) * out_stride[0],
+            out_tile_size[1] + (self.n_tiles[1] - 1) * out_stride[1],
+        ]
         out_im_size = scale_2d(self.im_size, scale_h, scale_w)
         # ----------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ test = [
     "transformers==5.13.1",
     "pycocotools==2.0.11",
     "shapely==2.1.2",
+    "tabulate>=0.9.0",
 ]
 # CPU / CI env (GitHub runners): CPU torch + CPU onnxruntime. torch is also a
 # transitive dep of rfdetr/ultralytics, hence the ci/gpu conflict below.

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/conftest.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/conftest.py
@@ -1,0 +1,99 @@
+# tests/memory/conftest.py
+
+import pytest
+import torch
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.common import FeatureProfile, TileConfig
+
+
+@pytest.fixture
+def tiled_config():
+    return TileConfig(
+        image_size=(348, 348),
+        tile_size=(174, 174),
+        stride=(87, 87),
+        batch_size=32,
+        channels=3,
+    )
+
+
+@pytest.fixture
+def no_tiling_config():
+    return TileConfig(
+        image_size=(348, 348),
+        tile_size=None,
+        stride=None,
+        batch_size=32,
+        channels=3,
+    )
+
+
+@pytest.fixture
+def patchcore_profile_fp16():
+    return FeatureProfile(
+        feature_shapes={
+            "layer2": (1, 512, 22, 22),
+            "layer3": (1, 1024, 11, 11),
+        },
+        feature_dtypes={
+            "layer2": "torch.float16",
+            "layer3": "torch.float16",
+        },
+        # Deliberately fp32 because your probe can return fp32 embedding
+        # while actual PatchCore memory_bank follows feature/training dtype.
+        embedding_shape_per_tile=(1, 1536, 22, 22),
+        embedding_dtype="torch.float32",
+        stitched_embedding_shape=(32, 1536, 44, 44),
+    )
+
+
+@pytest.fixture
+def patchcore_profile_fp32():
+    return FeatureProfile(
+        feature_shapes={
+            "layer2": (1, 512, 22, 22),
+            "layer3": (1, 1024, 11, 11),
+        },
+        feature_dtypes={
+            "layer2": "torch.float32",
+            "layer3": "torch.float32",
+        },
+        embedding_shape_per_tile=(1, 1536, 22, 22),
+        embedding_dtype="torch.float32",
+        stitched_embedding_shape=(32, 1536, 44, 44),
+    )
+
+
+class FakeFeatureExtractor(torch.nn.Module):
+    def forward(self, x):
+        b = x.shape[0]
+        dtype = x.dtype
+        device = x.device
+
+        return {
+            "layer2": torch.zeros(b, 512, 22, 22, dtype=dtype, device=device),
+            "layer3": torch.zeros(b, 1024, 11, 11, dtype=dtype, device=device),
+        }
+
+
+class FakePatchCoreInner(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.feature_extractor = FakeFeatureExtractor()
+
+    def generate_embedding(self, features):
+        # Reproduce the real mismatch you saw:
+        # feature outputs fp16, generated embedding probe fp32.
+        first = next(iter(features.values()))
+        b = first.shape[0]
+        return torch.zeros(b, 1536, 22, 22, dtype=torch.float32, device=first.device)
+
+
+class FakePatchCoreOuter:
+    def __init__(self):
+        self.model = FakePatchCoreInner()
+
+
+@pytest.fixture
+def fake_patchcore_model():
+    return FakePatchCoreOuter()

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_factory.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_factory.py
@@ -1,0 +1,50 @@
+# tests/memory/test_factory.py
+
+import pytest
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation import (
+    PadimMemoryEstimator,
+    PatchCoreMemoryEstimator,
+    make_memory_estimator,
+)
+
+
+class Patchcore:
+    pass
+
+
+class Padim:
+    n_features = 100
+
+
+class EfficientAd:
+    pass
+
+
+class Unknown:
+    pass
+
+
+def test_factory_builds_patchcore(tiled_config):
+    est = make_memory_estimator(
+        Patchcore(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+    assert isinstance(est, PatchCoreMemoryEstimator)
+
+
+def test_factory_builds_padim(tiled_config):
+    est = make_memory_estimator(
+        Padim(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+    assert isinstance(est, PadimMemoryEstimator)
+
+
+def test_factory_rejects_unknown(tiled_config):
+    with pytest.raises(NotImplementedError):
+        make_memory_estimator(Unknown(), tile_config=tiled_config)

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_padim_math.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_padim_math.py
@@ -1,0 +1,128 @@
+# tests/memory/test_padim_math.py
+
+import pytest
+import torch
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.common import MemoryBudget
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.padim import (
+    PadimMemoryEstimator as MemoryEstimator,
+)
+
+# Budget matching a 24 GB device (kept fixed so the math is deterministic
+# regardless of the machine running the tests).
+MEMORY_LIMIT_MIB = 24_000
+RESERVE_MIB = 500
+
+# PaDiM stats dimensions from the tiled_config / patchcore_profile_fp16 fixtures:
+# patches_per_image=1936, n_features=100, float32 stats (4 bytes).
+N_FEATURES = 100
+PATCHES_PER_IMAGE = 1936
+STATS_DTYPE_BYTES = 4
+BYTES_PER_MIB = 1024**2
+
+
+class FakePadim:
+    n_features = N_FEATURES
+
+
+def test_padim_stats_scale_with_n_features(tiled_config, patchcore_profile_fp16):
+    est = MemoryEstimator(
+        model=FakePadim(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+        stats_dtype=torch.float32,
+    )
+
+    estimate = est.estimate(
+        memory_budget=MemoryBudget(memory_limit_mib=MEMORY_LIMIT_MIB, reserve_mib=RESERVE_MIB),
+        profile=patchcore_profile_fp16,
+        padim_workspace_factor=0.25,
+        n_train_images=1000,
+    )
+
+    assert estimate.model["padim_dim_used"] == N_FEATURES
+    assert estimate.model["padim_covariance_mib"] == pytest.approx(
+        (PATCHES_PER_IMAGE * N_FEATURES * N_FEATURES * STATS_DTYPE_BYTES) / BYTES_PER_MIB
+    )
+    assert estimate.max_train_images > 0
+
+
+def test_padim_stats_peak_counts_covariance_and_inv_covariance(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    est = MemoryEstimator(
+        model=FakePadim(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+        stats_dtype=torch.float32,
+    )
+
+    stats = est.stats_mib(patchcore_profile_fp16)
+
+    P, d, b = PATCHES_PER_IMAGE, N_FEATURES, STATS_DTYPE_BYTES
+    cov = (P * d * d * b) / BYTES_PER_MIB
+    inv = (P * d * d * b) / BYTES_PER_MIB
+    mean = (P * d * b) / BYTES_PER_MIB
+    identity = (d * d * b) / BYTES_PER_MIB
+
+    assert stats["padim_covariance_mib"] == pytest.approx(cov)
+    assert stats["padim_inv_covariance_mib"] == pytest.approx(inv)
+    # Peak holds covariance workspace AND inv_covariance simultaneously (~2 P d d).
+    assert stats["padim_stats_peak_mib"] == pytest.approx(cov + inv + mean + identity)
+    assert stats["padim_stats_persistent_mib"] == pytest.approx(inv + mean)
+    assert stats["padim_stats_mib"] == pytest.approx(stats["padim_stats_peak_mib"])
+
+
+def test_padim_estimate_type_and_budget_uses_stats_peak(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    est = MemoryEstimator(
+        model=FakePadim(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+        stats_dtype=torch.float32,
+    )
+
+    estimate = est.estimate(
+        memory_budget=MemoryBudget(memory_limit_mib=MEMORY_LIMIT_MIB, reserve_mib=RESERVE_MIB),
+        profile=patchcore_profile_fp16,
+        n_train_images=1000,
+    )
+
+    assert estimate.model_type == "padim"
+    assert estimate.budget["padim_stats_peak_mib"] == pytest.approx(estimate.model["padim_stats_peak_mib"])
+    assert estimate.fits_requested_train_images is not None
+
+
+def test_padim_calibration_recovers_workspace_factor(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    est = MemoryEstimator(
+        model=FakePadim(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+        stats_dtype=torch.float32,
+    )
+
+    per = est.per_image_embedding_mib(patchcore_profile_fp16, padim_workspace_factor=0.0)
+    activation = est.activation_peak_mib(patchcore_profile_fp16)
+    stats_peak = est.stats_mib(patchcore_profile_fp16)["padim_stats_peak_mib"]
+
+    n = 500
+    factor = 0.3
+    observed = activation + stats_peak + n * per["train_embedding_per_image_mib"] * (1 + factor)
+
+    recovered = est.calibrate_workspace_factor(
+        observed_peak_mib=observed,
+        n_train_images=n,
+        profile=patchcore_profile_fp16,
+    )
+
+    assert recovered == pytest.approx(factor, rel=1e-6)

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_fake_profile.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_fake_profile.py
@@ -1,0 +1,54 @@
+# tests/memory/test_patchcore_fake_profile.py
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.patchcore import (
+    PatchCoreMemoryEstimator as MemoryEstimator,
+)
+
+
+def test_profile_fp16_features_but_fp32_embedding_resolves_fp16_bank(
+    fake_patchcore_model,
+    tiled_config,
+):
+    est = MemoryEstimator(
+        model=fake_patchcore_model,
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    profile = est.profile_features()
+
+    per = est.per_image_bank_mib(
+        profile,
+        coreset_sampling_ratio=0.07,
+        dataset_workspace_factor=1.1641,
+    )
+
+    assert profile.feature_dtypes["layer2"] == "torch.float16"
+    assert profile.feature_dtypes["layer3"] == "torch.float16"
+
+    # This intentionally reproduces your real behavior.
+    assert profile.embedding_dtype == "torch.float32"
+
+    # This is the critical behavior.
+    assert per["bank_dtype"] == "torch.float16"
+
+
+def test_profile_fp32_resolves_fp32_bank(fake_patchcore_model, tiled_config):
+    est = MemoryEstimator(
+        model=fake_patchcore_model,
+        tile_config=tiled_config,
+        precision="float32",
+        profiling_device="cpu",
+    )
+
+    profile = est.profile_features()
+
+    per = est.per_image_bank_mib(
+        profile,
+        coreset_sampling_ratio=0.07,
+        dataset_workspace_factor=1.1641,
+    )
+
+    assert profile.feature_dtypes["layer2"] == "torch.float32"
+    assert per["bank_dtype"] == "torch.float32"

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_math.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_math.py
@@ -1,0 +1,260 @@
+# tests/memory/test_patchcore_math.py
+
+import pytest
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.common import MemoryBudget
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.patchcore import (
+    ANOMALIB_QUERY_CHUNK_SIZE,
+    EUCLIDEAN_DIST_CHUNKED_FACTOR,
+    EUCLIDEAN_DIST_UNCHUNKED_FACTOR,
+)
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.patchcore import (
+    PatchCoreMemoryEstimator as MemoryEstimator,
+)
+
+# --- Shared test inputs (derived from the tiled_config / patchcore_profile_fp16
+# fixtures: patches_per_image=1936, embedding_dim=1536, fp16 bank). ---
+CORESET_SAMPLING_RATIO = 0.07
+DATASET_WORKSPACE_FACTOR = 1.1641
+
+# Budget matching a 24 GB device (kept fixed so the math is deterministic
+# regardless of the machine running the tests).
+MEMORY_LIMIT_MIB = 24_000
+RESERVE_MIB = 757
+
+# Calibration inputs (an observed peak / image count from a real 24 GB run).
+OBSERVED_PEAK_MIB = 23_243
+OBSERVED_N_TRAIN = 1782
+
+# --- Expected outputs for the fp16 fixture (coreset excluded from peak). ---
+RAW_BANK_PER_IMAGE_MIB = 5.671875
+CORESET_BANK_PER_IMAGE_MIB = 0.39703125
+DATASET_WORKSPACE_PER_IMAGE_MIB = 6.60263
+PEAK_BANK_PER_IMAGE_MIB = 12.274505
+EXPECTED_MAX_TRAIN_IMAGES = 1839
+EXPECTED_WORKSPACE_FACTOR = 1.234
+
+# When the query is NOT chunked (older anomalib), the validation peak dominates:
+# the (n_query x M) distance matrix plus the resident coreset, with
+# n_query = batch_size * patches_per_image. euclidean_dist keeps ~2x the matrix
+# alive at once (EUCLIDEAN_DIST_TRANSIENT_FACTOR), so this cap drops well below
+# bank storage. Derived from the same fixture.
+EXPECTED_MAX_TRAIN_IMAGES_UNCHUNKED = 696
+
+
+def test_patchcore_fp16_per_image_math(tiled_config, patchcore_profile_fp16):
+    est = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    per = est.per_image_bank_mib(
+        patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+    )
+
+    assert per["bank_dtype"] == "torch.float16"
+    assert per["bank_dtype_bytes"] == 2
+    assert per["raw_bank_per_image_mib"] == pytest.approx(RAW_BANK_PER_IMAGE_MIB)
+    assert per["coreset_bank_per_image_mib"] == pytest.approx(CORESET_BANK_PER_IMAGE_MIB)
+    assert per["dataset_workspace_per_image_mib"] == pytest.approx(DATASET_WORKSPACE_PER_IMAGE_MIB, rel=1e-4)
+    assert per["peak_bank_per_image_mib"] == pytest.approx(PEAK_BANK_PER_IMAGE_MIB, rel=1e-4)
+
+
+def test_patchcore_fp32_per_image_is_about_2x_fp16(
+    tiled_config,
+    patchcore_profile_fp16,
+    patchcore_profile_fp32,
+):
+    est16 = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+    est32 = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float32",
+        profiling_device="cpu",
+    )
+
+    per16 = est16.per_image_bank_mib(
+        patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+    )
+    per32 = est32.per_image_bank_mib(
+        patchcore_profile_fp32,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+    )
+
+    assert per32["peak_bank_per_image_mib"] == pytest.approx(
+        2 * per16["peak_bank_per_image_mib"],
+        rel=1e-6,
+    )
+
+
+def test_patchcore_calibration_recovers_workspace_factor(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    est = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    factor = est.calibrate_workspace_factor(
+        observed_peak_mib=OBSERVED_PEAK_MIB,
+        n_train_images=OBSERVED_N_TRAIN,
+        profile=patchcore_profile_fp16,
+        fixed_overhead_mib=0.0,
+    )
+
+    assert factor == pytest.approx(EXPECTED_WORKSPACE_FACTOR, rel=0.01)
+
+
+def test_patchcore_estimate_known_target_1782(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    est = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    estimate = est.estimate(
+        memory_budget=MemoryBudget(
+            memory_limit_mib=MEMORY_LIMIT_MIB,
+            reserve_mib=RESERVE_MIB,
+            fixed_overhead_mib=0,
+            safety_fraction=1.0,
+        ),
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+        # Chunked query keeps the inference distance matrix small so bank storage
+        # is the binding constraint (matches the original 24 GB calibration).
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+
+    assert estimate.budget["binding_constraint"] == "memory_bank_storage"
+    assert estimate.max_train_images == EXPECTED_MAX_TRAIN_IMAGES
+
+
+def test_patchcore_unchunked_inference_distance_binds(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    """On anomalib versions that don't chunk, the (n_query x M) distance matrix
+    is the binding constraint and caps max_train_images well below bank storage."""
+    est = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    estimate = est.estimate(
+        memory_budget=MemoryBudget(
+            memory_limit_mib=MEMORY_LIMIT_MIB,
+            reserve_mib=RESERVE_MIB,
+            fixed_overhead_mib=0,
+            safety_fraction=1.0,
+        ),
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+        inference_chunk_size=0,  # 0 forces the conservative, un-chunked estimate
+    )
+
+    assert estimate.budget["binding_constraint"] == "inference_distance_matrix"
+    assert estimate.max_train_images == EXPECTED_MAX_TRAIN_IMAGES_UNCHUNKED
+    assert estimate.max_train_images < EXPECTED_MAX_TRAIN_IMAGES
+
+
+def test_patchcore_distance_matrix_transient_factor_depends_on_chunk_mode(
+    tiled_config,
+    patchcore_profile_fp16,
+):
+    """Un-chunked anomalib (< 2.3) keeps two (n_query, M) tensors alive (2x); the
+    chunked, in-place euclidean_dist (>= 2.3) keeps one (1x)."""
+    est = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+    memory_bank_patches = 10_000
+    bank_dtype_bytes = est.dtype_nbytes(est.resolve_bank_dtype(patchcore_profile_fp16))
+
+    # Un-chunked: 2x a single (n_query, M) tensor.
+    n_query_unchunked = est.query_patches(patchcore_profile_fp16, inference_chunk_size=0)
+    single_unchunked_mib = (n_query_unchunked * memory_bank_patches * bank_dtype_bytes) / 1024**2
+    distance_unchunked = est.inference_distance_matrix_mib(
+        patchcore_profile_fp16,
+        memory_bank_patches=memory_bank_patches,
+        inference_chunk_size=0,
+    )
+    assert distance_unchunked == pytest.approx(EUCLIDEAN_DIST_UNCHUNKED_FACTOR * single_unchunked_mib)
+
+    # Chunked: 1x a single (chunk_size, M) tensor.
+    n_query_chunked = est.query_patches(patchcore_profile_fp16, inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE)
+    single_chunked_mib = (n_query_chunked * memory_bank_patches * bank_dtype_bytes) / 1024**2
+    distance_chunked = est.inference_distance_matrix_mib(
+        patchcore_profile_fp16,
+        memory_bank_patches=memory_bank_patches,
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+    assert distance_chunked == pytest.approx(EUCLIDEAN_DIST_CHUNKED_FACTOR * single_chunked_mib)
+
+
+def test_patchcore_fp32_max_roughly_half_fp16(
+    tiled_config,
+    patchcore_profile_fp16,
+    patchcore_profile_fp32,
+):
+    budget = MemoryBudget(
+        memory_limit_mib=MEMORY_LIMIT_MIB,
+        reserve_mib=RESERVE_MIB,
+        fixed_overhead_mib=0,
+        safety_fraction=1.0,
+    )
+
+    est16 = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+    est32 = MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float32",
+        profiling_device="cpu",
+    )
+
+    e16 = est16.estimate(
+        memory_budget=budget,
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+    )
+    e32 = est32.estimate(
+        memory_budget=budget,
+        profile=patchcore_profile_fp32,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+    )
+
+    assert e32.max_train_images < e16.max_train_images
+    assert e32.max_train_images == pytest.approx(e16.max_train_images / 2, rel=0.10)

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_monotonic.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_patchcore_monotonic.py
@@ -1,0 +1,64 @@
+# tests/memory/test_patchcore_monotonic.py
+
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.common import MemoryBudget
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.patchcore import (
+    ANOMALIB_QUERY_CHUNK_SIZE,
+)
+from anomaly_detectors.anomalib_lmi.v2.memory_estimation.patchcore import (
+    PatchCoreMemoryEstimator as MemoryEstimator,
+)
+
+CORESET_SAMPLING_RATIO = 0.07
+DATASET_WORKSPACE_FACTOR = 1.1641
+
+
+def make_est(tiled_config):
+    return MemoryEstimator(
+        model=object(),
+        tile_config=tiled_config,
+        precision="float16",
+        profiling_device="cpu",
+    )
+
+
+def test_more_memory_increases_max_images(tiled_config, patchcore_profile_fp16):
+    est = make_est(tiled_config)
+
+    low = est.estimate(
+        memory_budget=MemoryBudget(memory_limit_mib=12_000, reserve_mib=500),
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+    high = est.estimate(
+        memory_budget=MemoryBudget(memory_limit_mib=24_000, reserve_mib=500),
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+
+    assert high.max_train_images > low.max_train_images
+
+
+def test_higher_workspace_reduces_max_images(tiled_config, patchcore_profile_fp16):
+    est = make_est(tiled_config)
+    budget = MemoryBudget(memory_limit_mib=24_000, reserve_mib=500)
+
+    low = est.estimate(
+        memory_budget=budget,
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=0.0,
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+    high = est.estimate(
+        memory_budget=budget,
+        profile=patchcore_profile_fp16,
+        coreset_sampling_ratio=CORESET_SAMPLING_RATIO,
+        dataset_workspace_factor=DATASET_WORKSPACE_FACTOR,
+        inference_chunk_size=ANOMALIB_QUERY_CHUNK_SIZE,
+    )
+
+    assert high.max_train_images < low.max_train_images

--- a/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_tile_config.py
+++ b/tests/anomaly_detectors/anomalib_lmi/memory_estimation/test_tile_config.py
@@ -1,0 +1,21 @@
+# tests/memory/test_tile_config.py
+
+
+def test_tiled_config_counts(tiled_config):
+    assert tiled_config.uses_tiling is True
+    assert tiled_config.effective_tile_size == (174, 174)
+    assert tiled_config.effective_stride == (87, 87)
+    assert tiled_config.n_tiles_h == 3
+    assert tiled_config.n_tiles_w == 3
+    assert tiled_config.tiles_per_image == 9
+    assert tiled_config.effective_tile_batch == 288
+
+
+def test_no_tiling_config_counts(no_tiling_config):
+    assert no_tiling_config.uses_tiling is False
+    assert no_tiling_config.effective_tile_size == (348, 348)
+    assert no_tiling_config.effective_stride == (348, 348)
+    assert no_tiling_config.n_tiles_h == 1
+    assert no_tiling_config.n_tiles_w == 1
+    assert no_tiling_config.tiles_per_image == 1
+    assert no_tiling_config.effective_tile_batch == 32

--- a/tests/anomaly_detectors/anomalib_lmi/test_v2.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_v2.py
@@ -233,7 +233,9 @@ def test_folder_dataset_non_empty():
         normal_dir = os.path.join(tmpdir, "normal")
         os.makedirs(normal_dir)
         dummy = np.zeros((32, 32, 3), dtype=np.uint8)
-        cv2.imwrite(os.path.join(normal_dir, "img.png"), dummy)
+        # Two images so the 0.5 synthetic split yields at least 1 image per subset (floor(2*0.5)=1).
+        cv2.imwrite(os.path.join(normal_dir, "img0.png"), dummy)
+        cv2.imwrite(os.path.join(normal_dir, "img1.png"), dummy)
 
         datamodule = build_data(
             {

--- a/tests/anomaly_detectors/anomalib_lmi/test_v2.py
+++ b/tests/anomaly_detectors/anomalib_lmi/test_v2.py
@@ -15,6 +15,7 @@ from anomalib.deploy.inferencers.torch_inferencer import TorchInferencer
 from anomaly_detectors.ad_core.anomaly_detector import AnomalyDetector
 from anomaly_detectors.anomalib_lmi.convert_to_torchscript import convert_v2_torchscript
 from anomaly_detectors.anomalib_lmi.v2.model import AnomalyModel as AnomalyModelV2
+from anomaly_detectors.anomalib_lmi.v2.train import build_data, build_preprocessor
 
 os.environ["TRUST_REMOTE_CODE"] = "1"
 
@@ -218,3 +219,62 @@ def test_compare_trt_onnx(trt_model):
         pred_trt = trt_model.predict(rgb)[0]
         pred_onnx = onnx_model.predict(rgb)[0]
         assert np.allclose(pred_trt, pred_onnx, atol=0.01, rtol=0.05), f"TRT vs ONNX mismatch for {os.path.basename(p)}"
+
+
+def test_folder_dataset_non_empty():
+    """Ensure build_data produces a non-empty samples frame with correct label values.
+
+    Regression guard: pandas 3.x stores StrEnum labels as their str() representation
+    (e.g. "DirType.NORMAL") instead of the enum value ("normal"), which causes
+    make_folder_dataset to produce an empty samples frame and training to fail.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a minimal normal_dir structure: tmpdir/normal/img.png
+        normal_dir = os.path.join(tmpdir, "normal")
+        os.makedirs(normal_dir)
+        dummy = np.zeros((32, 32, 3), dtype=np.uint8)
+        cv2.imwrite(os.path.join(normal_dir, "img.png"), dummy)
+
+        datamodule = build_data(
+            {
+                "name": "test_dataset",
+                "root": tmpdir,
+                "normal_dir": "normal",
+                "extensions": [".png"],
+                "train_batch_size": 1,
+                "eval_batch_size": 1,
+                "num_workers": 0,
+                "test_split_mode": "synthetic",
+                "test_split_ratio": 0.5,
+                "val_split_mode": "same_as_test",
+                "val_split_ratio": 0.5,
+            }
+        )
+
+        datamodule.setup()
+        samples = datamodule.train_data.samples
+
+        assert len(samples) > 0, (
+            "Dataset is empty — pandas may be storing StrEnum labels as 'DirType.NORMAL' instead of 'normal'. Ensure pandas<3 is installed."
+        )
+
+        label_col = "label_index" if "label_index" in samples.columns else "label"
+        assert label_col in samples.columns, f"Expected label column not found; columns: {list(samples.columns)}"
+
+        if "label" in samples.columns:
+            bad = [v for v in samples["label"].unique() if "DirType" in str(v)]
+            assert not bad, (
+                f"Labels contain raw StrEnum repr: {bad}. Ensure pandas<3 is installed to fix DirType.NORMAL label serialization."
+            )
+
+
+def test_build_preprocessor():
+    pre_processor = build_preprocessor(
+        [
+            {"class_name": "Resize", "params": {"size": [64, 32]}},
+            {"class_name": "Normalize", "params": {"mean": [0.5, 0.5, 0.5], "std": [0.5, 0.5, 0.5]}},
+        ]
+    )
+
+    assert pre_processor.transform is not None
+    assert [type(transform).__name__ for transform in pre_processor.transform.transforms] == ["Resize", "Normalize"]

--- a/tests/dockerfile.ci
+++ b/tests/dockerfile.ci
@@ -33,5 +33,7 @@ RUN git clone --depth 1 -b ${ANOMALIB_VERSION} https://github.com/open-edge-plat
     if [ "${ANOMALIB_VERSION}" != "v2.2.0" ]; then \
         pip install --no-cache-dir "jsonargparse==4.27.7" && \
         anomalib install --option core; \
+    else \
+        pip install --no-cache-dir 'pandas<3'; \
     fi && \
     rm -rf anomalib

--- a/tests/dockerfile.tests
+++ b/tests/dockerfile.tests
@@ -35,4 +35,4 @@ RUN pip install 'numpy<2'
 
 # --- anomalib v2 suite (test_v2.py) ---
 FROM base AS v2
-RUN pip install anomalib==2.4.1
+RUN pip install anomalib==2.2.0 tabulate

--- a/tests/dockerfile.tests
+++ b/tests/dockerfile.tests
@@ -35,4 +35,5 @@ RUN pip install 'numpy<2'
 
 # --- anomalib v2 suite (test_v2.py) ---
 FROM base AS v2
-RUN pip install anomalib==2.2.0 tabulate
+RUN pip install anomalib==2.2.0
+RUN pip install 'pandas<3'

--- a/tests/lmi_utils/image_utils/test_tiler.py
+++ b/tests/lmi_utils/image_utils/test_tiler.py
@@ -91,3 +91,15 @@ def test_batch(im, tile, stride):
     tiles = t.tile(im, mode)
     im2 = t.untile(tiles, mode)
     assert torch.equal(im, im2)
+
+
+def test_untile_non_integral_feature_scale_covers_output():
+    image = torch.ones(1, 1, 640, 640)
+    tiler = Tiler([224, 224], [112, 112])
+    features = torch.nn.functional.interpolate(tiler.tile(image), size=(55, 55), mode="nearest")
+
+    reconstructed = tiler.untile(features)
+
+    assert reconstructed.shape == (1, 1, 157, 157)
+    assert torch.isfinite(reconstructed).all()
+    assert torch.equal(reconstructed, torch.ones_like(reconstructed))

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -31,7 +31,7 @@ elif [ "$ARGUMENT" == "ad-v1" ]; then
     pytest --html=$outpath/anomaly_detectors_v1.html tests/anomaly_detectors/anomalib_lmi/test_v1.py
 elif [ "$ARGUMENT" == "ad-v2" ]; then
     build_engines ad_v2
-    pytest --html=$outpath/anomaly_detectors_v2.html tests/anomaly_detectors/anomalib_lmi/test_v2.py
+    pytest --html=$outpath/anomaly_detectors_v2.html tests/anomaly_detectors/anomalib_lmi/test_v2.py tests/anomaly_detectors/anomalib_lmi/memory_estimation/
 else
     echo "Invalid argument. Please use 'all-v1' 'od' 'utils' 'ad-v1' 'ad-v2' 'cls'. "
     exit 1


### PR DESCRIPTION
## Summary
- Adds memory estimation for Anomalib v2 PatchCore and PaDiM training.
- Adds model-specific estimators that profile extracted features and account for image tiling, precision, VRAM budget, reserve headroom, and dataset size.
- Adds Anomalib tiler callback integration and corrects blend-mask generation for non-average overlap modes.
- train.py: added --skip-mem-estimate and --ckpt-path, report peak CUDA allocation/reservation, save lightning checkpoint for resuming training

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
