### PR TITLE
feat: embed model metadata in onnx/engine files

### DIFF
--- a/lmi_common/inference_engine.py
+++ b/lmi_common/inference_engine.py
@@ -1,4 +1,4 @@
-from typing import List, Protocol, Tuple, runtime_checkable
+from typing import Any, Dict, List, Protocol, Tuple, runtime_checkable
 
 import torch
 
@@ -18,5 +18,6 @@ class InferenceEngine(Protocol):
     input_shape: Tuple[int, ...]
     fp16: bool
     is_dynamic: bool
+    metadata: Dict[str, Any]  # embedded model metadata; {} when the file carries none
 
     def infer(self, *inputs: torch.Tensor) -> List[torch.Tensor]: ...

--- a/lmi_common/model_metadata.py
+++ b/lmi_common/model_metadata.py
@@ -1,0 +1,85 @@
+"""Embed and read model metadata (class names, ...) so a deployed model is a single file.
+
+An ONNX file carries the payload in its ``metadata_props``. A serialized TensorRT plan has no
+metadata slot, so the engine file is prefixed with a length-tagged JSON header — the same layout
+ultralytics uses, which keeps their engines readable here.
+
+Metadata is always optional: readers return ``{}`` for a file that carries none, and writers skip
+an empty payload, so plain ONNX files and headerless engines keep working unchanged.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+ONNX_METADATA_KEY = "lmi_metadata"
+
+_PLAN_MAGIC = b"ftrt"  # first bytes of a headerless serialized TensorRT plan
+_MAX_HEADER_BYTES = 1 << 20
+
+
+def embed_onnx_metadata(onnx_path: str, metadata: Mapping[str, Any]) -> None:
+    """Write ``metadata`` into an ONNX file's metadata_props, in place. Requires the ``onnx`` package."""
+    import onnx
+
+    model = onnx.load(onnx_path)
+    prop = next((p for p in model.metadata_props if p.key == ONNX_METADATA_KEY), None)
+    if prop is None:
+        prop = model.metadata_props.add()
+        prop.key = ONNX_METADATA_KEY
+    prop.value = json.dumps(dict(metadata))
+    onnx.save(model, onnx_path)
+    logger.info(f"Embedded metadata {sorted(metadata)} in {onnx_path}")
+
+
+def read_onnx_metadata(onnx_path: str) -> Dict[str, Any]:
+    """Read embedded metadata from an ONNX file ({} when it carries none, or when ``onnx`` is not installed)."""
+    try:
+        import onnx
+    except ImportError:
+        logger.warning(f"onnx is not installed; reading no metadata from {onnx_path}")
+        return {}
+
+    model = onnx.load(onnx_path, load_external_data=False)
+    return metadata_from_onnx_props({p.key: p.value for p in model.metadata_props})
+
+
+def metadata_from_onnx_props(props: Optional[Mapping[str, str]]) -> Dict[str, Any]:
+    """Decode the payload out of an ONNX metadata map, e.g. onnxruntime's ``custom_metadata_map``."""
+    raw = (props or {}).get(ONNX_METADATA_KEY)
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(f"Ignoring unreadable '{ONNX_METADATA_KEY}' ONNX metadata")
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def engine_metadata_header(metadata: Mapping[str, Any]) -> bytes:
+    """Serialize ``metadata`` as the length-tagged JSON header that prefixes an engine plan."""
+    payload = json.dumps(dict(metadata)).encode("utf-8")
+    return len(payload).to_bytes(4, byteorder="little", signed=True) + payload
+
+
+def split_engine_metadata(raw: bytes) -> Tuple[Dict[str, Any], bytes]:
+    """Split engine-file bytes into (metadata, serialized plan).
+
+    A plan carrying no header is returned untouched with empty metadata. TensorRT rejects a plan with
+    leading bytes, so the header must be stripped before deserializing.
+    """
+    if raw[:4] == _PLAN_MAGIC:
+        return {}, raw
+    length = int.from_bytes(raw[:4], byteorder="little", signed=True)
+    if not 0 < length <= min(_MAX_HEADER_BYTES, len(raw) - 4):
+        return {}, raw
+    try:
+        value = json.loads(raw[4 : 4 + length].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}, raw
+    if not isinstance(value, dict):
+        return {}, raw
+    return value, raw[4 + length :]

--- a/lmi_common/model_metadata.py
+++ b/lmi_common/model_metadata.py
@@ -35,12 +35,8 @@ def embed_onnx_metadata(onnx_path: str, metadata: Mapping[str, Any]) -> None:
 
 
 def read_onnx_metadata(onnx_path: str) -> Dict[str, Any]:
-    """Read embedded metadata from an ONNX file ({} when it carries none, or when ``onnx`` is not installed)."""
-    try:
-        import onnx
-    except ImportError:
-        logger.warning(f"onnx is not installed; reading no metadata from {onnx_path}")
-        return {}
+    """Read embedded metadata from an ONNX file ({} when it carries none)."""
+    import onnx
 
     model = onnx.load(onnx_path, load_external_data=False)
     return metadata_from_onnx_props({p.key: p.value for p in model.metadata_props})

