### PR TITLE
feat(rfdetr): infer model type from ckpt

### DIFF
--- a/object_detectors/rf_detr_lmi/checkpoint.py
+++ b/object_detectors/rf_detr_lmi/checkpoint.py
@@ -1,10 +1,7 @@
 """Building an rfdetr model from the variant a checkpoint records."""
 
 import inspect
-import math
-from typing import Any, Dict, List, Optional
-
-import torch
+from typing import Any, Dict, List
 
 
 def _trust_kwarg(from_checkpoint: Any) -> Dict[str, bool]:
@@ -13,68 +10,6 @@ def _trust_kwarg(from_checkpoint: Any) -> Dict[str, bool]:
         # Allows the pickle fallback for our own training checkpoints, whose "args" can hold objects rfdetr's safe-load misses.
         return {"trust_checkpoint": True}
     return {}
-
-
-def _find_tensor(weights: Dict[str, Any], suffix: str) -> Optional[Any]:
-    for key, value in weights.items():
-        if key.endswith(suffix) and isinstance(value, torch.Tensor):
-            return value
-    return None
-
-
-def _pe_tracks_resolution(model_name: Any) -> bool:
-    """Whether rfdetr sizes this variant's position grid from its resolution — what _resolution_from_weights assumes.
-
-    Mirrors rfdetr's own sync rule (config.ModelConfig._sync_pe_with_resolution): true when the variant's default
-    grid is its default resolution divided by its patch size. A variant that pins the grid instead (the deprecated
-    RFDETRBase: 37 x 14 != 560) would give a wrong resolution. An unresolvable variant is assumed to follow the rule.
-    """
-    from rfdetr import variants
-
-    config_cls = getattr(getattr(variants, str(model_name), None), "_model_config_class", None)
-    fields = getattr(config_cls, "model_fields", None)
-    if not isinstance(fields, dict):
-        return True
-    defaults = [getattr(fields.get(name), "default", None) for name in ("positional_encoding_size", "patch_size", "resolution")]
-    if not all(isinstance(default, int) for default in defaults):
-        return True
-    grid, patch, resolution = defaults
-    return grid * patch == resolution
-
-
-def _resolution_from_weights(weights: Dict[str, Any]) -> Optional[int]:
-    """The input size the backbone's position grid was trained for: grid side x patch size.
-
-    Returns None when the grid is not square (an unexpected backbone layout), leaving the resolution to rfdetr.
-    """
-    position = _find_tensor(weights, "embeddings.position_embeddings")
-    patch = _find_tensor(weights, "patch_embeddings.projection.weight")
-    if position is None or patch is None or position.ndim != 3 or patch.ndim != 4:
-        return None
-    grid = math.isqrt(position.shape[1] - 1)  # one non-patch token: the cls token
-    if grid * grid != position.shape[1] - 1:
-        return None
-    return grid * patch.shape[-1]
-
-
-def resolution_from_checkpoint(model_path: str) -> Optional[int]:
-    """The square resolution a checkpoint was trained at, or None when it cannot be read.
-
-    Callers must pass it back in, or the model runs at the variant's default resolution: rfdetr < 1.9 ignores the
-    checkpoint's model_config, naming the variant explicitly skips it on every version, and rfdetr strips
-    model_config out of checkpoint_best_total.pth altogether — hence the fallback to the weights themselves.
-    """
-    checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
-    if not isinstance(checkpoint, dict):
-        return None
-    model_config = checkpoint.get("model_config")
-    resolution = model_config.get("resolution") if isinstance(model_config, dict) else None
-    if isinstance(resolution, int):
-        return resolution
-    weights = checkpoint.get("model")
-    if not isinstance(weights, dict) or not _pe_tracks_resolution(checkpoint.get("model_name")):
-        return None
-    return _resolution_from_weights(weights)
 
 
 def load_from_checkpoint(model_path: str, supported: List[str], **kwargs: Any) -> Any:

--- a/object_detectors/rf_detr_lmi/checkpoint.py
+++ b/object_detectors/rf_detr_lmi/checkpoint.py
@@ -1,0 +1,106 @@
+"""Building an rfdetr model from the variant a checkpoint records."""
+
+import inspect
+import math
+from typing import Any, Dict, List, Optional
+
+import torch
+
+
+def _trust_kwarg(from_checkpoint: Any) -> Dict[str, bool]:
+    """trust_checkpoint if this rfdetr takes it; rfdetr < 1.9 forwards unknown kwargs into the model config, which rejects them."""
+    if "trust_checkpoint" in inspect.signature(from_checkpoint).parameters:
+        # Allows the pickle fallback for our own training checkpoints, whose "args" can hold objects rfdetr's safe-load misses.
+        return {"trust_checkpoint": True}
+    return {}
+
+
+def _find_tensor(weights: Dict[str, Any], suffix: str) -> Optional[Any]:
+    for key, value in weights.items():
+        if key.endswith(suffix) and isinstance(value, torch.Tensor):
+            return value
+    return None
+
+
+def _pe_tracks_resolution(model_name: Any) -> bool:
+    """Whether rfdetr sizes this variant's position grid from its resolution — what _resolution_from_weights assumes.
+
+    Mirrors rfdetr's own sync rule (config.ModelConfig._sync_pe_with_resolution): true when the variant's default
+    grid is its default resolution divided by its patch size. A variant that pins the grid instead (the deprecated
+    RFDETRBase: 37 x 14 != 560) would give a wrong resolution. An unresolvable variant is assumed to follow the rule.
+    """
+    from rfdetr import variants
+
+    config_cls = getattr(getattr(variants, str(model_name), None), "_model_config_class", None)
+    fields = getattr(config_cls, "model_fields", None)
+    if not isinstance(fields, dict):
+        return True
+    defaults = [getattr(fields.get(name), "default", None) for name in ("positional_encoding_size", "patch_size", "resolution")]
+    if not all(isinstance(default, int) for default in defaults):
+        return True
+    grid, patch, resolution = defaults
+    return grid * patch == resolution
+
+
+def _resolution_from_weights(weights: Dict[str, Any]) -> Optional[int]:
+    """The input size the backbone's position grid was trained for: grid side x patch size.
+
+    Returns None when the grid is not square (an unexpected backbone layout), leaving the resolution to rfdetr.
+    """
+    position = _find_tensor(weights, "embeddings.position_embeddings")
+    patch = _find_tensor(weights, "patch_embeddings.projection.weight")
+    if position is None or patch is None or position.ndim != 3 or patch.ndim != 4:
+        return None
+    grid = math.isqrt(position.shape[1] - 1)  # one non-patch token: the cls token
+    if grid * grid != position.shape[1] - 1:
+        return None
+    return grid * patch.shape[-1]
+
+
+def resolution_from_checkpoint(model_path: str) -> Optional[int]:
+    """The square resolution a checkpoint was trained at, or None when it cannot be read.
+
+    Callers must pass it back in, or the model runs at the variant's default resolution: rfdetr < 1.9 ignores the
+    checkpoint's model_config, naming the variant explicitly skips it on every version, and rfdetr strips
+    model_config out of checkpoint_best_total.pth altogether — hence the fallback to the weights themselves.
+    """
+    checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
+    if not isinstance(checkpoint, dict):
+        return None
+    model_config = checkpoint.get("model_config")
+    resolution = model_config.get("resolution") if isinstance(model_config, dict) else None
+    if isinstance(resolution, int):
+        return resolution
+    weights = checkpoint.get("model")
+    if not isinstance(weights, dict) or not _pe_tracks_resolution(checkpoint.get("model_name")):
+        return None
+    return _resolution_from_weights(weights)
+
+
+def load_from_checkpoint(model_path: str, supported: List[str], **kwargs: Any) -> Any:
+    """Build the rfdetr model whose variant the checkpoint names, turning rfdetr's failures into an actionable error.
+
+    num_classes is deliberately not a parameter: rfdetr reads it off the checkpoint's detection head, and passing it
+    would pin the head as a user override.
+
+    Args:
+        model_path: Path to an rfdetr checkpoint.
+        supported: Variant names the caller accepts, listed in the error when the checkpoint names none.
+        **kwargs: Forwarded to the rfdetr model constructor (device, resolution, ...).
+
+    Returns:
+        An rfdetr model instance of the recorded variant.
+
+    Raises:
+        ValueError: If the checkpoint records no variant.
+    """
+    from rfdetr import RFDETR
+
+    try:
+        return RFDETR.from_checkpoint(model_path, **_trust_kwarg(RFDETR.from_checkpoint), **kwargs)
+    except (KeyError, ValueError) as e:
+        raise ValueError(
+            f"Could not read the RF-DETR variant from {model_path} ({type(e).__name__}: {e}). "
+            f"rfdetr records it since 1.7.0; older checkpoints and Roboflow's published starter weights do not. "
+            f"Specify model_type explicitly, one of: {', '.join(supported)}."
+        ) from e

--- a/object_detectors/rf_detr_lmi/cli.py
+++ b/object_detectors/rf_detr_lmi/cli.py
@@ -23,7 +23,7 @@ except ImportError as e:
     logging.error(f"Failed to import rfdetr models: {e}")
     raise
 