--- a/lmi_common/onnx_engine.py
+++ b/lmi_common/onnx_engine.py
@@ -1,9 +1,11 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import torch
+
+from lmi_common.model_metadata import metadata_from_onnx_props
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +61,9 @@ class ONNXEngine:
     On CUDA, I/O is bound to torch CUDA tensors via ORT's IOBinding for a zero-copy GPU
     pipeline. Output buffers are pre-allocated once at max shape. Only a symbolic batch
     dim (dim 0) is supported; symbolic non-batch dims raise ``NotImplementedError``.
+
+    Embedded metadata written by ``lmi_common.model_metadata`` is exposed as ``self.metadata``
+    ({} for a model without any).
 
     Not thread-safe — create one instance per thread.
 
@@ -175,6 +180,9 @@ class ONNXEngine:
         self.input_shape: Tuple[int, ...] = input_spatial[first]
         self.fp16: bool = self.input_dtype == torch.float16
         self.is_dynamic: bool = is_dynamic
+        self.metadata: Dict[str, Any] = metadata_from_onnx_props(self._session.get_modelmeta().custom_metadata_map)
+        if self.metadata:
+            logger.info(f"ONNX metadata: {sorted(self.metadata)}")
 
         # Reusable IOBinding (CUDA only). Static outputs are bound once; dynamic-batch outputs
         # must be rebound each call so ORT's reported shape matches the actual computed shape.

--- a/lmi_common/trt_convert.py
+++ b/lmi_common/trt_convert.py
@@ -6,6 +6,8 @@ Requires TensorRT >= 8.5 (matches `lmi_common/trt_engine.py`).
 import inspect
 import logging
 
+from lmi_common.model_metadata import engine_metadata_header, read_onnx_metadata
+
 logger = logging.getLogger(__name__)
 
 _trt_logger_singleton = None
@@ -78,8 +80,9 @@ def onnx_to_trt(
     """Build a serialized TensorRT engine from an ONNX file.
 
     A static-shape ultralytics ONNX is built by ``ultralytics.utils.export.onnx2engine`` so its export metadata is embedded in the
-    plan file; everything else is built here. Static-batch ONNX (no dynamic dims) ignores the batch kwargs. Dynamic-batch ONNX
-    (axis 0 == -1) gets an optimization profile from the kwargs; other dynamic axes are not supported and will raise.
+    plan file; everything else is built here, and metadata embedded in the source ONNX is carried over to the engine's header.
+    Static-batch ONNX (no dynamic dims) ignores the batch kwargs. Dynamic-batch ONNX (axis 0 == -1) gets an optimization profile
+    from the kwargs; other dynamic axes are not supported and will raise.
 
     Args:
         onnx_path: source .onnx path.
@@ -154,6 +157,9 @@ def onnx_to_trt(
     if serialized_engine is None:
         raise RuntimeError("TensorRT engine build failed")
 
+    metadata = read_onnx_metadata(onnx_path)
     with open(engine_path, "wb") as f:
+        if metadata:
+            f.write(engine_metadata_header(metadata))
         f.write(serialized_engine)
     logger.info(f"TensorRT engine saved to {engine_path}")

--- a/lmi_common/trt_engine.py
+++ b/lmi_common/trt_engine.py
@@ -1,7 +1,9 @@
 import logging
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import torch
+
+from lmi_common.model_metadata import split_engine_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +14,9 @@ class TRTEngine:
     I/O buffers are allocated as torch CUDA tensors at init (at max-batch shape for
     dynamic engines). Only a dynamic batch dim (dim 0) is supported; dynamic spatial
     dims raise ``NotImplementedError``.
+
+    A metadata header written by ``lmi_common.trt_convert`` is stripped before deserializing and
+    exposed as ``self.metadata`` ({} for an engine without one).
 
     Not thread-safe — create one instance per thread.
 
@@ -41,9 +46,12 @@ class TRTEngine:
 
         runtime = trt.Runtime(trt_logger)
         with open(engine_path, "rb") as f:
-            engine = runtime.deserialize_cuda_engine(f.read())
+            metadata, plan = split_engine_metadata(f.read())
+        engine = runtime.deserialize_cuda_engine(plan)
         if engine is None:
             raise RuntimeError(f"Failed to deserialize TensorRT engine: {engine_path}")
+        if metadata:
+            logger.info(f"Engine metadata: {sorted(metadata)}")
 
         self._engine = engine
         self.context = engine.create_execution_context()
@@ -127,6 +135,7 @@ class TRTEngine:
         self.input_shape: Tuple[int, ...] = tuple(first_input_buf.shape[1:])  # (C, H, W)
         self.fp16: bool = first_input_buf.dtype == torch.float16
         self.is_dynamic: bool = is_dynamic
+        self.metadata: Dict[str, Any] = metadata
 
     def release(self) -> None:
         """Release TensorRT resources deterministically (context before engine) and drop CUDA I/O buffers.

--- a/object_detectors/rf_detr_lmi/cli.py
+++ b/object_detectors/rf_detr_lmi/cli.py
@@ -23,7 +23,7 @@ except ImportError as e:
     logging.error(f"Failed to import rfdetr models: {e}")
     raise
 
-from object_detectors.rf_detr_lmi.convert import _write_class_names, convert_to_onnx, convert_to_tensorrt
+from object_detectors.rf_detr_lmi.convert import convert_to_onnx, convert_to_tensorrt
 
 logger = logging.getLogger(__name__)
 
@@ -279,36 +279,33 @@ def get_conversion_output_dir(conversion_configs: Dict[str, Any]) -> str:
     return os.path.dirname(pretrain_weights) if pretrain_weights else "."
 
 
-def convert_model_to_onnx(model: Any, output_dir: str) -> None:
+def convert_model_to_onnx(model: Any, output_dir: str) -> str:
     """Convert model to ONNX format.
 
     Args:
         model: The model instance to convert.
         output_dir: Directory to save the converted model.
+
+    Returns:
+        Path to the exported ONNX file; rfdetr names it after the model variant.
     """
     logger.info("Starting model conversion to ONNX format...")
-    convert_to_onnx(model, output_dir)
-    onnx_path = os.path.join(output_dir, "inference_model.onnx")
-    _write_class_names(onnx_path, model.class_names)
-    logger.info(f"ONNX model saved to: {output_dir}")
+    onnx_path = convert_to_onnx(model, output_dir)
+    logger.info(f"ONNX model saved to: {onnx_path}")
+    return onnx_path
 
 
 def convert_model_to_tensorrt(model: Any, output_dir: str) -> None:
-    """Convert model to TensorRT format.
+    """Convert model to TensorRT format, exporting the ONNX it is built from first.
 
     Args:
         model: The model instance to convert.
         output_dir: Directory to save the converted model.
     """
-    onnx_model_path = os.path.join(output_dir, "inference_model.onnx")
-
-    # Convert to ONNX first if not already done
-    if not os.path.exists(onnx_model_path):
-        convert_model_to_onnx(model, output_dir=output_dir)
-
+    onnx_path = convert_model_to_onnx(model, output_dir)
     logger.info("Converting to TensorRT engine...")
-    convert_to_tensorrt(onnx_model_path)
-    logger.info(f"TensorRT model saved to: {output_dir}")
+    engine_path = convert_to_tensorrt(onnx_path)
+    logger.info(f"TensorRT model saved to: {engine_path}")
 
 
 def handle_conversion(configs: Dict[str, Any]) -> None:
@@ -337,11 +334,9 @@ def handle_conversion(configs: Dict[str, Any]) -> None:
 
 
 def handle_export(configs: Dict[str, Any]) -> None:
-    """Export trained weights to ONNX with a class-name sidecar via rfdetr's native exporter.
+    """Export trained weights to ONNX via rfdetr's native exporter, with class names embedded in the file.
 
-    Unlike the convert operation, this writes the fixed filenames model.onnx and
-    model.classes.json, the convention the RfdetrModel ONNX/TensorRT backends resolve
-    class names from.
+    Unlike the convert operation, this writes the fixed filename model.onnx.
 
     Args:
         configs: Configuration parameters containing model_configs and export_configs.
@@ -363,10 +358,9 @@ def handle_export(configs: Dict[str, Any]) -> None:
 
     # rfdetr names the exported file after the model variant (e.g. rfdetr-small.onnx);
     # stage it as model.onnx instead
-    onnx_path = model.export(output_dir=output_dir, opset_version=opset_version, verbose=verbose)
+    onnx_path = convert_to_onnx(model, output_dir, opset_version=opset_version, verbose=verbose)
     final_path = os.path.join(output_dir, "model.onnx")
     os.replace(onnx_path, final_path)
-    _write_class_names(final_path, model.class_names)
     logger.info(f"ONNX model exported to: {final_path}")
 
 

--- a/object_detectors/rf_detr_lmi/convert.py
+++ b/object_detectors/rf_detr_lmi/convert.py
@@ -1,61 +1,37 @@
-import json
-import logging
 import os
 
-logger = logging.getLogger(__name__)
+from lmi_common.model_metadata import embed_onnx_metadata
+from lmi_common.trt_convert import onnx_to_trt
 
 
-def _write_class_names(model_path: str, class_names: list) -> None:
-    """Write class names to a sidecar JSON file next to model_path."""
-    sidecar = os.path.splitext(model_path)[0] + ".classes.json"
-    with open(sidecar, "w", encoding="utf-8") as f:
-        json.dump(list(class_names), f)
-    logger.info(f"Class names written to: {sidecar}")
+def convert_to_onnx(model, output_dir: str, **kwargs) -> str:
+    """Export an rfdetr model to ONNX with its class names and num_select embedded, and return the .onnx path.
 
+    Args:
+        model: An rfdetr model instance.
+        output_dir (str): Directory to write the export into; rfdetr names the file itself.
+        **kwargs: opset_version (int, default 17), plus any rfdetr export kwargs.
 
-def build_trt_engine(onnx_dir: str, **kwargs) -> None:
-    try:
-        import tensorrt as trt
-    except ImportError as e:
-        raise ImportError("tensorrt is required for TensorRT conversion. Install it with: pip install tensorrt") from e
-
-    engine_dir = onnx_dir.replace(".onnx", ".engine")
-    workspace_mb = 4096
-    verbose = kwargs.get("verbose", False)
-
-    trt_logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
-    builder = trt.Builder(trt_logger)
-    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
-    parser = trt.OnnxParser(network, trt_logger)
-
-    with open(onnx_dir, "rb") as f:
-        if not parser.parse(f.read()):
-            for i in range(parser.num_errors):
-                logger.error(parser.get_error(i))
-            raise RuntimeError(f"Failed to parse ONNX: {onnx_dir}")
-
-    config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_mb << 20)
-    if builder.platform_has_fast_fp16:
-        config.set_flag(trt.BuilderFlag.FP16)
-
-    logger.info(f"Building TensorRT engine, saving to {engine_dir} ...")
-    engine_bytes = builder.build_serialized_network(network, config)
-    with open(engine_dir, "wb") as f:
-        f.write(engine_bytes)
-    logger.info("Done.")
-
-
-def convert_to_tensorrt(onnx_path: str, **kwargs) -> None:
+    Returns:
+        Path to the exported ONNX file.
     """
-    Convert an ONNX model to TensorRT engine.
+    # num_select varies by variant and is not recoverable from the exported graph.
+    metadata = {"class_names": list(model.class_names), "num_select": int(model.model.postprocess.num_select)}
+    onnx_path = model.export(output_dir=output_dir, opset_version=kwargs.pop("opset_version", 17), **kwargs)
+    embed_onnx_metadata(onnx_path, metadata)
+    return onnx_path
+
+
+def convert_to_tensorrt(onnx_path: str, **kwargs) -> str:
+    """Build a TensorRT engine next to the ONNX, carrying over the ONNX's embedded metadata.
 
     Args:
         onnx_path (str): Path to the ONNX model file.