-from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint, resolution_from_checkpoint
+from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint
 from object_detectors.rf_detr_lmi.convert import convert_to_onnx, convert_to_tensorrt
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ MODEL_REGISTRY = {
 }
 
 
-DEFAULT_MODEL_TYPE = "medium"
+DEFAULT_MODEL_TYPE = "small"
 
 
 def supported_model_types(task: str) -> List[str]:
@@ -75,6 +75,8 @@ def validate_training_config(training_configs: Dict[str, Any]) -> None:
         raise ValueError("Training configuration is missing.")
     if "output_dir" not in training_configs:
         raise ValueError("output_dir must be specified in training configuration.")
+    if "resolution" not in training_configs:
+        raise ValueError("resolution must be specified in training configuration.")
 
 
 def validate_export_config(export_configs: Dict[str, Any], model_configs: Dict[str, Any]) -> None:
@@ -93,6 +95,11 @@ def validate_export_config(export_configs: Dict[str, Any], model_configs: Dict[s
         raise ValueError("output_dir must be specified in export configuration.")
     if "pretrain_weights" not in model_configs:
         raise ValueError("pretrain_weights must be specified for export.")
+    if "resolution" not in export_configs:
+        raise ValueError(
+            "resolution must be specified in export configuration; use the resolution the model was trained at, "
+            "which training_config.json records under model_config."
+        )
 
 
 def validate_conversion_config(conversion_configs: Dict[str, Any], format: str) -> None:
@@ -109,6 +116,11 @@ def validate_conversion_config(conversion_configs: Dict[str, Any], format: str) 
         raise ValueError("Conversion format must be specified.")
     if not conversion_configs:
         raise ValueError("Conversion configuration is missing.")
+    if "resolution" not in conversion_configs:
+        raise ValueError(
+            "resolution must be specified in conversion configuration; use the resolution the model was trained at, "
+            "which training_config.json records under model_config."
+        )
 
 
 def parse_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -190,21 +202,13 @@ def load_pretrained_model(model_configs: Dict[str, Any], weights: str, **kwargs:
     Args:
         model_configs: Parsed model configuration; its optional model_type overrides what the checkpoint records.
         weights: Path to the checkpoint.
-        **kwargs: Forwarded to the rfdetr model constructor (resolution, device, ...). resolution defaults to the
-            one the checkpoint was trained at.
+        **kwargs: Forwarded to the rfdetr model constructor (resolution, device, ...).
 
     Returns:
         An rfdetr model instance.
     """
     task = model_configs.get("task", TASK_OD)
     model_type = model_configs.get("model_type")
-    if "resolution" not in kwargs:
-        # rfdetr < 1.9 drops the checkpoint's model_config, and naming the variant skips it on every version,
-        # so without this we would export at the variant's default resolution instead of the trained one.
-        resolution = resolution_from_checkpoint(weights)
-        if resolution is not None:
-            logger.info(f"Using the resolution recorded in {weights}: {resolution}")
-            kwargs["resolution"] = resolution
     if model_type:
         return get_model_class(task, model_type)(pretrain_weights=weights, **kwargs)
     logger.info(f"Reading the model variant from {weights}")
@@ -375,9 +379,9 @@ def handle_conversion(configs: Dict[str, Any]) -> None:
 
 
 def handle_export(configs: Dict[str, Any]) -> None:
-    """Export trained weights to ONNX via rfdetr's native exporter, with class names embedded in the file.
+    """Export a checkpoint to ONNX under the fixed filename model.onnx.
 
-    Unlike the convert operation, this writes the fixed filename model.onnx.
+    Same export path as the convert operation, which keeps rfdetr's variant-named file and can also build a TensorRT engine.
 
     Args:
         configs: Configuration parameters containing model_configs and export_configs.

--- a/object_detectors/rf_detr_lmi/cli.py
+++ b/object_detectors/rf_detr_lmi/cli.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import os
 from datetime import date
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 
@@ -23,6 +23,7 @@ except ImportError as e:
     logging.error(f"Failed to import rfdetr models: {e}")
     raise
 
+from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint, resolution_from_checkpoint
 from object_detectors.rf_detr_lmi.convert import convert_to_onnx, convert_to_tensorrt
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,14 @@ MODEL_REGISTRY = {
     (TASK_SEGMENTATION, "xlarge"): RFDETRSegXLarge,
     (TASK_SEGMENTATION, "2xlarge"): RFDETRSeg2XLarge,
 }
+
+
+DEFAULT_MODEL_TYPE = "medium"
+
+
+def supported_model_types(task: str) -> List[str]:
+    """Model sizes registered for a task."""
+    return sorted(m for t, m in MODEL_REGISTRY if t == task)
 
 
 def validate_training_config(training_configs: Dict[str, Any]) -> None:
@@ -115,7 +124,9 @@ def parse_config(config: Dict[str, Any]) -> Dict[str, Any]:
         ValueError: If configuration is invalid or incomplete.
     """
     model_configs = {
-        "model_type": config.get("model_type", "medium"),
+        # Absent means the variant comes from the checkpoint (convert/export); training has no checkpoint
+        # to read and falls back to DEFAULT_MODEL_TYPE.
+        "model_type": config.get("model_type"),
         "operation": config.get("operation", OPERATION_TRAIN),
         "task": config.get("task", TASK_OD),
     }
@@ -173,6 +184,33 @@ def get_model_class(task: str, model_type: str) -> Any:
     return model_class
 
 
+def load_pretrained_model(model_configs: Dict[str, Any], weights: str, **kwargs: Any) -> Any:
+    """Load an existing checkpoint, reading its variant from the file unless the config names one.
+
+    Args:
+        model_configs: Parsed model configuration; its optional model_type overrides what the checkpoint records.
+        weights: Path to the checkpoint.
+        **kwargs: Forwarded to the rfdetr model constructor (resolution, device, ...). resolution defaults to the
+            one the checkpoint was trained at.
+
+    Returns:
+        An rfdetr model instance.
+    """
+    task = model_configs.get("task", TASK_OD)
+    model_type = model_configs.get("model_type")
+    if "resolution" not in kwargs:
+        # rfdetr < 1.9 drops the checkpoint's model_config, and naming the variant skips it on every version,
+        # so without this we would export at the variant's default resolution instead of the trained one.
+        resolution = resolution_from_checkpoint(weights)
+        if resolution is not None:
+            logger.info(f"Using the resolution recorded in {weights}: {resolution}")
+            kwargs["resolution"] = resolution
+    if model_type:
+        return get_model_class(task, model_type)(pretrain_weights=weights, **kwargs)
+    logger.info(f"Reading the model variant from {weights}")
+    return load_from_checkpoint(weights, supported_model_types(task), **kwargs)
+
+
 def load_model(configs: Dict[str, Any]) -> Any:
     """Load the RF-DETR model based on the configuration.
 
@@ -187,13 +225,12 @@ def load_model(configs: Dict[str, Any]) -> Any:
     """
     model_configs = configs["model_configs"]
     task = model_configs.get("task", TASK_OD)
-    model_type = model_configs.get("model_type", "medium")
     operation = model_configs.get("operation", OPERATION_TRAIN)
-
-    model_class = get_model_class(task, model_type)
 
     # Instantiate model based on operation
     if operation == OPERATION_TRAIN:
+        # Training may start from scratch, so there is no checkpoint to read the variant from.
+        model_class = get_model_class(task, model_configs.get("model_type") or DEFAULT_MODEL_TYPE)
         kwargs = {}
         if "pretrain_weights" in model_configs:
             kwargs["pretrain_weights"] = model_configs["pretrain_weights"]
@@ -201,10 +238,14 @@ def load_model(configs: Dict[str, Any]) -> Any:
             kwargs["num_classes"] = model_configs["num_classes"]
         return model_class(**kwargs)
     elif operation == OPERATION_CONVERT:
-        conversion_configs = configs.get("conversion_configs", {})
+        conversion_configs = dict(configs.get("conversion_configs", {}))
         if not conversion_configs:
             raise ValueError("Conversion configuration is missing.")
-        return model_class(**conversion_configs)
+        weights = conversion_configs.pop("pretrain_weights", None)
+        if weights is None:
+            # No checkpoint to read from — convert the variant's own COCO-pretrained weights.
+            return get_model_class(task, model_configs.get("model_type") or DEFAULT_MODEL_TYPE)(**conversion_configs)
+        return load_pretrained_model(model_configs, weights, **conversion_configs)
     else:
         raise ValueError(f"Unsupported operation: {operation}")
 
@@ -353,8 +394,7 @@ def handle_export(configs: Dict[str, Any]) -> None:
     os.makedirs(output_dir, exist_ok=True)
 
     # Remaining export params (resolution, device, ...) are model constructor kwargs
-    model_class = get_model_class(model_configs["task"], model_configs["model_type"])
-    model = model_class(pretrain_weights=model_configs["pretrain_weights"], **export_params)
+    model = load_pretrained_model(model_configs, model_configs["pretrain_weights"], **export_params)
 
     # rfdetr names the exported file after the model variant (e.g. rfdetr-small.onnx);
     # stage it as model.onnx instead

--- a/object_detectors/rf_detr_lmi/convert.py
+++ b/object_detectors/rf_detr_lmi/convert.py
@@ -11,12 +11,14 @@ def convert_to_onnx(model, output_dir: str, **kwargs) -> str:
     Args:
         model: An rfdetr model instance.
         output_dir (str): Directory to write the export into; rfdetr names the file itself.
-        **kwargs: opset_version (int, default 17), plus any rfdetr export kwargs.
+        **kwargs: opset_version (int, default 17), verbose (bool, default False), plus any rfdetr export kwargs.
 
     Returns:
         Path to the exported ONNX file.
     """
     metadata = RfdetrMetadata.from_model(model)
+    # rfdetr defaults verbose to True, which makes torch.onnx.export dump every node in the graph.
+    kwargs.setdefault("verbose", False)
     onnx_path = model.export(output_dir=output_dir, opset_version=kwargs.pop("opset_version", 17), **kwargs)
     embed_onnx_metadata(onnx_path, metadata.as_payload())
     return onnx_path

--- a/object_detectors/rf_detr_lmi/infer.py
+++ b/object_detectors/rf_detr_lmi/infer.py
@@ -26,7 +26,13 @@ def setup_parser():
         default=None,
         help="Optional override; by default class names come from the model file itself (embedded at export, or the .pth checkpoint)",
     )
-    parser.add_argument("--model_type", "-t", type=str, required=False, help="Type of the model to use for inference")
+    parser.add_argument(
+        "--model_type",
+        "-t",
+        type=str,
+        default=None,
+        help="Optional override for .pth weights; by default the variant is read from the checkpoint",
+    )
     return parser
 
 
@@ -36,10 +42,6 @@ def inference_run(args):
     out_path = args.output
     class_map_path = args.class_map
     model_type = args.model_type
-    model_ext = os.path.splitext(model_path)[1].lower()
-    if model_ext == ".pth":
-        if not model_type:
-            raise ValueError("Model type must be specified when using .pth weights")
     if not os.path.exists(out_path):
         os.makedirs(out_path)
     class_map = None
@@ -51,7 +53,8 @@ def inference_run(args):
 
     # load model
     model = RfdetrModel(model_path, class_map=class_map, model_type=model_type)
-    image_size = model.image_size  # onnx/engine report their own input size; .pth uses the variant default
+    image_size = model.image_size  # onnx/engine report their own input size; .pth uses the checkpoint's resolution
+    logger.info(f"Model loaded with image size: {image_size}")
     # model warmup
     model.warmup()
     # find images

--- a/object_detectors/rf_detr_lmi/infer.py
+++ b/object_detectors/rf_detr_lmi/infer.py
@@ -69,7 +69,7 @@ def inference_run(args):
     img_list = get_images(imgs_path)
     logger.info(f"Found {len(img_list)} images in {imgs_path}")
     inference_times = []
-    for img_path in img_list:
+    for img_path in sorted(img_list):
         img_name = os.path.basename(img_path)
         image = cv2.imread(img_path)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)

--- a/object_detectors/rf_detr_lmi/infer.py
+++ b/object_detectors/rf_detr_lmi/infer.py
@@ -33,6 +33,13 @@ def setup_parser():
         default=None,
         help="Optional override for .pth weights; by default the variant is read from the checkpoint",
     )
+    parser.add_argument(
+        "--image_size",
+        "-s",
+        type=int,
+        default=None,
+        help="Square input size for .pth weights, which record none; by default the variant's own. onnx/engine carry their own size",
+    )
     return parser
 
 
@@ -52,8 +59,9 @@ def inference_run(args):
         class_map = {int(k): v for k, v in class_map.items()}
 
     # load model
-    model = RfdetrModel(model_path, class_map=class_map, model_type=model_type)
-    image_size = model.image_size  # onnx/engine report their own input size; .pth uses the checkpoint's resolution
+    size = [args.image_size, args.image_size] if args.image_size else None
+    model = RfdetrModel(model_path, class_map=class_map, model_type=model_type, image_size=size)
+    image_size = model.image_size  # onnx/engine report their own input size, ignoring the argument
     logger.info(f"Model loaded with image size: {image_size}")
     # model warmup
     model.warmup()

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -16,6 +16,7 @@ from lmi_common.trt_engine import TRTEngine
 from lmi_utils.image_utils.types import ImageLike
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
+from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint, resolution_from_checkpoint
 from object_detectors.rf_detr_lmi.metadata import RfdetrMetadata
 
 # Added in rfdetr 1.9.1; passing it to older versions raises TypeError.
@@ -327,12 +328,15 @@ class RfdetrPTH(RfdetrBase):
 
     This class provides an interface for RF-DETR models loaded from PyTorch checkpoint files.
     Supports multiple model variants: nano, small, medium, large.
+
+    The variant is read from the checkpoint itself; model_type is an override for checkpoints that
+    do not record it (see __init__).
     """
 
     def __init__(
         self,
         model_path: str,
-        model_type: str,
+        model_type: Optional[str] = None,
         class_map: Optional[dict] = None,
         device: str = "cuda",
         image_size: Optional[tuple] = None,
@@ -343,16 +347,19 @@ class RfdetrPTH(RfdetrBase):
         Args:
             model_path: Path to the model checkpoint file (.pth)
             model_type: Model variant (nano/small/medium/large/ or seg-nano/seg-small/seg-medium/seg-large/seg-xlarge/seg-2xlarge).
+                Defaults to the variant recorded in the checkpoint. Pass it only for a checkpoint that records none —
+                rfdetr writes the variant since 1.7.0, but Roboflow's published starter weights predate that.
             class_map: Dict mapping class indices to class names. Defaults to the checkpoint's built-in class names; pass it
                 only to override the index mapping — values must still exactly match the model's class names.
             device: Device to run on (cuda/cpu). Default: cuda if available
-            image_size: Tuple of (height, width); must be square. Default: model-specific
+            image_size: Tuple of (height, width); must be square. Default: the checkpoint's own resolution
             batch_size: Number of images per forward pass. Fixed at load time, so predict() chunks to it and zero-pads
                 a short final chunk. Default: 1
 
         Raises:
             FileNotFoundError: If model_path does not exist
-            ValueError: If model_type is not supported, image_size is not square, or batch_size is not positive
+            ValueError: If model_type is not supported, the checkpoint records no variant and none was given,
+                image_size is not square, or batch_size is not positive
         """
         from rfdetr import (
             RFDETRLarge,
@@ -367,19 +374,19 @@ class RfdetrPTH(RfdetrBase):
             RFDETRSmall,
         )
 
-        model_configs = {
-            "nano": (384, RFDETRNano),
-            "small": (512, RFDETRSmall),
-            "medium": (576, RFDETRMedium),
-            "large": (704, RFDETRLarge),
-            # "xlarge": (700, RFDETRXLarge),    # require license
-            # "2xlarge": (880, RFDETR2XLarge),  # require license
-            "seg-nano": (312, RFDETRSegNano),
-            "seg-small": (384, RFDETRSegSmall),
-            "seg-medium": (432, RFDETRSegMedium),
-            "seg-large": (504, RFDETRSegLarge),
-            "seg-xlarge": (624, RFDETRSegXLarge),
-            "seg-2xlarge": (768, RFDETRSeg2XLarge),
+        model_classes = {
+            "nano": RFDETRNano,
+            "small": RFDETRSmall,
+            "medium": RFDETRMedium,
+            "large": RFDETRLarge,
+            # "xlarge": RFDETRXLarge,    # require license
+            # "2xlarge": RFDETR2XLarge,  # require license
+            "seg-nano": RFDETRSegNano,
+            "seg-small": RFDETRSegSmall,
+            "seg-medium": RFDETRSegMedium,
+            "seg-large": RFDETRSegLarge,
+            "seg-xlarge": RFDETRSegXLarge,
+            "seg-2xlarge": RFDETRSeg2XLarge,
         }
 
         if not os.path.isfile(model_path):
@@ -390,31 +397,37 @@ class RfdetrPTH(RfdetrBase):
 
         self._setup_device(device)
 
-        model_type = model_type.lower()
-        if model_type not in model_configs:
-            supported = ", ".join(model_configs.keys())
-            raise ValueError(f"Unsupported model type: '{model_type}'. Supported types: {supported}")
-
-        default_resolution, model_class = model_configs[model_type]
-
+        model_kwargs = {"device": self.device}
         if image_size is not None:
             # rfdetr takes a single resolution and traces the graph at it; a non-square image_size
             # would only fail once the first frame reaches the traced model.
             if image_size[0] != image_size[1]:
                 raise ValueError(f"RF-DETR runs at a square resolution; got image_size=({image_size[0]}, {image_size[1]})")
-            self.image_size = (image_size[0], image_size[1])
+            model_kwargs["resolution"] = image_size[0]
         else:
-            self.image_size = (default_resolution, default_resolution)
+            # rfdetr < 1.9 drops the checkpoint's model_config, and the named-variant path below never reads it,
+            # so without this the model runs at the variant's default resolution instead of the trained one.
+            resolution = resolution_from_checkpoint(model_path)
+            if resolution is not None:
+                model_kwargs["resolution"] = resolution
 
-        self.logger.info(
-            f"Loading {model_type} RF-DETR model from {model_path} "
-            f"with resolution {self.image_size[0]}x{self.image_size[1]} on {self.device}"
-        )
-        model_kwargs = {"pretrain_weights": model_path, "resolution": self.image_size[0], "device": self.device}
-        num_classes = self._num_classes_from_checkpoint(model_path)
-        if num_classes is not None:
-            model_kwargs["num_classes"] = num_classes
-        self.model = model_class(**model_kwargs)
+        if model_type is None:
+            self.logger.info(f"Loading RF-DETR model from {model_path} on {self.device}, variant read from the checkpoint")
+            self.model = load_from_checkpoint(model_path, sorted(model_classes), **model_kwargs)
+        else:
+            model_type = model_type.lower()
+            if model_type not in model_classes:
+                supported = ", ".join(model_classes.keys())
+                raise ValueError(f"Unsupported model type: '{model_type}'. Supported types: {supported}")
+            self.logger.info(f"Loading {model_type} RF-DETR model from {model_path} on {self.device}")
+            num_classes = self._num_classes_from_checkpoint(model_path)
+            if num_classes is not None:
+                model_kwargs["num_classes"] = num_classes
+            self.model = model_classes[model_type](pretrain_weights=model_path, **model_kwargs)
+
+        resolution = self.model.model_config.resolution
+        self.image_size = (resolution, resolution)
+        self.logger.info(f"Running at resolution {resolution}x{resolution}")
         if class_map is None:
             # Same quantity rfdetr's own predict() keys the sparse-COCO decision on.
             class_map = self._class_map_from_names(self.model.class_names, getattr(self.model.model.args, "num_classes", None))

--- a/object_detectors/rf_detr_lmi/model.py
+++ b/object_detectors/rf_detr_lmi/model.py
@@ -16,7 +16,7 @@ from lmi_common.trt_engine import TRTEngine
 from lmi_utils.image_utils.types import ImageLike
 from object_detectors.od_core.od_base import ODBase
 from object_detectors.od_core.results import Results
-from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint, resolution_from_checkpoint
+from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint
 from object_detectors.rf_detr_lmi.metadata import RfdetrMetadata
 
 # Added in rfdetr 1.9.1; passing it to older versions raises TypeError.
@@ -352,7 +352,8 @@ class RfdetrPTH(RfdetrBase):
             class_map: Dict mapping class indices to class names. Defaults to the checkpoint's built-in class names; pass it
                 only to override the index mapping — values must still exactly match the model's class names.
             device: Device to run on (cuda/cpu). Default: cuda if available
-            image_size: Tuple of (height, width); must be square. Default: the checkpoint's own resolution
+            image_size: Tuple of (height, width); must be square. Default: the variant's own resolution, which a
+                checkpoint trained at another size does not carry — pass it to run at the training resolution.
             batch_size: Number of images per forward pass. Fixed at load time, so predict() chunks to it and zero-pads
                 a short final chunk. Default: 1
 
@@ -399,17 +400,9 @@ class RfdetrPTH(RfdetrBase):
 
         model_kwargs = {"device": self.device}
         if image_size is not None:
-            # rfdetr takes a single resolution and traces the graph at it; a non-square image_size
-            # would only fail once the first frame reaches the traced model.
             if image_size[0] != image_size[1]:
                 raise ValueError(f"RF-DETR runs at a square resolution; got image_size=({image_size[0]}, {image_size[1]})")
             model_kwargs["resolution"] = image_size[0]
-        else:
-            # rfdetr < 1.9 drops the checkpoint's model_config, and the named-variant path below never reads it,
-            # so without this the model runs at the variant's default resolution instead of the trained one.
-            resolution = resolution_from_checkpoint(model_path)
-            if resolution is not None:
-                model_kwargs["resolution"] = resolution
 
         if model_type is None:
             self.logger.info(f"Loading RF-DETR model from {model_path} on {self.device}, variant read from the checkpoint")
@@ -427,9 +420,12 @@ class RfdetrPTH(RfdetrBase):
 
         resolution = self.model.model_config.resolution
         self.image_size = (resolution, resolution)
-        self.logger.info(f"Running at resolution {resolution}x{resolution}")
+        if image_size is None:
+            self.logger.warning(f"image_size is not specified, using the variant's default size {resolution}x{resolution}")
+        else:
+            self.logger.info(f"Running at resolution {resolution}x{resolution}")
+
         if class_map is None:
-            # Same quantity rfdetr's own predict() keys the sparse-COCO decision on.
             class_map = self._class_map_from_names(self.model.class_names, getattr(self.model.model.args, "num_classes", None))
         elif set(class_map.values()) != set(self.model.class_names):
             raise ValueError(

--- a/object_detectors/rf_detr_lmi/readme.md
+++ b/object_detectors/rf_detr_lmi/readme.md
@@ -130,7 +130,7 @@ services:
 conversion config file:
 
 ```yaml
-model_type: small
+# model_type: small  # optional; by default the variant is read from pretrain_weights
 operation: convert
 task: seg         # od or seg
 format: tensorrt  # onnx tensorrt
@@ -163,7 +163,7 @@ services:
 The export operation uses rfdetr's native exporter and writes the fixed filename `model.onnx`, with the class names embedded in the file's own metadata — the `RfdetrModel` ONNX/TensorRT backends read them from there, so the model deploys as a single file.
 
 ```yaml
-model_type: small
+# model_type: small  # optional; by default the variant is read from pretrain_weights
 operation: export
 task: seg         # od or seg
 pretrain_weights: /app/training/checkpoint_best_total.pth   # required; must be a .pth file
@@ -172,6 +172,11 @@ export:
     resolution: 384
     opset_version: 17           # optional, default 17
 ```
+
+For `convert` and `export`, `model_type` is optional: the variant is read from the checkpoint named by
+`pretrain_weights`. rfdetr records it from 1.7.0 on, so set `model_type` only for an older checkpoint or
+Roboflow's published starter weights, which record none. `train` has no checkpoint to read and still needs it
+(defaulting to `medium`).
 
 Any additional keys under `export` (e.g. `device`) are passed to the model constructor.
 
@@ -185,7 +190,9 @@ Any additional keys under `export` (e.g. `device`) are passed to the model const
 | `.onnx` | ONNX Runtime | cuda or cpu |
 | `.engine` | TensorRT | cuda |
 
-The `.pth` backend takes `model_type` and an optional `batch_size` (fixed at load time, since the traced graph bakes it in).
+The `.pth` backend reads its variant and resolution from the checkpoint, and takes an optional `batch_size` (fixed at load
+time, since the traced graph bakes it in). rfdetr records the variant from 1.7.0 on; pass `model_type` only for an older
+checkpoint or Roboflow's published starter weights, which record none.
 The `.onnx` and `.engine` backends read the batch size and resolution from the model, and take class names from `class_map`
 or from the metadata embedded at export (`metadata_props` in an ONNX, a JSON header on an engine). Passing `class_map`
 is required for a model exported elsewhere, which carries no embedded names.
@@ -204,5 +211,5 @@ services:
       - ./preprocessed/test:/app/data/
       - ./training:/app/training
     command: >
-      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions --model_type seg-small
+      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions
 ```

--- a/object_detectors/rf_detr_lmi/readme.md
+++ b/object_detectors/rf_detr_lmi/readme.md
@@ -64,7 +64,7 @@ training:
     grad_accum_steps: 4                 # gradient accumulation steps
     lr: 1e-4                            # learning rate
     output_dir: /app/training           # output directory
-    resolution: 384                     # image size (square image only)
+    resolution: 384                     # required; image size (square image only)
 ```
 
 The optional top-level `pretrain_weights` controls the weights training starts from:
@@ -136,7 +136,7 @@ task: seg         # od or seg
 format: tensorrt  # onnx tensorrt
 conversion:
     pretrain_weights: /app/training/checkpoint_best_total.pth   # must be .pth file
-    resolution: 384
+    resolution: 384   # required; set it to the resolution the model was trained at
     device: cuda
     output_dir: /app/training
 ```
@@ -169,14 +169,20 @@ task: seg         # od or seg
 pretrain_weights: /app/training/checkpoint_best_total.pth   # required; must be a .pth file
 export:
     output_dir: /app/training   # receives model.onnx
-    resolution: 384
+    resolution: 384             # required; set it to the resolution the model was trained at
     opset_version: 17           # optional, default 17
 ```
 
 For `convert` and `export`, `model_type` is optional: the variant is read from the checkpoint named by
 `pretrain_weights`. rfdetr records it from 1.7.0 on, so set `model_type` only for an older checkpoint or
 Roboflow's published starter weights, which record none. `train` has no checkpoint to read and still needs it
-(defaulting to `medium`).
+(defaulting to `small`).
+
+`resolution` is required by `train`, `convert` and `export` alike — a config without it is rejected. Nothing reads
+the size off a checkpoint: rfdetr does not keep it in `checkpoint_best_total.pth`, and it resizes the position
+embeddings to fit whatever it loads at without failing, so a wrong size costs accuracy instead of raising. The
+exported ONNX and TensorRT engine bake the size in permanently. For `convert` and `export`, use the resolution the
+model was trained at — `training_config.json`, written beside the checkpoints, records it under `model_config`.
 
 Any additional keys under `export` (e.g. `device`) are passed to the model constructor.
 
@@ -190,9 +196,8 @@ Any additional keys under `export` (e.g. `device`) are passed to the model const
 | `.onnx` | ONNX Runtime | cuda or cpu |
 | `.engine` | TensorRT | cuda |
 
-The `.pth` backend reads its variant and resolution from the checkpoint, and takes an optional `batch_size` (fixed at load
-time, since the traced graph bakes it in). rfdetr records the variant from 1.7.0 on; pass `model_type` only for an older
-checkpoint or Roboflow's published starter weights, which record none.
+The `.pth` backend reads its variant from the checkpoint and takes an optional `batch_size` (fixed at load time, since
+the traced graph bakes it in). It runs at the variant's default resolution unless passing a `image_size`.
 The `.onnx` and `.engine` backends read the batch size and resolution from the model, and take class names from `class_map`
 or from the metadata embedded at export (`metadata_props` in an ONNX, a JSON header on an engine). Passing `class_map`
 is required for a model exported elsewhere, which carries no embedded names.
@@ -211,5 +216,8 @@ services:
       - ./preprocessed/test:/app/data/
       - ./training:/app/training
     command: >
-      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions
+      python3 -m object_detectors.rf_detr_lmi.infer --weights /app/training/checkpoint_best_total.pth --input /app/data/test --output /app/training/predictions --image_size 384
 ```
+
+Pass `--image_size` for `.pth` weights trained at anything other than the variant's default size, which is what they
+fall back to. An `.onnx` or `.engine` carries its own input size and ignores the argument.

--- a/tests/assets/models/od/rf_detr/rf-detr-seg-small.pth
+++ b/tests/assets/models/od/rf_detr/rf-detr-seg-small.pth
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6de3da31b2572cac214a1c76cce4a92a13966d56390ac2b3a3de9a8dc2b2bca3
-size 135042342
+oid sha256:30d610b9e9c688aae6e71da30c92127593b94ca67d8d574a82b965935d09ac1e
+size 135029018

--- a/tests/object_detectors/rf_detr_lmi/test_checkpoint.py
+++ b/tests/object_detectors/rf_detr_lmi/test_checkpoint.py
@@ -3,19 +3,12 @@
 import argparse
 import inspect
 import os
-from types import SimpleNamespace
 
 import pytest
 import torch
-from rfdetr import RFDETR, RFDETRSegSmall, variants
+from rfdetr import RFDETR, RFDETRSegSmall
 
-from object_detectors.rf_detr_lmi.checkpoint import (
-    _pe_tracks_resolution,
-    _resolution_from_weights,
-    _trust_kwarg,
-    load_from_checkpoint,
-    resolution_from_checkpoint,
-)
+from object_detectors.rf_detr_lmi.checkpoint import _trust_kwarg, load_from_checkpoint
 
 PTH_FILE = "tests/assets/models/od/rf_detr/rf-detr-seg-small.pth"
 RESOLUTION = 384
@@ -66,56 +59,6 @@ def test_resolution_kwarg_reaches_the_constructor():
     """Callers override the checkpoint's resolution through **kwargs; dropping it would export at the wrong size."""
     model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu", resolution=432)
     assert model.model_config.resolution == 432
-
-
-def test_resolution_from_checkpoint_reads_the_recorded_value():
-    assert resolution_from_checkpoint(PTH_FILE) == RESOLUTION
-
-
-def test_resolution_falls_back_to_the_weights():
-    """rfdetr strips model_config out of checkpoint_best_total.pth, leaving the position grid as the only record."""
-    checkpoint = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
-    del checkpoint["model_config"]
-    assert _resolution_from_weights(checkpoint["model"]) == RESOLUTION
-
-
-def test_weights_derivation_matches_a_live_model():
-    """Pins the state-dict names and the grid-times-patch rule to this rfdetr; a rename here beats a silent wrong size."""
-    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu")
-    assert _resolution_from_weights(model.model.model.state_dict()) == model.model_config.resolution
-
-
-def test_no_derivation_for_a_variant_that_pins_its_position_grid(monkeypatch, tmp_path):
-    """Deriving the resolution is only valid where rfdetr itself sizes the grid from the resolution."""
-
-    class PinnedConfig:
-        model_fields = {
-            "positional_encoding_size": SimpleNamespace(default=37),
-            "patch_size": SimpleNamespace(default=14),
-            "resolution": SimpleNamespace(default=560),
-        }
-
-    monkeypatch.setattr(variants, "RFDETRPinned", SimpleNamespace(_model_config_class=PinnedConfig), raising=False)
-    assert _pe_tracks_resolution("RFDETRPinned") is False
-
-    path = str(tmp_path / "pinned.pth")
-    checkpoint = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
-    del checkpoint["model_config"]
-    checkpoint["model_name"] = "RFDETRPinned"
-    torch.save(checkpoint, path)
-    assert resolution_from_checkpoint(path) is None
-
-
-def test_every_supported_variant_sizes_its_grid_from_its_resolution():
-    """The rule the weights fallback relies on; a new variant that breaks it must show up here."""
-    assert all(_pe_tracks_resolution(f"RFDETR{name}") for name in ("Nano", "Small", "Medium", "Large", "SegSmall", "SegLarge"))
-
-
-def test_resolution_from_checkpoint_is_none_when_unreadable(tmp_path):
-    """Nothing to read the resolution from; the caller then leaves it to rfdetr."""
-    path = str(tmp_path / "no_model_config.pth")
-    torch.save({"model": {}}, path)
-    assert resolution_from_checkpoint(path) is None
 
 
 def test_namespace_args_still_load(tmp_path):

--- a/tests/object_detectors/rf_detr_lmi/test_checkpoint.py
+++ b/tests/object_detectors/rf_detr_lmi/test_checkpoint.py
@@ -1,0 +1,136 @@
+"""The rfdetr entry point checkpoint.py calls, pinned so a signature change fails here rather than in the field."""
+
+import argparse
+import inspect
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from rfdetr import RFDETR, RFDETRSegSmall, variants
+
+from object_detectors.rf_detr_lmi.checkpoint import (
+    _pe_tracks_resolution,
+    _resolution_from_weights,
+    _trust_kwarg,
+    load_from_checkpoint,
+    resolution_from_checkpoint,
+)
+
+PTH_FILE = "tests/assets/models/od/rf_detr/rf-detr-seg-small.pth"
+RESOLUTION = 384
+
+
+def test_from_checkpoint_is_a_classmethod_on_the_base_class():
+    """We call it off RFDETR itself and let it pick the subclass; an instance method would defeat that."""
+    assert isinstance(inspect.getattr_static(RFDETR, "from_checkpoint"), classmethod)
+
+
+def test_from_checkpoint_signature_matches_how_we_call_it():
+    """checkpoint.py passes the path positionally and forwards **kwargs."""
+    params = list(inspect.signature(RFDETR.from_checkpoint).parameters.values())
+
+    assert params[0].kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    assert any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params), "no **kwargs left to forward device/resolution through"
+
+
+def test_trust_checkpoint_is_passed_only_when_accepted():
+    """rfdetr < 1.9 has no trust_checkpoint and feeds unknown kwargs to the model config, which rejects them."""
+    params = inspect.signature(RFDETR.from_checkpoint).parameters
+    passed = _trust_kwarg(RFDETR.from_checkpoint)
+
+    assert passed == ({"trust_checkpoint": True} if "trust_checkpoint" in params else {})
+    if passed:
+        assert params["trust_checkpoint"].kind is not inspect.Parameter.POSITIONAL_ONLY
+
+
+def test_returns_the_variant_the_checkpoint_records():
+    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu")
+    assert type(model) is RFDETRSegSmall
+    assert model.model_config.resolution == RESOLUTION
+
+
+def test_pretrain_weights_is_set_by_rfdetr():
+    """checkpoint.py deliberately does not pass pretrain_weights; from_checkpoint must keep setting it itself."""
+    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu")
+    assert os.path.realpath(model.model_config.pretrain_weights) == os.path.realpath(PTH_FILE)
+
+
+def test_num_classes_comes_off_the_checkpoint_head():
+    """checkpoint.py omits num_classes so the head is sized by the weights; a rfdetr default would silently mismatch."""
+    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu")
+    assert model.model_config.num_classes == 90  # COCO, as stored in this checkpoint's class_embed
+
+
+def test_resolution_kwarg_reaches_the_constructor():
+    """Callers override the checkpoint's resolution through **kwargs; dropping it would export at the wrong size."""
+    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu", resolution=432)
+    assert model.model_config.resolution == 432
+
+
+def test_resolution_from_checkpoint_reads_the_recorded_value():
+    assert resolution_from_checkpoint(PTH_FILE) == RESOLUTION
+
+
+def test_resolution_falls_back_to_the_weights():
+    """rfdetr strips model_config out of checkpoint_best_total.pth, leaving the position grid as the only record."""
+    checkpoint = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    del checkpoint["model_config"]
+    assert _resolution_from_weights(checkpoint["model"]) == RESOLUTION
+
+
+def test_weights_derivation_matches_a_live_model():
+    """Pins the state-dict names and the grid-times-patch rule to this rfdetr; a rename here beats a silent wrong size."""
+    model = load_from_checkpoint(PTH_FILE, ["small"], device="cpu")
+    assert _resolution_from_weights(model.model.model.state_dict()) == model.model_config.resolution
+
+
+def test_no_derivation_for_a_variant_that_pins_its_position_grid(monkeypatch, tmp_path):
+    """Deriving the resolution is only valid where rfdetr itself sizes the grid from the resolution."""
+
+    class PinnedConfig:
+        model_fields = {
+            "positional_encoding_size": SimpleNamespace(default=37),
+            "patch_size": SimpleNamespace(default=14),
+            "resolution": SimpleNamespace(default=560),
+        }
+
+    monkeypatch.setattr(variants, "RFDETRPinned", SimpleNamespace(_model_config_class=PinnedConfig), raising=False)
+    assert _pe_tracks_resolution("RFDETRPinned") is False
+
+    path = str(tmp_path / "pinned.pth")
+    checkpoint = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    del checkpoint["model_config"]
+    checkpoint["model_name"] = "RFDETRPinned"
+    torch.save(checkpoint, path)
+    assert resolution_from_checkpoint(path) is None
+
+
+def test_every_supported_variant_sizes_its_grid_from_its_resolution():
+    """The rule the weights fallback relies on; a new variant that breaks it must show up here."""
+    assert all(_pe_tracks_resolution(f"RFDETR{name}") for name in ("Nano", "Small", "Medium", "Large", "SegSmall", "SegLarge"))
+
+
+def test_resolution_from_checkpoint_is_none_when_unreadable(tmp_path):
+    """Nothing to read the resolution from; the caller then leaves it to rfdetr."""
+    path = str(tmp_path / "no_model_config.pth")
+    torch.save({"model": {}}, path)
+    assert resolution_from_checkpoint(path) is None
+
+
+def test_namespace_args_still_load(tmp_path):
+    """Checkpoints from rfdetr's pre-Lightning loop pickle args as an argparse.Namespace."""
+    path = str(tmp_path / "namespace_args.pth")
+    ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    ckpt["args"] = argparse.Namespace(**ckpt["args"])
+    torch.save(ckpt, path)
+
+    assert type(load_from_checkpoint(path, ["small"], device="cpu")) is RFDETRSegSmall
+
+
+def test_missing_variant_raises_an_actionable_error(tmp_path):
+    """rfdetr's own KeyError names nothing the caller can act on."""
+    path = str(tmp_path / "no_variant.pth")
+    torch.save({"model": {}}, path)
+    with pytest.raises(ValueError, match="Specify model_type explicitly, one of: nano, small"):
+        load_from_checkpoint(path, ["nano", "small"], device="cpu")

--- a/tests/object_detectors/rf_detr_lmi/test_cli.py
+++ b/tests/object_detectors/rf_detr_lmi/test_cli.py
@@ -1,0 +1,132 @@
+"""Which RF-DETR variant each CLI operation loads, and where it comes from."""
+
+import os
+
+import pytest
+from rfdetr import RFDETRSegSmall, RFDETRSmall
+
+from object_detectors.rf_detr_lmi import cli
+
+PTH_FILE = "tests/assets/models/od/rf_detr/rf-detr-seg-small.pth"
+
+
+@pytest.fixture
+def loaded(monkeypatch):
+    """Record which variant load_model resolves, without paying to build a real rfdetr model."""
+    calls = {}
+
+    def fake_from_checkpoint(model_path, supported, **kwargs):
+        calls.update(source="checkpoint", model_path=model_path, supported=supported, kwargs=kwargs)
+        return "model"
+
+    def fake_get_model_class(task, model_type):
+        def build(**kwargs):
+            calls.update(source="model_type", task=task, model_type=model_type, kwargs=kwargs)
+            return "model"
+
+        return build
+
+    def fake_convert_to_onnx(model, output_dir, **kwargs):
+        path = os.path.join(output_dir, "rfdetr-seg-small.onnx")
+        open(path, "w").close()
+        return path
+
+    monkeypatch.setattr(cli, "load_from_checkpoint", fake_from_checkpoint)
+    monkeypatch.setattr(cli, "get_model_class", fake_get_model_class)
+    monkeypatch.setattr(cli, "convert_to_onnx", fake_convert_to_onnx)
+    return calls
+
+
+def test_absent_model_type_is_not_defaulted():
+    """No model_type must stay None, so convert/export can read the variant off the checkpoint."""
+    configs = cli.parse_config({"operation": "export", "task": "seg", "pretrain_weights": PTH_FILE, "export": {"output_dir": "/tmp"}})
+    assert configs["model_configs"]["model_type"] is None
+
+
+def test_convert_reads_variant_from_checkpoint(loaded):
+    configs = cli.parse_config(
+        {"operation": "convert", "task": "seg", "format": "onnx", "conversion": {"pretrain_weights": PTH_FILE, "resolution": 384}}
+    )
+    cli.load_model(configs)
+    assert loaded["source"] == "checkpoint"
+    assert loaded["model_path"] == PTH_FILE
+    # pretrain_weights is left out: from_checkpoint sets it itself
+    assert loaded["kwargs"] == {"resolution": 384}
+
+
+def test_convert_defaults_the_resolution_to_the_checkpoint(loaded):
+    """Exporting at the variant's default would silently shrink a model trained at another resolution."""
+    configs = cli.parse_config({"operation": "convert", "task": "seg", "format": "onnx", "conversion": {"pretrain_weights": PTH_FILE}})
+    cli.load_model(configs)
+    assert loaded["kwargs"] == {"resolution": 384}
+
+
+def test_convert_model_type_overrides_checkpoint(loaded):
+    configs = cli.parse_config(
+        {"operation": "convert", "task": "seg", "format": "onnx", "model_type": "small", "conversion": {"pretrain_weights": PTH_FILE}}
+    )
+    cli.load_model(configs)
+    assert loaded["source"] == "model_type"
+    assert (loaded["task"], loaded["model_type"]) == ("seg", "small")
+    assert loaded["kwargs"]["pretrain_weights"] == PTH_FILE
+
+
+def test_convert_without_weights_uses_default_variant(loaded):
+    """No checkpoint to read from — fall back to the default variant's own pretrained weights."""
+    configs = cli.parse_config({"operation": "convert", "task": "od", "format": "onnx", "conversion": {"resolution": 384}})
+    cli.load_model(configs)
+    assert loaded["model_type"] == cli.DEFAULT_MODEL_TYPE
+
+
+def test_export_reads_variant_from_checkpoint(loaded, tmp_path):
+    configs = cli.parse_config(
+        {
+            "operation": "export",
+            "task": "seg",
+            "pretrain_weights": PTH_FILE,
+            "export": {"output_dir": str(tmp_path), "resolution": 384},
+        }
+    )
+    cli.handle_export(configs)
+    assert loaded["source"] == "checkpoint"
+    assert loaded["model_path"] == PTH_FILE
+    assert loaded["kwargs"] == {"resolution": 384}
+    assert os.path.exists(tmp_path / "model.onnx")
+
+
+def test_export_model_type_overrides_checkpoint(loaded, tmp_path):
+    configs = cli.parse_config(
+        {
+            "operation": "export",
+            "task": "seg",
+            "model_type": "small",
+            "pretrain_weights": PTH_FILE,
+            "export": {"output_dir": str(tmp_path)},
+        }
+    )
+    cli.handle_export(configs)
+    assert loaded["source"] == "model_type"
+    assert (loaded["task"], loaded["model_type"]) == ("seg", "small")
+
+
+def test_train_still_defaults_the_variant(loaded):
+    """Training may start from scratch, so it cannot read a variant and keeps the default."""
+    configs = cli.parse_config({"operation": "train", "task": "od", "training": {"output_dir": "/tmp"}})
+    cli.load_model(configs)
+    assert loaded["model_type"] == cli.DEFAULT_MODEL_TYPE
+
+
+def test_supported_model_types_are_per_task():
+    """seg registers sizes od does not; the error listing must not offer an unbuildable one."""
+    assert "2xlarge" in cli.supported_model_types("seg")
+    assert "2xlarge" not in cli.supported_model_types("od")
+
+
+def test_checkpoint_variant_maps_onto_the_registry():
+    """The name the checkpoint records must resolve to the same class as task: seg + model_type: small."""
+    from object_detectors.rf_detr_lmi.checkpoint import load_from_checkpoint
+
+    model = load_from_checkpoint(PTH_FILE, cli.supported_model_types("seg"), device="cpu")
+    assert type(model) is RFDETRSegSmall
+    assert cli.get_model_class("seg", "small") is RFDETRSegSmall
+    assert cli.get_model_class("od", "small") is RFDETRSmall

--- a/tests/object_detectors/rf_detr_lmi/test_cli.py
+++ b/tests/object_detectors/rf_detr_lmi/test_cli.py
@@ -39,7 +39,9 @@ def loaded(monkeypatch):
 
 def test_absent_model_type_is_not_defaulted():
     """No model_type must stay None, so convert/export can read the variant off the checkpoint."""
-    configs = cli.parse_config({"operation": "export", "task": "seg", "pretrain_weights": PTH_FILE, "export": {"output_dir": "/tmp"}})
+    configs = cli.parse_config(
+        {"operation": "export", "task": "seg", "pretrain_weights": PTH_FILE, "export": {"output_dir": "/tmp", "resolution": 384}}
+    )
     assert configs["model_configs"]["model_type"] is None
 
 
@@ -54,16 +56,30 @@ def test_convert_reads_variant_from_checkpoint(loaded):
     assert loaded["kwargs"] == {"resolution": 384}
 
 
-def test_convert_defaults_the_resolution_to_the_checkpoint(loaded):
-    """Exporting at the variant's default would silently shrink a model trained at another resolution."""
-    configs = cli.parse_config({"operation": "convert", "task": "seg", "format": "onnx", "conversion": {"pretrain_weights": PTH_FILE}})
-    cli.load_model(configs)
-    assert loaded["kwargs"] == {"resolution": 384}
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"operation": "train", "task": "od", "training": {"output_dir": "/tmp"}},
+        {"operation": "convert", "task": "seg", "format": "onnx", "conversion": {"pretrain_weights": PTH_FILE}},
+        {"operation": "export", "task": "seg", "pretrain_weights": PTH_FILE, "export": {"output_dir": "/tmp"}},
+    ],
+    ids=["train", "convert", "export"],
+)
+def test_resolution_is_required(config):
+    """The size is never read off the checkpoint, and an export bakes it in, so every operation must state it."""
+    with pytest.raises(ValueError, match="resolution must be specified"):
+        cli.parse_config(config)
 
 
 def test_convert_model_type_overrides_checkpoint(loaded):
     configs = cli.parse_config(
-        {"operation": "convert", "task": "seg", "format": "onnx", "model_type": "small", "conversion": {"pretrain_weights": PTH_FILE}}
+        {
+            "operation": "convert",
+            "task": "seg",
+            "format": "onnx",
+            "model_type": "small",
+            "conversion": {"pretrain_weights": PTH_FILE, "resolution": 384},
+        }
     )
     cli.load_model(configs)
     assert loaded["source"] == "model_type"