-        **kwargs: Additional keyword arguments for conversion options.
+        **kwargs: Forwarded to ``lmi_common.trt_convert.onnx_to_trt`` (fp16, workspace_gb, batch profile).
+
+    Returns:
+        Path to the built engine.
     """
-    build_trt_engine(onnx_path, **kwargs)
-
-
-def convert_to_onnx(model, output_dir: str, **kwargs) -> None:
-    model.export(output_dir=output_dir, opset_version=kwargs.get("opset_version", 17))
+    engine_path = os.path.splitext(onnx_path)[0] + ".engine"
+    onnx_to_trt(onnx_path, engine_path, **kwargs)
+    return engine_path

--- a/object_detectors/rf_detr_lmi/infer.py
+++ b/object_detectors/rf_detr_lmi/infer.py
@@ -24,9 +24,8 @@ def setup_parser():
         "-m",
         type=str,
         default=None,
-        help="Path to class map JSON file (optional; auto-discovered from <model>.classes.json)",
+        help="Optional override; by default class names come from the model file itself (embedded at export, or the .pth checkpoint)",
     )
-    parser.add_argument("--image_size", "-s", type=int, nargs=2, required=True, help="Input image size [h,w] for the model")
     parser.add_argument("--model_type", "-t", type=str, required=False, help="Type of the model to use for inference")
     return parser
 
@@ -36,7 +35,6 @@ def inference_run(args):
     imgs_path = args.input
     out_path = args.output
     class_map_path = args.class_map
-    image_size = args.image_size
     model_type = args.model_type
     model_ext = os.path.splitext(model_path)[1].lower()
     if model_ext == ".pth":
@@ -52,7 +50,8 @@ def inference_run(args):
         class_map = {int(k): v for k, v in class_map.items()}
 
     # load model
-    model = RfdetrModel(model_path, class_map=class_map, image_size=image_size, model_type=model_type)
+    model = RfdetrModel(model_path, class_map=class_map, model_type=model_type)
+    image_size = model.image_size  # onnx/engine report their own input size; .pth uses the variant default
     # model warmup
     model.warmup()
     # find images

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -1,4 +1,4 @@
-import json
+import inspect
 import logging
 import os
 from typing import List, Optional
@@ -17,6 +17,9 @@ from lmi_utils.image_utils.types import ImageLike
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
 
+# Added in rfdetr 1.9.1; passing it to older versions raises TypeError.
+_POSTPROCESS_TAKES_SCORE_THRESHOLD = "score_threshold" in inspect.signature(PostProcess.forward).parameters
+
 
 class RfdetrBase(ODBase):
     """Shared base class for all RF-DETR model backends.
@@ -33,10 +36,9 @@ class RfdetrBase(ODBase):
     STDS = [0.229, 0.224, 0.225]
 
     def _init_common(self) -> None:
-        """Initialize normalization constants and postprocessor shared by all backends."""
+        """Initialize normalization constants shared by all backends; each backend sets its own postprocessor."""
         self.means = self.MEANS
         self.stds = self.STDS
-        self.postprocessor = PostProcess(num_select=300)
 
     @staticmethod
     def _num_classes_from_checkpoint(model_path: str) -> Optional[int]:
@@ -73,30 +75,31 @@ class RfdetrBase(ODBase):
         return dict(enumerate(names))
 
     @staticmethod
-    def _load_class_map(model_path: str, provided: Optional[dict], num_logit_slots: Optional[int] = None) -> dict:
-        """Resolve class_map from explicit argument or sidecar <stem>.classes.json.
+    def _resolve_class_map(model_path: str, engine_metadata: dict, provided: Optional[dict], num_logit_slots: Optional[int] = None) -> dict:
+        """Resolve class_map from the class names embedded in the model file, or from an explicit override.
 
         Args:
-            model_path: Path to the model file.
-            provided: Caller-supplied class_map, or None to auto-discover.
+            model_path: Path to the model file, for the error message.
+            engine_metadata: Metadata read off the model file by the engine wrapper; its "class_names" is the default source.
+            provided: Override class_map, used as-is when given. Needed only for a model exported without embedded names.
+            num_logit_slots: Detection-head class count, used to spot COCO-pretrained checkpoints.
 
         Returns:
             Dict mapping int index to str class name.
 
         Raises:
-            FileNotFoundError: If class_map is None and no sidecar exists.
+            ValueError: If the model file carries no class names and no override was given.
         """
         if provided is not None:
             return provided
-        sidecar = os.path.splitext(model_path)[0] + ".classes.json"
-        if os.path.isfile(sidecar):
-            RfdetrBase.logger.info(f"Loading class names from sidecar: {sidecar}")
-            with open(sidecar, encoding="utf-8") as f:
-                return RfdetrBase._class_map_from_names(json.load(f), num_logit_slots)
-        raise FileNotFoundError(
-            f"class_map not provided and no sidecar found at {sidecar}. "
-            "Pass class_map explicitly or place a <model>.classes.json next to the model."
-        )
+        class_names = engine_metadata.get("class_names")
+        if not class_names:
+            raise ValueError(
+                f"class_map not provided and no class names embedded in {model_path}. "
+                "Pass class_map explicitly, or re-export the model with rf_detr_lmi/cli.py to embed them."
+            )
+        RfdetrBase.logger.info(f"Loaded {len(class_names)} class names embedded in {model_path}")
+        return RfdetrBase._class_map_from_names(class_names, num_logit_slots)
 
     def warmup(self) -> None:
         """Warm up the model by running a dummy inference. Requires self.image_size."""
@@ -119,7 +122,7 @@ class RfdetrBase(ODBase):
             images = [images]
 
         def resize_stretch(img_tensor, size):
-            # antialias=False matches rfdetr >= 1.9.0 predict(), which mirrors Albumentations' cv2.INTER_LINEAR training resize.
+            # antialias=False mirrors the cv2.INTER_LINEAR training resize; rfdetr's predict() only matches from 1.9.0.
             return F.resize(img_tensor, [size[0], size[1]], antialias=False)
 
         tensors = [self._to_float_chw(img) for img in images]
@@ -221,8 +224,18 @@ class RfdetrBase(ODBase):
 
         orig_sizes = [img.shape[:2] for img in images]
         target_sizes = torch.tensor(orig_sizes, device=self.device)
-        rs = self.postprocessor(return_predictions, target_sizes=target_sizes)
+        extra = {"score_threshold": self._mask_score_floor(configs)} if _POSTPROCESS_TAKES_SCORE_THRESHOLD else {}
+        rs = self.postprocessor(return_predictions, target_sizes=target_sizes, **extra)
         return [self._postprocess_single(r, configs, operators[i], return_segments) for i, r in enumerate(rs)]
+
+    @staticmethod
+    def _mask_score_floor(configs: dict) -> float:
+        """Lowest score _apply_confidence_filter can keep, letting PostProcess skip masks it would discard anyway.
+
+        PostProcess tests ``score > floor`` while ours is ``score >= threshold``, so step one float32 below.
+        """
+        smallest = min(configs.values(), default=1.0)
+        return float(np.nextafter(np.float32(smallest), np.float32("-inf")))
 
 
 class RfdetrModel(ModelFactory, ODBase):
@@ -242,6 +255,9 @@ class _RfdetrEngine(RfdetrBase):
 
     Both engines are built from the same rfdetr ONNX export, whose outputs are ordered
     (dets, labels[, masks]) — the order RfdetrBase.postprocess unpacks.
+
+    Class names come from the metadata embedded in the model file at export; the class_map argument is
+    an override, needed only for a model exported without it.
     """
 
     _engine_cls = None
@@ -257,8 +273,11 @@ class _RfdetrEngine(RfdetrBase):
         if not self.engine.is_dynamic:
             self.fixed_batch_size = self.engine.max_batch
         self._init_common()
+        # No rfdetr model here, so rebuild its postprocessor from the num_select embedded at export; 300 is rfdetr's default.
+        self.postprocessor = PostProcess(num_select=int(self.engine.metadata.get("num_select", 300)))
         # Outputs are (dets, labels[, masks]); labels is (B, queries, num_classes + background).
-        self._setup_class_map(self._load_class_map(model_path, class_map, self.engine._output_buffers[1].shape[-1] - 1))
+        num_logit_slots = self.engine._output_buffers[1].shape[-1] - 1
+        self._setup_class_map(self._resolve_class_map(model_path, self.engine.metadata, class_map, num_logit_slots))
 
     def warmup(self):
         """Warm up the model by running a dummy inference."""
@@ -321,8 +340,8 @@ class RfdetrPTH(RfdetrBase):
         Args:
             model_path: Path to the model checkpoint file (.pth)
             model_type: Model variant (nano/small/medium/large/ or seg-nano/seg-small/seg-medium/seg-large/seg-xlarge/seg-2xlarge).
-            class_map: Dict mapping class indices to class names. If None, inferred from the model's built-in class names.
-                If provided, values must exactly match the model's class names.
+            class_map: Dict mapping class indices to class names. Defaults to the checkpoint's built-in class names; pass it
+                only to override the index mapping — values must still exactly match the model's class names.
             device: Device to run on (cuda/cpu). Default: cuda if available
             image_size: Tuple of (height, width); must be square. Default: model-specific
             batch_size: Number of images per forward pass. Fixed at load time, so predict() chunks to it and zero-pads