@@ -101,7 +117,7 @@ def test_export_model_type_overrides_checkpoint(loaded, tmp_path):
             "task": "seg",
             "model_type": "small",
             "pretrain_weights": PTH_FILE,
-            "export": {"output_dir": str(tmp_path)},
+            "export": {"output_dir": str(tmp_path), "resolution": 384},
         }
     )
     cli.handle_export(configs)
@@ -111,7 +127,7 @@ def test_export_model_type_overrides_checkpoint(loaded, tmp_path):
 
 def test_train_still_defaults_the_variant(loaded):
     """Training may start from scratch, so it cannot read a variant and keeps the default."""
-    configs = cli.parse_config({"operation": "train", "task": "od", "training": {"output_dir": "/tmp"}})
+    configs = cli.parse_config({"operation": "train", "task": "od", "training": {"output_dir": "/tmp", "resolution": 384}})
     cli.load_model(configs)
     assert loaded["model_type"] == cli.DEFAULT_MODEL_TYPE
 

--- a/tests/object_detectors/rf_detr_lmi/test_model.py
+++ b/tests/object_detectors/rf_detr_lmi/test_model.py
@@ -57,7 +57,6 @@ def obj_detector():
     obj_detector = ObjectDetector(
         metadata=dict(version="v1", model_name="rfdetr", task="od", framework="rfdetr"),
         model_path=PTH_FILE,
-        model_type=MODEL_TYPE,
         device=DEVICE,
         class_map=COCO_CLASSES,
         image_size=[IMAGE_SIZE, IMAGE_SIZE],
@@ -87,7 +86,6 @@ def cpu_models():
     od_pth = ObjectDetector(
         metadata=dict(version="v1", model_name="rfdetr", task="od", framework="rfdetr"),
         model_path=PTH_FILE,
-        model_type=MODEL_TYPE,
         device="cpu",
         class_map=COCO_CLASSES,
         image_size=[IMAGE_SIZE, IMAGE_SIZE],
@@ -144,12 +142,12 @@ def assert_outputs_match_rf(rf_preds, outputs, label):
 def test_nonsquare_image_size_rejected():
     """A non-square image_size must fail at load, not on the first frame in production."""
     with pytest.raises(ValueError, match="square resolution"):
-        RfdetrModel(PTH_FILE, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE + 24])
+        RfdetrModel(PTH_FILE, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE + 24])
 
 
 def test_class_map_inferred_from_model(imgs_coco, obj_detector):
     """With no class_map, names come from the model itself and must match an explicit COCO map."""
-    inferred = RfdetrModel(PTH_FILE, model_type=MODEL_TYPE, device=DEVICE, image_size=[IMAGE_SIZE, IMAGE_SIZE])
+    inferred = RfdetrModel(PTH_FILE, device=DEVICE, image_size=[IMAGE_SIZE, IMAGE_SIZE])
     assert inferred.class_map == COCO_CLASSES
 
     img = cv2.resize(imgs_coco[0], (IMAGE_SIZE, IMAGE_SIZE))
@@ -160,17 +158,13 @@ def test_class_map_inferred_from_model(imgs_coco, obj_detector):
 
 def test_nonpositive_batch_size_rejected():
     with pytest.raises(ValueError, match="positive integer"):
-        RfdetrModel(
-            PTH_FILE, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE], batch_size=0
-        )
+        RfdetrModel(PTH_FILE, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE], batch_size=0)
 
 
 def test_batch_size_chunks_and_pads(imgs_coco):
     """batch_size=2 over 3 images must chunk and zero-pad the short last chunk, returning one result per image."""
     imgs = [cv2.resize(img, (IMAGE_SIZE, IMAGE_SIZE)) for img in imgs_coco[:3]]
-    batched = RfdetrModel(
-        PTH_FILE, model_type=MODEL_TYPE, device=DEVICE, class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE], batch_size=2
-    )
+    batched = RfdetrModel(PTH_FILE, device=DEVICE, class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE], batch_size=2)
     assert batched.fixed_batch_size == 2
 
     out, _ = batched.predict(imgs, configs=0.5)