@@ -402,9 +421,13 @@ class RfdetrPTH(RfdetrBase):
             )
         self._setup_class_map(class_map)
         # The traced graph has batch_size baked in, so fixed_batch_size must match it.
-        self.model.inference(batch_size=batch_size)
+        # rfdetr renamed optimize_for_inference() to inference() in 1.9.0; the old name is still an alias there.
+        optimize = getattr(self.model, "inference", None) or self.model.optimize_for_inference
+        optimize(batch_size=batch_size)
         self.fixed_batch_size = batch_size
         self._init_common()
+        # Built from the checkpoint's resolved config, and survives the optimize call above.
+        self.postprocessor = self.model.model.postprocess
 
     def forward(self, image: torch.Tensor, **kwargs) -> list:
         """Perform inference on a batch of images.

--- a/object_detectors/rf_detr_lmi/readme.md
+++ b/object_detectors/rf_detr_lmi/readme.md
@@ -158,7 +158,7 @@ services:
 
 ## Exporting to ONNX
 
-The export operation uses rfdetr's native exporter and writes the fixed filenames `model.onnx` plus a `model.classes.json` class-name sidecar, the convention the `RfdetrModel` ONNX/TensorRT backends resolve class names from.
+The export operation uses rfdetr's native exporter and writes the fixed filename `model.onnx`, with the class names embedded in the file's own metadata — the `RfdetrModel` ONNX/TensorRT backends read them from there, so the model deploys as a single file.
 
 ```yaml
 model_type: small
@@ -166,7 +166,7 @@ operation: export
 task: seg         # od or seg
 pretrain_weights: /app/training/checkpoint_best_total.pth   # required; must be a .pth file
 export:
-    output_dir: /app/training   # receives model.onnx + model.classes.json
+    output_dir: /app/training   # receives model.onnx
     resolution: 384
     opset_version: 17           # optional, default 17
 ```
@@ -185,7 +185,8 @@ Any additional keys under `export` (e.g. `device`) are passed to the model const
 
 The `.pth` backend takes `model_type` and an optional `batch_size` (fixed at load time, since the traced graph bakes it in).
 The `.onnx` and `.engine` backends read the batch size and resolution from the model, and take class names from `class_map`
-or the `<model>.classes.json` sidecar written at export.
+or from the metadata embedded at export (`metadata_props` in an ONNX, a JSON header on an engine). Passing `class_map`
+is required for a model exported elsewhere, which carries no embedded names.
 
 docker-compose file
 ```yaml
@@ -201,5 +202,5 @@ services:
       - ./preprocessed/test:/app/data/
       - ./training:/app/training
     command: >
-      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions --model_type seg-small --image_size 384 384
+      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions --model_type seg-small
 ```

--- a/tests/lmi_common/test_model_metadata.py
+++ b/tests/lmi_common/test_model_metadata.py
@@ -1,0 +1,139 @@
+"""Metadata embedded in a model file, so a deployed model needs no sidecar.
+
+Covers both halves of the convention: an ONNX carries the payload in its metadata_props, an engine in a
+length-tagged JSON header that TensorRT would otherwise choke on. Metadata is optional throughout —
+files without any must still load, reporting {}.
+"""
+
+import json
+
+import pytest
+import torch
+
+onnx = pytest.importorskip("onnx")
+
+from lmi_common.model_metadata import (  # noqa: E402
+    ONNX_METADATA_KEY,
+    embed_onnx_metadata,
+    engine_metadata_header,
+    metadata_from_onnx_props,
+    read_onnx_metadata,
+    split_engine_metadata,
+)
+
+try:
+    import tensorrt  # noqa: F401
+
+    _HAS_TRT = True
+except ImportError:
+    _HAS_TRT = False
+
+needs_engine = pytest.mark.skipif(
+    not (_HAS_TRT and torch.cuda.is_available()),
+    reason="engine round trip needs TensorRT and a CUDA torch",
+)
+
+PAYLOAD = {"class_names": ["cat", "dog"]}
+
+
+@pytest.fixture(scope="module")
+def plain_onnx(tmp_path_factory):
+    """A minimal ONNX with no metadata of its own."""
+    path = tmp_path_factory.mktemp("meta") / "plain.onnx"
+    torch.onnx.export(
+        torch.nn.Conv2d(3, 8, 3).eval(),
+        torch.zeros(1, 3, 32, 32),
+        str(path),
+        input_names=["input"],
+        output_names=["output"],
+        opset_version=17,
+    )
+    return str(path)
+
+
+def test_onnx_round_trip(plain_onnx, tmp_path):
+    import shutil
+
+    path = str(tmp_path / "embedded.onnx")
+    shutil.copy(plain_onnx, path)
+    embed_onnx_metadata(path, PAYLOAD)
+    assert read_onnx_metadata(path) == PAYLOAD
+
+
+def test_onnx_embed_is_idempotent(plain_onnx, tmp_path):
+    """Re-exporting over an embedded file must overwrite the payload, not add a second property."""
+    import shutil
+
+    path = str(tmp_path / "twice.onnx")
+    shutil.copy(plain_onnx, path)
+    embed_onnx_metadata(path, PAYLOAD)
+    embed_onnx_metadata(path, {"class_names": ["bird"]})
+    assert read_onnx_metadata(path) == {"class_names": ["bird"]}
+    assert [p.key for p in onnx.load(path).metadata_props].count(ONNX_METADATA_KEY) == 1
+
+
+def test_onnx_without_metadata(plain_onnx):
+    assert read_onnx_metadata(plain_onnx) == {}
+
+
+@pytest.mark.parametrize("props", [None, {}, {"author": "someone else"}, {ONNX_METADATA_KEY: "not json"}, {ONNX_METADATA_KEY: "[1, 2]"}])
+def test_props_without_usable_payload(props):
+    assert metadata_from_onnx_props(props) == {}
+
+
+def test_onnx_engine_reports_metadata(plain_onnx, tmp_path):
+    """What the ONNX backend actually consumes: onnxruntime's own view of the embedded payload."""
+    pytest.importorskip("onnxruntime")
+    import shutil
+
+    from lmi_common.onnx_engine import ONNXEngine
+
+    path = str(tmp_path / "ort.onnx")
+    shutil.copy(plain_onnx, path)
+    embed_onnx_metadata(path, PAYLOAD)
+    assert ONNXEngine(path, device="cpu").metadata == PAYLOAD
+    assert ONNXEngine(plain_onnx, device="cpu").metadata == {}
+
+
+def test_header_round_trip():
+    plan = b"ftrt" + b"\x00" * 64
+    metadata, stripped = split_engine_metadata(engine_metadata_header(PAYLOAD) + plan)
+    assert metadata == PAYLOAD
+    assert stripped == plan
+
+
+def test_headerless_plan_is_untouched():
+    plan = b"ftrt" + json.dumps(PAYLOAD).encode()  # magic first: the JSON-looking tail must not be read as a header
+    assert split_engine_metadata(plan) == ({}, plan)
+
+
+@pytest.mark.parametrize("raw", [b"", b"\x00\x00\x00\x00", b"\xff\xff\xff\xffnope", (10).to_bytes(4, "little") + b"not json.."])
+def test_undecodable_header_leaves_bytes_alone(raw):
+    assert split_engine_metadata(raw) == ({}, raw)
+
+
+@needs_engine
+def test_engine_carries_metadata_to_trt_engine(plain_onnx, tmp_path):
+    """The round trip that matters: metadata embedded in an ONNX survives the build and the plan still deserializes."""
+    import shutil
+
+    from lmi_common.trt_convert import onnx_to_trt
+    from lmi_common.trt_engine import TRTEngine
+
+    onnx_path = str(tmp_path / "src.onnx")
+    shutil.copy(plain_onnx, onnx_path)
+    embed_onnx_metadata(onnx_path, PAYLOAD)
+
+    engine_path = str(tmp_path / "src.engine")
+    onnx_to_trt(onnx_path, engine_path, fp16=False, workspace_gb=2)
+    assert TRTEngine(engine_path, device="cuda").metadata == PAYLOAD
+
+
+@needs_engine
+def test_engine_without_metadata_still_loads(plain_onnx, tmp_path):
+    from lmi_common.trt_convert import onnx_to_trt
+    from lmi_common.trt_engine import TRTEngine
+
+    engine_path = str(tmp_path / "plain.engine")
+    onnx_to_trt(plain_onnx, engine_path, fp16=False, workspace_gb=2)
+    assert TRTEngine(engine_path, device="cuda").metadata == {}