@@ -179,8 +173,60 @@ def test_batch_size_chunks_and_pads(imgs_coco):
         _assert_nonempty_out({k: out[k][i] for k in KEYS})
 
 
+def test_variant_read_from_checkpoint():
+    """The default path resolves the variant from the checkpoint, matching an explicit model_type."""
+    inferred = RfdetrModel(PTH_FILE, device="cpu", class_map=COCO_CLASSES)
+    override = RfdetrModel(PTH_FILE, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES)
+    assert type(inferred.model) is type(override.model)
+    assert inferred.image_size == override.image_size == (IMAGE_SIZE, IMAGE_SIZE)
+
+
+def test_resolution_comes_from_the_checkpoint(tmp_path):
+    """A model trained at a non-default resolution must run at it, not at the variant's default."""
+    path = str(tmp_path / "trained_at_432.pth")
+    ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    ckpt["model_config"]["resolution"] = 432
+    torch.save(ckpt, path)
+
+    inferred = RfdetrModel(path, device="cpu", class_map=COCO_CLASSES)
+    override = RfdetrModel(path, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES)
+    assert inferred.image_size == override.image_size == (432, 432)
+
+
+def test_resolution_survives_a_stripped_checkpoint(tmp_path):
+    """rfdetr strips model_config out of checkpoint_best_total.pth; the position grid must still give the resolution."""
+    path = str(tmp_path / "stripped.pth")
+    ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    del ckpt["model_config"]
+    key = "backbone.0.encoder.encoder.embeddings.position_embeddings"
+    position = ckpt["model"][key]
+    ckpt["model"][key] = torch.zeros(1, 36 * 36 + 1, position.shape[2], dtype=position.dtype)  # 36 patches of 12 px
+    torch.save(ckpt, path)
+
+    assert RfdetrModel(path, device="cpu", class_map=COCO_CLASSES).image_size == (432, 432)
+
+
+def test_explicit_image_size_still_wins(tmp_path):
+    """image_size is an override; the checkpoint's own resolution must not shadow it."""
+    path = str(tmp_path / "trained_at_432.pth")
+    ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
+    ckpt["model_config"]["resolution"] = 432
+    torch.save(ckpt, path)
+
+    model = RfdetrModel(path, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE])
+    assert model.image_size == (IMAGE_SIZE, IMAGE_SIZE)
+
+
+def test_checkpoint_without_variant_asks_for_model_type(tmp_path):
+    """Starter weights record no variant; the error must name model_type rather than surface rfdetr's KeyError."""
+    path = str(tmp_path / "no_variant.pth")
+    torch.save({"model": {}}, path)
+    with pytest.raises(ValueError, match="Specify model_type explicitly"):
+        RfdetrModel(path, device="cpu", class_map=COCO_CLASSES)
+
+
 def test_model_class_comparison(obj_detector):
-    direct = RfdetrModel(PTH_FILE, model_type=MODEL_TYPE, device=DEVICE, class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE])
+    direct = RfdetrModel(PTH_FILE, device=DEVICE, class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE])
     api = obj_detector
     assert type(direct) is type(api), f"direct={type(direct).__name__}, api={type(api).__name__}"
 

--- a/tests/object_detectors/rf_detr_lmi/test_model.py
+++ b/tests/object_detectors/rf_detr_lmi/test_model.py
@@ -181,33 +181,42 @@ def test_variant_read_from_checkpoint():
     assert inferred.image_size == override.image_size == (IMAGE_SIZE, IMAGE_SIZE)
 
 
-def test_resolution_comes_from_the_checkpoint(tmp_path):
-    """A model trained at a non-default resolution must run at it, not at the variant's default."""
+def test_resolution_defaults_to_the_variant(tmp_path):
+    """No image_size means the variant's own resolution, whatever size the checkpoint was trained at."""
     path = str(tmp_path / "trained_at_432.pth")
     ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
     ckpt["model_config"]["resolution"] = 432
     torch.save(ckpt, path)
 
-    inferred = RfdetrModel(path, device="cpu", class_map=COCO_CLASSES)
-    override = RfdetrModel(path, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES)
-    assert inferred.image_size == override.image_size == (432, 432)
+    assert RfdetrModel(path, model_type=MODEL_TYPE, device="cpu", class_map=COCO_CLASSES).image_size == (IMAGE_SIZE, IMAGE_SIZE)
 
 
-def test_resolution_survives_a_stripped_checkpoint(tmp_path):
-    """rfdetr strips model_config out of checkpoint_best_total.pth; the position grid must still give the resolution."""
+def test_unspecified_image_size_is_logged(tmp_path, caplog):
+    """The variant default is only right by luck for a model trained at another size; the fallback must be visible."""
+    with caplog.at_level(logging.WARNING):
+        model = RfdetrModel(PTH_FILE, device="cpu", class_map=COCO_CLASSES)
+    assert model.image_size == (IMAGE_SIZE, IMAGE_SIZE)
+    assert "image_size is not specified" in caplog.text
+
+
+def test_explicit_image_size_is_not_logged_as_a_default(caplog):
+    with caplog.at_level(logging.WARNING):
+        RfdetrModel(PTH_FILE, device="cpu", class_map=COCO_CLASSES, image_size=[IMAGE_SIZE, IMAGE_SIZE])
+    assert "image_size is not specified" not in caplog.text
+
+
+def test_stripped_checkpoint_loads_at_the_variant_default(tmp_path):
+    """rfdetr strips model_config out of checkpoint_best_total.pth, the only weights file the workflow deploys."""
     path = str(tmp_path / "stripped.pth")
     ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
     del ckpt["model_config"]