--- a/tests/object_detectors/rf_detr_lmi/test_model.py
+++ b/tests/object_detectors/rf_detr_lmi/test_model.py
@@ -1,10 +1,12 @@
 import logging
 import os
+from importlib.metadata import version
 
 import cv2
 import numpy as np
 import pytest
 import torch
+from packaging.version import Version
 from rfdetr import RFDETRSegSmall
 from rfdetr.assets.coco_classes import COCO_CLASSES
 
@@ -21,6 +23,8 @@ OUT_DIR = "tests/outputs/od/rf_detr"
 IMAGE_SIZE = 384
 MODEL_TYPE = "seg-small"
 OFF_SIZES = [(512, 640), (576, 704), (704, 512)]  # (h, w), non-square
+# rfdetr 1.9.0 dropped antialiasing from predict(); older versions can't match preprocess() pixel for pixel.
+RFDETR_ANTIALIASES_PREDICT = Version(version("rfdetr")) < Version("1.9.0")
 
 
 def load_image(path):
@@ -196,11 +200,17 @@ class Test_Rfdetr_Model:
 
             assert_outputs_match_rf(rf_preds, outputs_pth, "pth_model")
 
+    @pytest.mark.xfail(
+        RFDETR_ANTIALIASES_PREDICT,
+        reason="rfdetr < 1.9.0 antialiases in predict(); preprocess() follows the training resize instead",
+        strict=False,
+    )
     def test_compare_with_rfdetr_nonsquare(self, imgs_coco, cpu_models):
         """Non-square inputs exercise the off-size resize guard.
 
-        Our guard fits inputs to the square model input with an antialias-free stretch on the float
-        tensor, matching rfdetr's own predict() preprocessing, so detections must match exactly.
+        Our guard fits inputs to the square model input with an antialias-free stretch on the float tensor, matching
+        rfdetr >= 1.9.0's own predict(), so detections must match exactly. Only this test resizes; the square case
+        is already model-sized.
         """
 
         rf_model, pth_model = cpu_models