-    key = "backbone.0.encoder.encoder.embeddings.position_embeddings"
-    position = ckpt["model"][key]
-    ckpt["model"][key] = torch.zeros(1, 36 * 36 + 1, position.shape[2], dtype=position.dtype)  # 36 patches of 12 px
     torch.save(ckpt, path)
 
-    assert RfdetrModel(path, device="cpu", class_map=COCO_CLASSES).image_size == (432, 432)
+    assert RfdetrModel(path, device="cpu", class_map=COCO_CLASSES).image_size == (IMAGE_SIZE, IMAGE_SIZE)
 
 
 def test_explicit_image_size_still_wins(tmp_path):
-    """image_size is an override; the checkpoint's own resolution must not shadow it."""
+    """image_size is the only way to run at a non-default resolution."""
     path = str(tmp_path / "trained_at_432.pth")
     ckpt = torch.load(PTH_FILE, map_location="cpu", weights_only=False)
     ckpt["model_config"]["resolution"] = 432

--- a/tests/object_detectors/rf_detr_lmi/test_onnx.py
+++ b/tests/object_detectors/rf_detr_lmi/test_onnx.py
@@ -19,7 +19,6 @@ COCO_DIR = "tests/assets/images/coco"
 PTH_FILE = "tests/assets/models/od/rf_detr/rf-detr-seg-small.pth"
 KEYS = ["boxes", "scores", "masks", "segments", "classes"]
 IMAGE_SIZE = 384
-MODEL_TYPE = "seg-small"
 METADATA = dict(version="v1", model_name="rfdetr", task="od", framework="rfdetr")
 
 
@@ -55,7 +54,6 @@ def pth_model():
     return ObjectDetector(
         metadata=METADATA,
         model_path=PTH_FILE,
-        model_type=MODEL_TYPE,
         class_map=COCO_CLASSES,
         image_size=[IMAGE_SIZE, IMAGE_SIZE],
         device="cpu",

--- a/tests/rebuild_rfdetr_checkpoint.py
+++ b/tests/rebuild_rfdetr_checkpoint.py
@@ -1,0 +1,72 @@
+"""Re-stamp the committed RF-DETR test checkpoint with the variant name rfdetr needs to identify it.
+
+``RfdetrPTH`` reads the variant from the checkpoint (``RFDETR.from_checkpoint``) instead of taking a
+``model_type`` argument. rfdetr writes that ``model_name`` key from 1.7.0 on, but Roboflow's published
+starter weights predate it and hold nothing but a ``model`` state dict, so ``from_checkpoint`` fails on
+them. This script downloads the starter weights and rewrites them with the keys rfdetr looks for, so the
+test asset exercises the same path a user's own trained checkpoint takes.
+
+    python -m tests.rebuild_rfdetr_checkpoint            # overwrite the committed asset
+    python -m tests.rebuild_rfdetr_checkpoint -o /tmp/x.pth
+
+The weights are untouched — only metadata is added. Needs ``rfdetr``; runs on CPU.
+"""
+
+import argparse
+import logging
+import os
+import urllib.request
+
+import torch
+
+logger = logging.getLogger("rebuild_rfdetr_checkpoint")
+
+OUT_PATH = "tests/assets/models/od/rf_detr/rf-detr-seg-small.pth"
+# rfdetr's own RF_DETR_SEG_SMALL asset entry (rfdetr/assets/model_weights.py).
+SOURCE_URL = "https://storage.googleapis.com/rfdetr/rf-detr-seg-s-ft.pth"
+SOURCE_MD5 = "0a2a3006381d0c42853907e700eadd08"
+MODEL_NAME = "RFDETRSegSmall"
+
+
+def download(url: str, dest: str) -> None:
+    """Fetch url to dest unless dest already exists."""
+    if os.path.isfile(dest):
+        logger.info("reusing %s", dest)
+        return
+    logger.info("downloading %s ...", url)
+    urllib.request.urlretrieve(url, dest)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", default=OUT_PATH, help=f"where to write the checkpoint (default: {OUT_PATH})")
+    parser.add_argument("--source", default=None, help="starter weights to re-stamp; downloaded from Roboflow when omitted")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    source = args.source
+    if source is None:
+        source = os.path.join("/tmp", os.path.basename(SOURCE_URL))
+        download(SOURCE_URL, source)
+
+    from rfdetr import RFDETRSegSmall
+
+    checkpoint = torch.load(source, map_location="cpu", weights_only=False)
+    if "model" not in checkpoint:
+        raise ValueError(f"{source} has no 'model' state dict; keys: {sorted(checkpoint)}")
+
+    # Build the variant off the same weights so its resolved config is what gets recorded.
+    model_config = RFDETRSegSmall(pretrain_weights=source, device="cpu").model_config.model_dump()
+    model_config.pop("pretrain_weights", None)  # from_checkpoint sets this to the checkpoint's own path
+    model_config["model_name"] = MODEL_NAME
+
+    # "args" and "model_name" are what from_checkpoint reads; "model_config" seeds the constructor kwargs.
+    payload = {"model": checkpoint["model"], "args": model_config, "model_name": MODEL_NAME, "model_config": model_config}
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    torch.save(payload, args.output)
+    logger.info("wrote %s (%.1f MB)", args.output, os.path.getsize(args.output) / 1e6)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](../docs/CONTRIBUTING.md) before submitting. -->

## Summary
infer the model name from ckpt

## Breaking changes

- [ ] This PR introduces a breaking change — `PRERELEASE.md` has been updated with before/after examples.

## Checklist

- [ ] PR title follows conventional commits — `feat:`, `fix:`, `chore:`, etc. (required for semantic versioning)
- [ ] `pre-commit run --all-files` passes
- [ ] Docstrings / comments updated if public API changed