@@ -419,11 +429,14 @@ def test_clamp_boxes_to_image():
     Backend-agnostic: built without an engine, feed synthetic raw head outputs (one query with an
     oversized cxcywh box that decodes past every edge, one inside) through RfdetrBase.postprocess.
     """
+    from rfdetr.models.postprocess import PostProcess
+
     from object_detectors.rf_detr_lmi.model import RfdetrTRT
 
     model = object.__new__(RfdetrTRT)
     model.device = torch.device("cpu")
     model._init_common()
+    model.postprocessor = PostProcess(num_select=300)  # normally from the engine's metadata
     model._setup_class_map({0: "person"})
 
     image_h, image_w = 100, 200

--- a/tests/object_detectors/rf_detr_lmi/test_onnx.py
+++ b/tests/object_detectors/rf_detr_lmi/test_onnx.py
@@ -91,18 +91,49 @@ def test_matches_pth(imgs_coco, onnx_model, pth_model):
         np.testing.assert_allclose(ref["scores"][i], out["scores"][i], atol=5e-3)
 
 
-def test_class_map_from_sidecar(imgs_coco, onnx_file, pth_model):
-    """cli.py writes an ordered <stem>.classes.json; names resolved from it must match an explicit class_map."""
-    from object_detectors.rf_detr_lmi.convert import _write_class_names
-
-    _write_class_names(onnx_file, list(COCO_CLASSES.values()))
+def test_class_map_from_embedded_metadata(imgs_coco, onnx_file, pth_model):
+    """convert_to_onnx embeds the ordered class names in the file; names read back from it must match an explicit class_map."""
     model = ObjectDetector(metadata=METADATA, model_path=onnx_file, image_size=[IMAGE_SIZE, IMAGE_SIZE], device="cpu")
     assert model.class_map == COCO_CLASSES
 
     out, _ = model.predict(imgs_coco, configs=0.5)
     ref, _ = pth_model.predict(imgs_coco, configs=0.5)
     for i in range(len(imgs_coco)):
-        assert np.array_equal(ref["classes"][i], out["classes"][i]), f"image {i}: sidecar names disagree with explicit class_map"
+        assert np.array_equal(ref["classes"][i], out["classes"][i]), f"image {i}: embedded names disagree with explicit class_map"
+
+
+def test_num_select_from_embedded_metadata(onnx_model, pth_model):
+    """The engine backend must reuse the checkpoint's num_select (100 for seg-small), not a hardcoded 300."""
+    assert pth_model.postprocessor.num_select == 100, "rfdetr changed seg-small's num_select; update this test"
+    assert onnx_model.postprocessor.num_select == pth_model.postprocessor.num_select
+
+
+def test_num_select_falls_back_when_absent(tmp_path, onnx_file):
+    """An ONNX exported before num_select was embedded must still load, at rfdetr's 300 default."""
+    import onnx
+
+    from lmi_common.model_metadata import embed_onnx_metadata
+
+    legacy = str(tmp_path / "no_num_select.onnx")
+    onnx.save(onnx.load(onnx_file), legacy)
+    embed_onnx_metadata(legacy, {"class_names": list(COCO_CLASSES.values())})
+
+    assert RfdetrONNX(legacy, device="cpu").postprocessor.num_select == 300
+
+
+def test_missing_class_names_raises(tmp_path, onnx_file):
+    """A model carrying no embedded names and no class_map must fail with a clear error, not a wrong class map."""
+    import onnx
+
+    from lmi_common.model_metadata import ONNX_METADATA_KEY
+
+    stripped = str(tmp_path / "no_metadata.onnx")
+    model = onnx.load(onnx_file)
+    del model.metadata_props[[p.key for p in model.metadata_props].index(ONNX_METADATA_KEY)]
+    onnx.save(model, stripped)
+
+    with pytest.raises(ValueError, match="no class names embedded"):
+        ObjectDetector(metadata=METADATA, model_path=stripped, image_size=[IMAGE_SIZE, IMAGE_SIZE], device="cpu")
 
 
 def test_cuda(imgs_coco, onnx_file):

--- a/tests/object_detectors/rf_detr_lmi/test_trt.py
+++ b/tests/object_detectors/rf_detr_lmi/test_trt.py
@@ -74,6 +74,18 @@ def test_trt_warmup(trt_model):
     trt_model.warmup()
 
 
+def test_class_map_from_embedded_metadata(trt_model):
+    """Names embedded at export ride in the engine's header, so no class_map argument is needed."""
+    if not trt_model.engine.metadata.get("class_names"):
+        pytest.skip(f"{TRT_MODEL} carries no embedded class names; rebuild it with tests/build_test_engines.py")
+    model = ObjectDetector(
+        metadata=dict(version="v1", model_name="rfdetr", task="od", framework="rfdetr"),
+        model_path=TRT_MODEL,
+        image_size=[IMAGE_SIZE, IMAGE_SIZE],
+    )
+    assert model.class_map == COCO_CLASSES
+
+
 def test_operators_batch(imgs_coco, trt_model):
     from lmi_utils.preprocess_utils.ops import ResizeMeta
 


### PR DESCRIPTION
…sidecar

<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary


## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
